### PR TITLE
Add cascade to sentEmail

### DIFF
--- a/apps/backend/prisma/migrations/20250225200753_add_tenancy_cascade/migration.sql
+++ b/apps/backend/prisma/migrations/20250225200753_add_tenancy_cascade/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "SentEmail" DROP CONSTRAINT "SentEmail_tenancyId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "SentEmail" ADD CONSTRAINT "SentEmail_tenancyId_fkey" FOREIGN KEY ("tenancyId") REFERENCES "Tenancy"("id") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/migrations/20250225200857_add_another/migration.sql
+++ b/apps/backend/prisma/migrations/20250225200857_add_another/migration.sql
@@ -1,0 +1,5 @@
+-- DropForeignKey
+ALTER TABLE "SentEmail" DROP CONSTRAINT "SentEmail_tenancyId_userId_fkey";
+
+-- AddForeignKey
+ALTER TABLE "SentEmail" ADD CONSTRAINT "SentEmail_tenancyId_userId_fkey" FOREIGN KEY ("tenancyId", "userId") REFERENCES "ProjectUser"("tenancyId", "projectUserId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -945,7 +945,7 @@ model SentEmail {
 
   error   Json?
   tenancy Tenancy      @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
-  user    ProjectUser? @relation(fields: [tenancyId, userId], references: [tenancyId, projectUserId])
+  user    ProjectUser? @relation(fields: [tenancyId, userId], references: [tenancyId, projectUserId], onDelete: Cascade)
 
   @@id([tenancyId, id])
 }

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -944,7 +944,7 @@ model SentEmail {
   text         String?
 
   error   Json?
-  tenancy Tenancy      @relation(fields: [tenancyId], references: [id])
+  tenancy Tenancy      @relation(fields: [tenancyId], references: [id], onDelete: Cascade)
   user    ProjectUser? @relation(fields: [tenancyId, userId], references: [tenancyId, projectUserId])
 
   @@id([tenancyId, id])


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add cascading delete and update behavior to `SentEmail` foreign key constraints in migrations and Prisma schema.
> 
>   - **Behavior**:
>     - Add `ON DELETE CASCADE ON UPDATE CASCADE` to `SentEmail_tenancyId_fkey` in `20250225200753_add_tenancy_cascade/migration.sql`.
>     - Add `ON DELETE CASCADE ON UPDATE CASCADE` to `SentEmail_tenancyId_userId_fkey` in `20250225200857_add_another/migration.sql`.
>   - **Schema**:
>     - Update `SentEmail` model in `schema.prisma` to include `onDelete: Cascade` for `tenancy` and `user` relations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for a194d691db7580acdf84983a7f2833f829e24e2e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->