### PR TITLE
Fix sign in button in forgot password page

### DIFF
--- a/packages/template/src/components-page/forgot-password.tsx
+++ b/packages/template/src/components-page/forgot-password.tsx
@@ -86,7 +86,7 @@ export function ForgotPassword(props: { fullPage?: boolean }) {
           <Typography type='h2'>{t("Reset Your Password")}</Typography>
           <Typography>
             {t("Don't need to reset?")}{" "}
-            <StyledLink href={stackApp.urls['signUp']}>
+            <StyledLink href={stackApp.urls['signIn']}>
               {t("Sign in")}
             </StyledLink>
           </Typography>


### PR DESCRIPTION
Fix sign in button in forgot password page

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes 'Sign in' button link in `forgot-password.tsx` to point to the correct URL.
> 
>   - **Behavior**:
>     - Fixes the 'Sign in' button link in `forgot-password.tsx` to point to `signIn` URL instead of `signUp`.
>   - **Misc**:
>     - No other changes or additions.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for e6590a1a882e3cd84eb3a84dc528a6fa996a73c4. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->