### PR TITLE
style update for docs upgrade

### DIFF
--- a/docs/fern/docs/pages-template/snippets/make-full-page.mdx
+++ b/docs/fern/docs/pages-template/snippets/make-full-page.mdx
@@ -2,8 +2,10 @@
 
 <Aside>{" "}</Aside>
 
-<style>{`
-  article > .grid {
-    grid-template-columns: minmax(0, 1fr) !important;
+<style>
+{`
+  article > .md\\:grid {
+    grid-template-columns: repeat(1, minmax(0, 1fr)) !important;
   }
-`}</style>
+`}
+</style>

--- a/docs/fern/style.css
+++ b/docs/fern/style.css
@@ -68,7 +68,7 @@
   content: "Show properties";
 }
 
-.fern-accordion > [data-state="open"] > button >.fern-accordion-trigger-title > .accordion-show-properties::before {
+.fern-accordion > [data-state="open"] > button > .fern-accordion-trigger-title > .accordion-show-properties::before {
   content: "Hide properties";
 }
 
@@ -117,27 +117,27 @@ tr.stack-clickable-row-missing {
   background-color: red !important;
 }
 
-.fa-icon[style*="square-t"] {
-  background-color: #763fa6 !important;
+svg[icon*="square-t"] {
+  color: #763fa6 !important;
 }
 
-.fa-icon[style*="square-h"] {
-  background-color: #3fa641 !important;
+svg[icon*="square-h"] {
+  color: #3fa641 !important;
 }
 
-.fa-icon[style*="square-code"] {
-  background-color: #4448c2 !important;
+svg[icon*="square-code"] {
+  color: #4448c2 !important;
 }
 
-.fa-icon[style*="square-u"] {
-  background-color: #eb7f38 !important;
+svg[icon*="square-u"] {
+  color: #eb7f38 !important;
 }
 
 .stack-dim-text {
   opacity: 0.5;
 }
 
-.fern-sidebar-link-content > svg:last-child {
+.fern-sidebar-link span + svg {
   display: none;
 }
 


### PR DESCRIPTION
Prepares docs styling for UX upgrade. Previewable here: https://canary.ferndocs.com/api/fern-docs/preview?host=stack-auth-preview-785c61b6-1e23-41e0-95c7-2013b4df64e4.docs.buildwithfern.com


<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Updates documentation styling for UX upgrade by modifying grid layout and icon color styling.
> 
>   - **Styling Changes**:
>     - In `make-full-page.mdx`, updated grid class from `.grid` to `.md\:grid` and changed grid-template-columns to `repeat(1, minmax(0, 1fr))`.
>     - In `style.css`, changed `.fa-icon` selectors to `svg[icon*="square-"]` for color styling.
>     - Adjusted `.fern-sidebar-link` to hide SVGs following a span.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 559a51fd2a93b0e4ba216534aa162bcb89231611. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->