### PR TITLE
Fix webhook tests

### DIFF
--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -1124,6 +1124,8 @@ export namespace Webhook {
       return messageResponse.body;
     }));
 
-    return messages;
+    return messages.sort((a, b) => {
+      return new Date(b.timestamp).getTime() - new Date(a.timestamp).getTime();
+    });
   }
 }

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
@@ -525,6 +525,7 @@ it("creates a team on the server and adds a different user as the creator", asyn
   `);
 });
 
+
 it("should trigger team membership webhook when a user is added to a team", async ({ expect }) => {
   const { projectId, svixToken, endpointId } = await Webhook.createProjectWithEndpoint();
 
@@ -546,105 +547,25 @@ it("should trigger team membership webhook when a user is added to a team", asyn
 
   const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
 
-  expect(attemptResponse).toMatchInlineSnapshot(`
-    [
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team_membership.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "team_id": "<stripped UUID>",
-            "user_id": "<stripped UUID>",
-          },
-          "type": "team_membership.created",
+  const teamMembershipCreatedEvent = attemptResponse.find(event => event.eventType === "team_membership.created");
+
+  expect(teamMembershipCreatedEvent).toMatchInlineSnapshot(`
+    {
+      "channels": null,
+      "eventId": null,
+      "eventType": "team_membership.created",
+      "id": "<stripped svix message id>",
+      "payload": {
+        "data": {
+          "team_id": "<stripped UUID>",
+          "user_id": "<stripped UUID>",
         },
-        "timestamp": <stripped field 'timestamp'>,
+        "type": "team_membership.created",
       },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "mailbox-1--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "New Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-    ]
+      "timestamp": <stripped field 'timestamp'>,
+    }
   `);
+
 });
 
 
@@ -676,148 +597,22 @@ it("should trigger team membership webhook when a user is removed from a team", 
 
   const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
 
-  expect(attemptResponse).toMatchInlineSnapshot(`
-    [
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team_membership.deleted",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "team_id": "<stripped UUID>",
-            "user_id": "<stripped UUID>",
-          },
-          "type": "team_membership.deleted",
+  const teamMembershipDeletedEvent = attemptResponse.find(event => event.eventType === "team_membership.deleted");
+
+  expect(teamMembershipDeletedEvent).toMatchInlineSnapshot(`
+    {
+      "channels": null,
+      "eventId": null,
+      "eventType": "team_membership.deleted",
+      "id": "<stripped svix message id>",
+      "payload": {
+        "data": {
+          "team_id": "<stripped UUID>",
+          "user_id": "<stripped UUID>",
         },
-        "timestamp": <stripped field 'timestamp'>,
+        "type": "team_membership.deleted",
       },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team_membership.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "team_id": "<stripped UUID>",
-            "user_id": "<stripped UUID>",
-          },
-          "type": "team_membership.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "mailbox-1--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "New Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-    ]
+      "timestamp": <stripped field 'timestamp'>,
+    }
   `);
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
@@ -647,6 +647,7 @@ it("should trigger team membership webhook when a user is added to a team", asyn
   `);
 });
 
+
 it("should trigger team membership webhook when a user is removed from a team", async ({ expect }) => {
   const { projectId, svixToken, endpointId } = await Webhook.createProjectWithEndpoint();
 
@@ -783,119 +784,6 @@ it("should trigger team membership webhook when a user is removed from a team", 
             "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
           },
           "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-    ]
-  `);
-});
-
-
-it("should trigger team membership webhook when a user is removed from a team", async ({ expect }) => {
-  const { projectId, svixToken, endpointId } = await Webhook.createProjectWithEndpoint();
-
-  await Auth.Otp.signIn();
-  const { teamId } = await Team.createAndAddCurrent();
-
-  await bumpEmailAddress();
-  const { userId } = await Auth.Otp.signIn();
-
-  const addUserResponse = await niceBackendFetch(`/api/v1/team-memberships/${teamId}/${userId}`, {
-    accessType: "server",
-    method: "POST",
-    body: {},
-  });
-
-  expect(addUserResponse.status).toBe(201);
-
-  const removeUserResponse = await niceBackendFetch(`/api/v1/team-memberships/${teamId}/${userId}`, {
-    accessType: "server",
-    method: "DELETE"
-  });
-
-  expect(removeUserResponse.status).toBe(200);
-
-  await wait(3000);
-
-  const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
-
-  expect(attemptResponse).toMatchInlineSnapshot(`
-    [
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team_membership.deleted",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "team_id": "<stripped UUID>",
-            "user_id": "<stripped UUID>",
-          },
-          "type": "team_membership.deleted",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team_membership.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "team_id": "<stripped UUID>",
-            "user_id": "<stripped UUID>",
-          },
-          "type": "team_membership.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "user.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "auth_with_email": true,
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "display_name": null,
-            "has_password": false,
-            "id": "<stripped UUID>",
-            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-            "oauth_providers": [],
-            "otp_auth_enabled": true,
-            "passkey_auth_enabled": false,
-            "primary_email": "mailbox-1--<stripped UUID>@stack-generated.example.com",
-            "primary_email_auth_enabled": true,
-            "primary_email_verified": true,
-            "profile_image_url": null,
-            "requires_totp_mfa": false,
-            "selected_team": null,
-            "selected_team_id": null,
-            "server_metadata": null,
-            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-          },
-          "type": "user.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "New Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.created",
         },
         "timestamp": <stripped field 'timestamp'>,
       },

--- a/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/teams.test.ts
@@ -821,48 +821,28 @@ it("should trigger team webhook when a team is updated", async ({ expect }) => {
   await wait(3000);
 
   const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
+  const teamUpdatedEvent = attemptResponse.find(event => event.eventType === "team.updated");
 
-  expect(attemptResponse).toMatchInlineSnapshot(`
-    [
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.updated",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "Updated Team Name",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.updated",
+  expect(teamUpdatedEvent).toMatchInlineSnapshot(`
+    {
+      "channels": null,
+      "eventId": null,
+      "eventType": "team.updated",
+      "id": "<stripped svix message id>",
+      "payload": {
+        "data": {
+          "client_metadata": null,
+          "client_read_only_metadata": null,
+          "created_at_millis": <stripped field 'created_at_millis'>,
+          "display_name": "Updated Team Name",
+          "id": "<stripped UUID>",
+          "profile_image_url": null,
+          "server_metadata": null,
         },
-        "timestamp": <stripped field 'timestamp'>,
+        "type": "team.updated",
       },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "Test Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-    ]
+      "timestamp": <stripped field 'timestamp'>,
+    }
   `);
 });
 
@@ -890,39 +870,19 @@ it("should trigger team webhook when a team is deleted", async ({ expect }) => {
   await wait(3000);
 
   const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
+  const teamDeletedEvent = attemptResponse.find(event => event.eventType === "team.deleted");
 
-  expect(attemptResponse).toMatchInlineSnapshot(`
-    [
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.deleted",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": { "id": "<stripped UUID>" },
-          "type": "team.deleted",
-        },
-        "timestamp": <stripped field 'timestamp'>,
+  expect(teamDeletedEvent).toMatchInlineSnapshot(`
+    {
+      "channels": null,
+      "eventId": null,
+      "eventType": "team.deleted",
+      "id": "<stripped svix message id>",
+      "payload": {
+        "data": { "id": "<stripped UUID>" },
+        "type": "team.deleted",
       },
-      {
-        "channels": null,
-        "eventId": null,
-        "eventType": "team.created",
-        "id": "<stripped svix message id>",
-        "payload": {
-          "data": {
-            "client_metadata": null,
-            "client_read_only_metadata": null,
-            "created_at_millis": <stripped field 'created_at_millis'>,
-            "display_name": "Test Team",
-            "id": "<stripped UUID>",
-            "profile_image_url": null,
-            "server_metadata": null,
-          },
-          "type": "team.created",
-        },
-        "timestamp": <stripped field 'timestamp'>,
-      },
-    ]
+      "timestamp": <stripped field 'timestamp'>,
+    }
   `);
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
@@ -2044,72 +2044,40 @@ describe("with server access", () => {
     await wait(3000);
 
     const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
+    const userUpdatedEvent = attemptResponse.find(event => event.eventType === "user.updated");
 
-    expect(attemptResponse).toMatchInlineSnapshot(`
-      [
-        {
-          "channels": null,
-          "eventId": null,
-          "eventType": "user.updated",
-          "id": "<stripped svix message id>",
-          "payload": {
-            "data": {
-              "auth_with_email": false,
-              "client_metadata": null,
-              "client_read_only_metadata": null,
-              "display_name": "Test User",
-              "has_password": false,
-              "id": "<stripped UUID>",
-              "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-              "oauth_providers": [],
-              "otp_auth_enabled": false,
-              "passkey_auth_enabled": false,
-              "primary_email": "test@example.com",
-              "primary_email_auth_enabled": false,
-              "primary_email_verified": false,
-              "profile_image_url": null,
-              "requires_totp_mfa": false,
-              "selected_team": null,
-              "selected_team_id": null,
-              "server_metadata": null,
-              "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-            },
-            "type": "user.updated",
+    expect(userUpdatedEvent).toMatchInlineSnapshot(`
+      {
+        "channels": null,
+        "eventId": null,
+        "eventType": "user.updated",
+        "id": "<stripped svix message id>",
+        "payload": {
+          "data": {
+            "auth_with_email": false,
+            "client_metadata": null,
+            "client_read_only_metadata": null,
+            "display_name": "Test User",
+            "has_password": false,
+            "id": "<stripped UUID>",
+            "last_active_at_millis": <stripped field 'last_active_at_millis'>,
+            "oauth_providers": [],
+            "otp_auth_enabled": false,
+            "passkey_auth_enabled": false,
+            "primary_email": "test@example.com",
+            "primary_email_auth_enabled": false,
+            "primary_email_verified": false,
+            "profile_image_url": null,
+            "requires_totp_mfa": false,
+            "selected_team": null,
+            "selected_team_id": null,
+            "server_metadata": null,
+            "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
           },
-          "timestamp": <stripped field 'timestamp'>,
+          "type": "user.updated",
         },
-        {
-          "channels": null,
-          "eventId": null,
-          "eventType": "user.created",
-          "id": "<stripped svix message id>",
-          "payload": {
-            "data": {
-              "auth_with_email": false,
-              "client_metadata": null,
-              "client_read_only_metadata": null,
-              "display_name": null,
-              "has_password": false,
-              "id": "<stripped UUID>",
-              "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-              "oauth_providers": [],
-              "otp_auth_enabled": false,
-              "passkey_auth_enabled": false,
-              "primary_email": "test@example.com",
-              "primary_email_auth_enabled": false,
-              "primary_email_verified": false,
-              "profile_image_url": null,
-              "requires_totp_mfa": false,
-              "selected_team": null,
-              "selected_team_id": null,
-              "server_metadata": null,
-              "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-            },
-            "type": "user.created",
-          },
-          "timestamp": <stripped field 'timestamp'>,
-        },
-      ]
+        "timestamp": <stripped field 'timestamp'>,
+      }
     `);
   });
 
@@ -2137,55 +2105,23 @@ describe("with server access", () => {
     await wait(3000);
 
     const attemptResponse = await Webhook.listWebhookAttempts(projectId, endpointId, svixToken);
+    const userDeletedEvent = attemptResponse.find(event => event.eventType === "user.deleted");
 
-    expect(attemptResponse).toMatchInlineSnapshot(`
-      [
-        {
-          "channels": null,
-          "eventId": null,
-          "eventType": "user.deleted",
-          "id": "<stripped svix message id>",
-          "payload": {
-            "data": {
-              "id": "<stripped UUID>",
-              "teams": [],
-            },
-            "type": "user.deleted",
+    expect(userDeletedEvent).toMatchInlineSnapshot(`
+      {
+        "channels": null,
+        "eventId": null,
+        "eventType": "user.deleted",
+        "id": "<stripped svix message id>",
+        "payload": {
+          "data": {
+            "id": "<stripped UUID>",
+            "teams": [],
           },
-          "timestamp": <stripped field 'timestamp'>,
+          "type": "user.deleted",
         },
-        {
-          "channels": null,
-          "eventId": null,
-          "eventType": "user.created",
-          "id": "<stripped svix message id>",
-          "payload": {
-            "data": {
-              "auth_with_email": false,
-              "client_metadata": null,
-              "client_read_only_metadata": null,
-              "display_name": null,
-              "has_password": false,
-              "id": "<stripped UUID>",
-              "last_active_at_millis": <stripped field 'last_active_at_millis'>,
-              "oauth_providers": [],
-              "otp_auth_enabled": false,
-              "passkey_auth_enabled": false,
-              "primary_email": "test@example.com",
-              "primary_email_auth_enabled": false,
-              "primary_email_verified": false,
-              "profile_image_url": null,
-              "requires_totp_mfa": false,
-              "selected_team": null,
-              "selected_team_id": null,
-              "server_metadata": null,
-              "signed_up_at_millis": <stripped field 'signed_up_at_millis'>,
-            },
-            "type": "user.created",
-          },
-          "timestamp": <stripped field 'timestamp'>,
-        },
-      ]
+        "timestamp": <stripped field 'timestamp'>,
+      }
     `);
   });
 });


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Sort webhook messages by timestamp and remove duplicate test case for user removal webhook in `team-memberships.test.ts`.
> 
>   - **Behavior**:
>     - Sorts webhook messages by `timestamp` in `Webhook.listWebhookAttempts()` in `backend-helpers.ts`.
>     - Removes duplicate test case for triggering webhook on user removal in `team-memberships.test.ts`.
>   - **Tests**:
>     - Ensures webhook messages are sorted in descending order by `timestamp`.
>     - Removes redundant test for team membership webhook on user removal.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 01c8b0f6873affae0caf67f7ddda34c7277dfb3d. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->