### PR TITLE
Project Cards should use Links

### DIFF
--- a/apps/dashboard/src/components/project-card.tsx
+++ b/apps/dashboard/src/components/project-card.tsx
@@ -2,14 +2,14 @@
 import { Link } from "@/components/link";
 import { useFromNow } from '@/hooks/use-from-now';
 import { AdminProject } from '@stackframe/stack';
-import { CardDescription, CardFooter, CardHeader, CardTitle, ClickableCard, Typography } from '@stackframe/stack-ui';
+import { Card, CardDescription, CardFooter, CardHeader, CardTitle, Typography } from '@stackframe/stack-ui';
 
 export function ProjectCard({ project }: { project: AdminProject }) {
   const createdAt = useFromNow(project.createdAt);
 
   return (
     <Link href={`/projects/${project.id}`}>
-      <ClickableCard className='flex flex-col justify-between'>
+      <Card className='flex flex-col justify-between'>
         <CardHeader>
           <CardTitle className="normal-case truncate">{project.displayName}</CardTitle>
           <CardDescription>{project.description}</CardDescription>
@@ -22,7 +22,7 @@ export function ProjectCard({ project }: { project: AdminProject }) {
             {createdAt}
           </Typography>
         </CardFooter>
-      </ClickableCard>
+      </Card>
     </Link>
   );
 }

--- a/apps/dashboard/src/components/project-card.tsx
+++ b/apps/dashboard/src/components/project-card.tsx
@@ -1,27 +1,28 @@
 'use client';
-import { useRouter } from "@/components/router";
+import { Link } from "@/components/link";
 import { useFromNow } from '@/hooks/use-from-now';
 import { AdminProject } from '@stackframe/stack';
 import { CardDescription, CardFooter, CardHeader, CardTitle, ClickableCard, Typography } from '@stackframe/stack-ui';
 
 export function ProjectCard({ project }: { project: AdminProject }) {
   const createdAt = useFromNow(project.createdAt);
-  const router = useRouter();
 
   return (
-    <ClickableCard className='flex flex-col justify-between' onClick={() => router.push(`/projects/${project.id}`)}>
-      <CardHeader>
-        <CardTitle className="normal-case truncate">{project.displayName}</CardTitle>
-        <CardDescription>{project.description}</CardDescription>
-      </CardHeader>
-      <CardFooter className="flex justify-between mt-2">
-        <Typography type='label' variant='secondary'>
-          {project.userCount} users
-        </Typography>
-        <Typography type='label' variant='secondary'>
-          {createdAt}
-        </Typography>
-      </CardFooter>
-    </ClickableCard>
+    <Link href={`/projects/${project.id}`}>
+      <ClickableCard className='flex flex-col justify-between'>
+        <CardHeader>
+          <CardTitle className="normal-case truncate">{project.displayName}</CardTitle>
+          <CardDescription>{project.description}</CardDescription>
+        </CardHeader>
+        <CardFooter className="flex justify-between mt-2">
+          <Typography type='label' variant='secondary'>
+            {project.userCount} users
+          </Typography>
+          <Typography type='label' variant='secondary'>
+            {createdAt}
+          </Typography>
+        </CardFooter>
+      </ClickableCard>
+    </Link>
   );
 }

--- a/apps/dashboard/src/components/project-card.tsx
+++ b/apps/dashboard/src/components/project-card.tsx
@@ -2,13 +2,14 @@
 import { Link } from "@/components/link";
 import { useFromNow } from '@/hooks/use-from-now';
 import { AdminProject } from '@stackframe/stack';
+import { urlString } from "@stackframe/stack-shared/dist/utils/urls";
 import { Card, CardDescription, CardFooter, CardHeader, CardTitle, Typography } from '@stackframe/stack-ui';
 
 export function ProjectCard({ project }: { project: AdminProject }) {
   const createdAt = useFromNow(project.createdAt);
 
   return (
-    <Link href={`/projects/${project.id}`}>
+    <Link href={urlString`/projects/${project.id}`}>
       <Card className='flex flex-col justify-between'>
         <CardHeader>
           <CardTitle className="normal-case truncate">{project.displayName}</CardTitle>

--- a/packages/stack-ui/src/components/ui/card.tsx
+++ b/packages/stack-ui/src/components/ui/card.tsx
@@ -17,21 +17,6 @@ const Card = forwardRefIfNeeded<
 ));
 Card.displayName = "Card";
 
-const ClickableCard = forwardRefIfNeeded<
-  HTMLDivElement,
-  React.HTMLAttributes<HTMLDivElement>
->(({ className, ...props }, ref) => (
-  <div
-    ref={ref}
-    className={cn(
-      "rounded-xl border bg-card text-card-foreground shadow-sm cursor-pointer hover:border-[color:var(--primary)] ease-in-out",
-      className
-    )}
-    {...props}
-  />
-));
-ClickableCard.displayName = "ClickableCard";
-
 const CardHeader = forwardRefIfNeeded<
   HTMLDivElement,
   React.HTMLAttributes<HTMLDivElement>
@@ -99,5 +84,5 @@ const CardFooter = forwardRefIfNeeded<
 ));
 CardFooter.displayName = "CardFooter";
 
-export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardSubtitle, CardTitle, ClickableCard };
+export { Card, CardContent, CardDescription, CardFooter, CardHeader, CardSubtitle, CardTitle };
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Replace `ClickableCard` with `Link` in `project-card.tsx` for navigation and remove `ClickableCard` from `card.tsx`.
> 
>   - **Behavior**:
>     - Replace `ClickableCard` with `Link` in `project-card.tsx` to navigate to project pages using links.
>     - Remove `ClickableCard` from `card.tsx`, eliminating the click event handling for cards.
>   - **Imports**:
>     - Add `Link` and `urlString` imports in `project-card.tsx`.
>     - Remove `useRouter` import from `project-card.tsx`.
>   - **Exports**:
>     - Remove `ClickableCard` from exports in `card.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 7149043de8bbf9966dc3e516f760188f324b021a. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->