### PR TITLE
Fix table header buttons

### DIFF
--- a/packages/stack-ui/src/components/data-table/column-header.tsx
+++ b/packages/stack-ui/src/components/data-table/column-header.tsx
@@ -1,7 +1,7 @@
-import { cn } from "../..";
-import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSeparator, DropdownMenuTrigger } from "@stackframe/stack-ui";
+import { Button, DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@stackframe/stack-ui";
 import { Column } from "@tanstack/react-table";
-import { LucideIcon, EyeOff, ArrowUp, ArrowDown } from "lucide-react";
+import { ArrowDown, ArrowUp, LucideIcon } from "lucide-react";
+import { cn } from "../../lib/utils";
 
 type DataTableColumnHeaderProps<TData, TValue> = {
   column: Column<TData, TValue>,
@@ -31,7 +31,7 @@ export function DataTableColumnHeader<TData, TValue>({
           <Button
             variant="ghost"
             size="sm"
-            className="-ml-3 h-8 data-[state=open]:bg-accent"
+            className={cn("-ml-3 h-8 data-[state=open]:bg-accent", !column.getCanSort() && "pointer-events-none")}
           >
             <span>{columnTitle}</span>
             {column.getIsSorted() === "desc" ? (
@@ -42,13 +42,8 @@ export function DataTableColumnHeader<TData, TValue>({
           </Button>
         </DropdownMenuTrigger>
         <DropdownMenuContent align="start" className="stack-scope">
-          {column.getCanSort() && (
-            <>
-              <Item icon={ArrowUp} onClick={() => column.toggleSorting(false)}>Asc</Item>
-              <Item icon={ArrowDown} onClick={() => column.toggleSorting(true)}>Desc</Item>
-            </>
-          )}
-          <Item icon={EyeOff} onClick={() => column.toggleVisibility(false)}>Hide</Item>
+          <Item icon={ArrowUp} onClick={() => column.toggleSorting(false)}>Asc</Item>
+          <Item icon={ArrowDown} onClick={() => column.toggleSorting(true)}>Desc</Item>
         </DropdownMenuContent>
       </DropdownMenu>
     </div>

--- a/packages/stack-ui/src/components/data-table/faceted-filter.tsx
+++ b/packages/stack-ui/src/components/data-table/faceted-filter.tsx
@@ -1,4 +1,3 @@
-import { cn } from "../..";
 import { CheckIcon } from "@radix-ui/react-icons";
 import {
   Badge, Button, Command,
@@ -14,6 +13,7 @@ import {
 import { Column } from "@tanstack/react-table";
 import { ListFilter } from "lucide-react";
 import React from "react";
+import { cn } from "../../lib/utils";
 
 type DataTableFacetedFilterProps<TData, TValue> = {
   column?: Column<TData, TValue>,

--- a/packages/stack-ui/src/components/ui/skeleton.tsx
+++ b/packages/stack-ui/src/components/ui/skeleton.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { cn } from "../..";
+import { cn } from "../../lib/utils";
 
 function Skeleton({
   className,


### PR DESCRIPTION
Remove Hide button and disable events if dropdown list is empty

<!--
Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md
-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Remove `Hide` button and disable sorting events if dropdown list is empty in `column-header.tsx`.
> 
>   - **Behavior**:
>     - Remove `Hide` button from `DataTableColumnHeader` in `column-header.tsx`.
>     - Disable sorting events in `DataTableColumnHeader` if dropdown list is empty by adding `pointer-events-none` class.
>   - **Imports**:
>     - Adjust import order in `column-header.tsx`, `faceted-filter.tsx`, and `skeleton.tsx` to improve organization.
>     - Remove unused `DropdownMenuSeparator` and `EyeOff` imports in `column-header.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 4f7f5e683b0975069d53bd5aaa24ae7d8b1a5df7. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->