### PR TITLE
add impersonate and error to user details page

### DIFF
--- a/apps/dashboard/src/components/data-table/user-table.tsx
+++ b/apps/dashboard/src/components/data-table/user-table.tsx
@@ -1,14 +1,15 @@
 'use client';
 import { useAdminApp } from '@/app/(main)/(protected)/projects/[projectId]/use-admin-app';
+import { useRouter } from "@/components/router";
 import { ServerUser } from '@stackframe/stack';
 import { deepPlainEquals } from '@stackframe/stack-shared/dist/utils/objects';
 import { deindent } from '@stackframe/stack-shared/dist/utils/strings';
-import { ActionCell, ActionDialog, AvatarCell, BadgeCell, CopyField, DataTableColumnHeader, DataTableManualPagination, DateCell, SearchToolbarItem, SimpleTooltip, TextCell, Typography } from "@stackframe/stack-ui";
+import { ActionCell, AvatarCell, BadgeCell, DataTableColumnHeader, DataTableManualPagination, DateCell, SearchToolbarItem, SimpleTooltip, TextCell } from "@stackframe/stack-ui";
 import { ColumnDef, ColumnFiltersState, Row, SortingState, Table } from "@tanstack/react-table";
 import { useState } from "react";
 import { Link } from '../link';
 import { UserDialog } from '../user-dialog';
-import { useRouter } from "@/components/router";
+import { DeleteUserDialog, ImpersonateUserDialog } from '../user-dialogs';
 
 export type ExtendedServerUser = ServerUser & {
   authTypes: string[],
@@ -21,46 +22,6 @@ function userToolbarRender<TData>(table: Table<TData>) {
       <SearchToolbarItem table={table} placeholder="Search table" />
     </>
   );
-}
-
-function DeleteUserDialog(props: {
-  user: ServerUser,
-  open: boolean,
-  onOpenChange: (open: boolean) => void,
-}) {
-  return <ActionDialog
-    open={props.open}
-    onOpenChange={props.onOpenChange}
-    title="Delete User"
-    danger
-    cancelButton
-    okButton={{ label: "Delete User", onClick: async () => { await props.user.delete(); } }}
-    confirmText="I understand that this action cannot be undone."
-  >
-    {`Are you sure you want to delete the user ${props.user.displayName ? '"' + props.user.displayName + '"' : ''} with ID ${props.user.id}?`}
-  </ActionDialog>;
-}
-
-function ImpersonateUserDialog(props: {
-  user: ServerUser,
-  impersonateSnippet: string | null,
-  onClose: () => void,
-}) {
-  return <ActionDialog
-    open={props.impersonateSnippet !== null}
-    onOpenChange={(open) => !open && props.onClose()}
-    title="Impersonate User"
-    okButton
-  >
-    <Typography>
-      Open your website and paste the following code into the browser console:
-    </Typography>
-    <CopyField
-      monospace
-      height={60}
-      value={props.impersonateSnippet ?? ""}
-    />
-  </ActionDialog>;
 }
 
 function UserActions({ row }: { row: Row<ExtendedServerUser> }) {

--- a/apps/dashboard/src/components/data-table/user-table.tsx
+++ b/apps/dashboard/src/components/data-table/user-table.tsx
@@ -8,7 +8,8 @@ import { ActionCell, AvatarCell, BadgeCell, DataTableColumnHeader, DataTableManu
 import { ColumnDef, ColumnFiltersState, Row, SortingState, Table } from "@tanstack/react-table";
 import { useState } from "react";
 import { Link } from '../link';
-import { UserDialog, DeleteUserDialog, ImpersonateUserDialog } from '../user-dialog';
+import { UserDialog } from '../user-dialog';
+import { DeleteUserDialog, ImpersonateUserDialog } from '../user-dialogs';
 
 export type ExtendedServerUser = ServerUser & {
   authTypes: string[],

--- a/apps/dashboard/src/components/user-dialogs.tsx
+++ b/apps/dashboard/src/components/user-dialogs.tsx
@@ -1,6 +1,6 @@
 import { ServerUser } from '@stackframe/stack';
 import { ActionDialog, CopyField, Typography } from "@stackframe/stack-ui";
-import { useRouter } from 'next/navigation';
+import { useRouter } from './router';
 
 
 export function DeleteUserDialog(props: {

--- a/apps/dashboard/src/components/user-dialogs.tsx
+++ b/apps/dashboard/src/components/user-dialogs.tsx
@@ -1,0 +1,56 @@
+import { ServerUser } from '@stackframe/stack';
+import { ActionDialog, CopyField, Typography } from "@stackframe/stack-ui";
+import { useRouter } from 'next/navigation';
+
+
+export function DeleteUserDialog(props: {
+  user: ServerUser,
+  open: boolean,
+  redirectTo?: string,
+  onOpenChange: (open: boolean) => void,
+}) {
+  const router = useRouter();
+  return <ActionDialog
+    open={props.open}
+    onOpenChange={props.onOpenChange}
+    title="Delete User"
+    danger
+    cancelButton
+    okButton={{
+      label: "Delete User", onClick: async () => {
+        await props.user.delete();
+        if (props.redirectTo) {
+          router.push(props.redirectTo);
+        }
+      }
+    }}
+    confirmText="I understand that this action cannot be undone."
+  >
+    {`Are you sure you want to delete the user ${props.user.displayName ? '"' + props.user.displayName + '"' : ''} with ID ${props.user.id}?`}
+  </ActionDialog>;
+}
+
+
+export function ImpersonateUserDialog(props: {
+  user: ServerUser,
+  impersonateSnippet: string | null,
+  onClose: () => void,
+}) {
+
+
+  return <ActionDialog
+    open={props.impersonateSnippet !== null}
+    onOpenChange={(open) => !open && props.onClose()}
+    title="Impersonate User"
+    okButton
+  >
+    <Typography>
+      Open your website and paste the following code into the browser console:
+    </Typography>
+    <CopyField
+      monospace
+      height={60}
+      value={props.impersonateSnippet ?? ""}
+    />
+  </ActionDialog>;
+}

--- a/packages/stack-shared/src/interface/serverInterface.ts
+++ b/packages/stack-shared/src/interface/serverInterface.ts
@@ -112,13 +112,16 @@ export class StackServerInterface extends StackClientInterface {
   }
 
   async getServerUserById(userId: string): Promise<Result<UsersCrud['Server']['Read']>> {
-    const response = await this.sendServerRequest(
+    const responseOrError = await this.sendServerRequestAndCatchKnownError(
       urlString`/users/${userId}`,
       {},
       null,
+      [KnownErrors.UserNotFound],
     );
-    const user: CurrentUserCrud['Server']['Read'] | null = await response.json();
-    if (!user) return Result.error(new Error("Failed to get user"));
+    if (responseOrError.status === "error") {
+      return Result.error(responseOrError.error);
+    }
+    const user: CurrentUserCrud['Server']['Read'] = await responseOrError.data.json();
     return Result.ok(user);
   }
 

--- a/packages/stack-shared/src/interface/serverInterface.ts
+++ b/packages/stack-shared/src/interface/serverInterface.ts
@@ -121,7 +121,7 @@ export class StackServerInterface extends StackClientInterface {
     if (responseOrError.status === "error") {
       return Result.error(responseOrError.error);
     }
-    const user: CurrentUserCrud['Server']['Read'] = await responseOrError.data.json();
+    const user: UsersCrud['Server']['Read'] = await responseOrError.data.json();
     return Result.ok(user);
   }
 


### PR DESCRIPTION
Add some buttons to user details page


<img width="1443" alt="image" src="https://github.com/user-attachments/assets/1c8fa865-29bc-43e7-ab77-f8ef55f934a4" />


<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Add impersonate and delete functionalities to user details page and refactor dialogs into a separate component.
> 
>   - **User Details Page**:
>     - Added `Impersonate` and `Delete` options in `page-client.tsx` using `DropdownMenu`.
>     - Utilizes `DeleteUserDialog` and `ImpersonateUserDialog` from `user-dialogs.tsx`.
>   - **Components**:
>     - Moved `DeleteUserDialog` and `ImpersonateUserDialog` to `user-dialogs.tsx`.
>     - Removed inline dialog definitions from `user-table.tsx`.
>   - **Server Interface**:
>     - Updated `getServerUserById` in `serverInterface.ts` to handle `UserNotFound` error using `sendServerRequestAndCatchKnownError`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 4cf7ec7d419044d978ba13aa2c5a313caab81003. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->