### PR TITLE
Fixed docs image ratio

### DIFF
--- a/docs/fern/style.css
+++ b/docs/fern/style.css
@@ -142,29 +142,50 @@ tr.stack-clickable-row-missing {
 }
 
 .stack-50h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 50px !important;
 }
 
 .stack-100h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 100px !important;
 }
 
 .stack-150h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 150px !important;
 }
 
 .stack-200h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 200px !important;
 }
 
 .stack-250h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 250px !important;
 }
 
 .stack-300h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 300px !important;
 }
 
 .stack-350h {
+  aspect-ratio: unset !important;
+  height: unset !important;
+  width: unset !important;
   height: 350px !important;
 }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "repository": "",
   "scripts": {
     "pre-no-codegen": "npx -y only-allow pnpm",
-    "pre-preinstall": "npx -y only-allow pnpm && node -e \"if(process.env.STACK_SKIP_TEMPLATE_GENERATION !== 'true') require('child_process').execSync('npx --package=ts-node ts-node ./scripts/generate-sdks.ts')\"",
+    "pre-preinstall": "npx -y only-allow pnpm && node -e \"if(process.env.STACK_SKIP_TEMPLATE_GENERATION !== 'true') require('child_process').execSync('npx --package=tsx tsx ./scripts/generate-sdks.ts')\"",
     "pre": "pnpm pre-preinstall && node -e \"if(process.env.STACK_SKIP_TEMPLATE_GENERATION !== 'true') { require('child_process').execSync('pnpm run generate-docs') }\"",
     "preinstall": "pnpm pre-preinstall",
     "typecheck": "pnpm pre && turbo typecheck",
@@ -52,7 +52,7 @@
     "verify-data-integrity": "pnpm pre && pnpm -C apps/backend run verify-data-integrity",
     "generate-openapi": "pnpm pre && turbo run generate-openapi",
     "generate-keys": "pnpm pre && turbo run generate-keys",
-    "generate-sdks": "npx --package=ts-node ts-node ./scripts/generate-sdks.ts",
+    "generate-sdks": "npx --package=tsx tsx ./scripts/generate-sdks.ts",
     "generate-sdks:watch": "chokidar --silent -c 'pnpm run generate-sdks' './packages/template' --ignore './packages/template/package.json' --ignore '**/node_modules/**' --ignore '**/dist/**' --ignore '**/.turbo/**' --throttle 2000",
     "generate-docs": "tsx ./scripts/generate-docs.ts",
     "generate-docs:watch": "chokidar --silent -c 'pnpm run generate-docs' './docs/fern/docs/pages-template' './docs/fern/docs-template.yml' --throttle 2000"


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Update `pre-preinstall` and `generate-sdks` scripts to use `tsx` instead of `ts-node` in `package.json`.
> 
>   - **Scripts**:
>     - Update `pre-preinstall` and `generate-sdks` scripts in `package.json` to use `tsx` instead of `ts-node` for executing `generate-sdks.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 4e290f12eae51d3143f3e525e8f9846824523257. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->