### PR TITLE
Log sentry error regarding no access token

### DIFF
--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -165,6 +165,9 @@ export abstract class OAuthBaseProvider {
       throw new StackAssertionError(`Inner OAuth callback failed due to error: ${error}`, { params, cause: error });
     }
 
+    if ('error' in tokenSet) {
+      throw new StackAssertionError(`Inner OAuth callback failed due to error: ${tokenSet.error}, ${tokenSet.error_description}`, { params, tokenSet });
+    }
     tokenSet = processTokenSet(this.constructor.name, tokenSet, this.defaultAccessTokenExpiresInMillis);
 
     return {


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add error handling in `OAuthBaseProvider.getCallback()` for `tokenSet` errors, throwing `StackAssertionError`.
> 
>   - **Error Handling**:
>     - In `OAuthBaseProvider.getCallback()`, added check for `'error' in tokenSet`.
>     - Throws `StackAssertionError` with `tokenSet.error` and `tokenSet.error_description` if error exists in `tokenSet`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for e6c96ae5ebc14e10e0d067281d04bcfe0a244236. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->