### PR TITLE
Add timeout for sending test emails

### DIFF
--- a/apps/backend/src/app/api/latest/internal/send-test-email/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/send-test-email/route.tsx
@@ -3,6 +3,8 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import * as schemaFields from "@stackframe/stack-shared/dist/schema-fields";
 import { adaptSchema, adminAuthTypeSchema, emailSchema, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StackAssertionError, captureError } from "@stackframe/stack-shared/dist/utils/errors";
+import { timeout } from "@stackframe/stack-shared/dist/utils/promises";
+import { Result } from "@stackframe/stack-shared/dist/utils/results";
 
 export const POST = createSmartRouteHandler({
   metadata: {
@@ -35,7 +37,7 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   handler: async ({ body, auth }) => {
-    const result = await sendEmailWithoutRetries({
+    const resultOuter = await timeout(sendEmailWithoutRetries({
       tenancyId: auth.tenancy.id,
       emailConfig: {
         type: 'standard',
@@ -50,6 +52,13 @@ export const POST = createSmartRouteHandler({
       to: body.recipient_email,
       subject: "Test Email from Stack Auth",
       text: "This is a test email from Stack Auth. If you successfully received this email, your email server configuration is working correctly.",
+    }), 10000);
+
+
+    const result = resultOuter.status === 'ok' ? resultOuter.data : Result.error({
+      errorType: undefined,
+      rawError: undefined,
+      message: "Timed out while sending test email. Make sure the email server is running and accepting connections.",
     });
 
     let errorMessage = result.status === 'error' ? result.error.message : undefined;

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -82,7 +82,7 @@ async function _sendEmailWithoutRetries(options: SendEmailOptions): Promise<Resu
   runAsynchronously(async () => {
     await wait(5000);
     if (!finished) {
-      captureError("email-send-timeout", new StackAssertionError("Email send took longer than 8s; maybe the email service is too slow?", {
+      captureError("email-send-timeout", new StackAssertionError("Email send took longer than 5s; maybe the email service is too slow?", {
         config: options.emailConfig.type === 'shared' ? "shared" : pick(options.emailConfig, ['host', 'port', 'username', 'senderEmail', 'senderName']),
         to: options.to,
         subject: options.subject,

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -1,7 +1,7 @@
 {
   "//": "THIS FILE IS AUTO-GENERATED FROM TEMPLATE. DO NOT EDIT IT DIRECTLY",
   "name": "@stackframe/react",
-  "version": "2.7.18",
+  "version": "2.7.19",
   "sideEffects": false,
   "main": "./dist/index.js",
   "types": "./dist/index.d.ts",


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Add 10-second timeout for sending test emails and update error handling in `route.tsx` and `emails.tsx`.
> 
>   - **Behavior**:
>     - Add 10-second timeout to `sendEmailWithoutRetries` in `route.tsx` for sending test emails.
>     - Update error message for email send timeout in `route.tsx` to indicate potential server issues.
>   - **Error Handling**:
>     - Reduce timeout duration for capturing errors in `_sendEmailWithoutRetries` in `emails.tsx` from 8s to 5s.
>   - **Misc**:
>     - Increment version in `package.json` from `2.7.18` to `2.7.19`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for bb8b29551e5efe959bc21bdeb8d3949639bdc465. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->