### PR TITLE
Email send dashboard fix

### DIFF
--- a/apps/backend/src/app/api/latest/internal/emails/crud.tsx
+++ b/apps/backend/src/app/api/latest/internal/emails/crud.tsx
@@ -2,17 +2,25 @@ import { prismaClient } from "@/prisma-client";
 import { createCrudHandlers } from "@/route-handlers/crud-handler";
 import { SentEmail } from "@prisma/client";
 import { InternalEmailsCrud, internalEmailsCrud } from "@stackframe/stack-shared/dist/interface/crud/emails";
-import { projectIdSchema, yupObject } from "@stackframe/stack-shared/dist/schema-fields";
+import { yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
 
 function prismaModelToCrud(prismaModel: SentEmail): InternalEmailsCrud["Admin"]["Read"] {
+  const senderConfig = prismaModel.senderConfig as any;
 
   return {
     id: prismaModel.id,
     subject: prismaModel.subject,
     sent_at_millis: prismaModel.createdAt.getTime(),
     to: prismaModel.to,
-    sender_config: prismaModel.senderConfig,
+    sender_config: {
+      type: senderConfig.type,
+      host: senderConfig.host,
+      port: senderConfig.port,
+      username: senderConfig.username,
+      sender_name: senderConfig.senderName,
+      sender_email: senderConfig.senderEmail,
+    },
     error: prismaModel.error,
   };
 }
@@ -20,18 +28,17 @@ function prismaModelToCrud(prismaModel: SentEmail): InternalEmailsCrud["Admin"][
 
 export const internalEmailsCrudHandlers = createLazyProxy(() => createCrudHandlers(internalEmailsCrud, {
   paramsSchema: yupObject({
-    projectId: projectIdSchema.defined(),
+    emailId: yupString().optional(),
   }),
   onList: async ({ auth }) => {
     const emails = await prismaClient.sentEmail.findMany({
       where: {
-        tenancy: {
-          projectId: auth.project.id,
-        },
+        tenancyId: auth.tenancy.id,
       },
       orderBy: {
         createdAt: 'desc',
       },
+      take: 100,
     });
 
     return {

--- a/apps/backend/src/app/api/latest/internal/emails/crud.tsx
+++ b/apps/backend/src/app/api/latest/internal/emails/crud.tsx
@@ -22,11 +22,11 @@ export const internalEmailsCrudHandlers = createLazyProxy(() => createCrudHandle
   paramsSchema: yupObject({
     projectId: projectIdSchema.defined(),
   }),
-  onList: async ({ params }) => {
+  onList: async ({ auth }) => {
     const emails = await prismaClient.sentEmail.findMany({
       where: {
         tenancy: {
-          projectId: params.projectId,
+          projectId: auth.project.id,
         },
       },
       orderBy: {

--- a/apps/backend/src/app/api/latest/internal/emails/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/emails/route.tsx
@@ -1,0 +1,3 @@
+import { internalEmailsCrudHandlers } from "./crud";
+
+export const GET = internalEmailsCrudHandlers.listHandler;

--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -957,6 +957,16 @@ export namespace Project {
     });
     return createResult;
   }
+
+  export async function resetContext() {
+    backendContext.set({
+      projectKeys: InternalProjectKeys,
+      mailbox: createMailbox(`default-mailbox--${randomUUID()}${generatedEmailSuffix}`),
+      generatedMailboxNamesCount: 0,
+      userAuth: null,
+      ipData: undefined,
+    });
+  }
 }
 
 export namespace Team {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/email.test.ts
@@ -1,0 +1,125 @@
+import { it } from "../../../../../helpers";
+import { Auth, Project, niceBackendFetch } from "../../../../backend-helpers";
+
+// Test the internal emails CRUD endpoint for listing sent emails
+it("should list sent emails for the current project", async ({ expect }) => {
+  // Sign in and create a project
+  const { adminAccessToken } = await Project.createAndSwitch({
+    config: {
+      magic_link_enabled: true,
+    },
+  });
+
+  // Fetch the sent emails list
+  await Auth.Otp.signIn();
+
+  const response = await niceBackendFetch("/api/v1/internal/emails", {
+    method: "GET",
+    accessType: "admin",
+    headers: {
+      'x-stack-admin-access-token': adminAccessToken,
+    },
+  });
+
+  // Expect a successful response with the correct structure
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": {
+        "is_paginated": false,
+        "items": [
+          {
+            "error": null,
+            "id": "<stripped UUID>",
+            "sender_config": {
+              "host": "127.0.0.1",
+              "port": 2500,
+              "sender_email": "noreply@example.com",
+              "sender_name": "New Project",
+              "type": "shared",
+              "username": "does not matter, ignored by Inbucket",
+            },
+            "sent_at_millis": <stripped field 'sent_at_millis'>,
+            "subject": "Sign in to New Project: Your code is <stripped code>",
+            "to": ["default-mailbox--<stripped UUID>@stack-generated.example.com"],
+          },
+        ],
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});
+
+
+it("should not allow two different projects to see the same send log", async ({ expect }) => {
+  const { adminAccessToken } = await Project.createAndSwitch({
+    config: {
+      magic_link_enabled: true,
+    },
+  });
+
+  // Fetch the sent emails list
+  await Auth.Otp.signIn();
+
+  const response = await niceBackendFetch("/api/v1/internal/emails", {
+    method: "GET",
+    accessType: "admin",
+    headers: {
+      'x-stack-admin-access-token': adminAccessToken,
+    },
+  });
+
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": {
+        "is_paginated": false,
+        "items": [
+          {
+            "error": null,
+            "id": "<stripped UUID>",
+            "sender_config": {
+              "host": "127.0.0.1",
+              "port": 2500,
+              "sender_email": "noreply@example.com",
+              "sender_name": "New Project",
+              "type": "shared",
+              "username": "does not matter, ignored by Inbucket",
+            },
+            "sent_at_millis": <stripped field 'sent_at_millis'>,
+            "subject": "Sign in to New Project: Your code is <stripped code>",
+            "to": ["default-mailbox--<stripped UUID>@stack-generated.example.com"],
+          },
+        ],
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+
+  await Project.resetContext();
+
+  const { adminAccessToken: adminAccessToken2 } = await Project.createAndSwitch({
+    config: {
+      magic_link_enabled: true,
+    },
+  });
+
+  const response2 = await niceBackendFetch("/api/v1/internal/emails", {
+    method: "GET",
+    accessType: "admin",
+    headers: {
+      'x-stack-admin-access-token': adminAccessToken2,
+    },
+  });
+
+  expect(response2).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": {
+        "is_paginated": false,
+        "items": [],
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});

--- a/apps/e2e/tests/snapshot-serializer.ts
+++ b/apps/e2e/tests/snapshot-serializer.ts
@@ -40,6 +40,7 @@ const stripFields = [
   "signed_up_at_millis",
   "expires_at_millis",
   "created_at_millis",
+  "sent_at_millis",
   "updated_at_millis",
   "manually_revoked_at_millis",
   "last_four",

--- a/packages/stack-shared/src/interface/crud/emails.ts
+++ b/packages/stack-shared/src/interface/crud/emails.ts
@@ -1,12 +1,14 @@
 import { createCrud, CrudTypeOf } from "../../crud";
 import * as fieldSchema from "../../schema-fields";
+import { emailConfigWithoutPasswordSchema } from "./projects";
+
 
 export const sentEmailReadSchema = fieldSchema.yupObject({
   id: fieldSchema.yupString().defined(),
   subject: fieldSchema.yupString().defined(),
   sent_at_millis: fieldSchema.yupNumber().defined(),
   to: fieldSchema.yupArray(fieldSchema.yupString().defined()),
-  sender_config: fieldSchema.yupMixed().nullable().defined(),
+  sender_config: emailConfigWithoutPasswordSchema.defined(),
   error: fieldSchema.yupMixed().nullable().optional(),
 }).defined();
 

--- a/packages/stack-shared/src/interface/crud/emails.ts
+++ b/packages/stack-shared/src/interface/crud/emails.ts
@@ -13,7 +13,7 @@ export const sentEmailReadSchema = fieldSchema.yupObject({
 }).defined();
 
 export const internalEmailsCrud = createCrud({
-  clientReadSchema: sentEmailReadSchema,
+  adminReadSchema: sentEmailReadSchema,
 });
 
 export type InternalEmailsCrud = CrudTypeOf<typeof internalEmailsCrud>;

--- a/packages/stack-shared/src/interface/crud/projects.ts
+++ b/packages/stack-shared/src/interface/crud/projects.ts
@@ -56,6 +56,8 @@ export const emailConfigSchema = yupObject({
   }),
 });
 
+export const emailConfigWithoutPasswordSchema = emailConfigSchema.pick(['type', 'host', 'port', 'username', 'sender_name', 'sender_email']);
+
 const domainSchema = yupObject({
   domain: schemaFields.urlSchema.defined()
     .matches(/^https?:\/\//, 'URL must start with http:// or https://')

--- a/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
@@ -21,7 +21,7 @@ import { _StackServerAppImplIncomplete } from "./server-app-impl";
 // NEXT_LINE_PLATFORM react-like
 import { useAsyncCache } from "./common";
 
-export class _StackAdminAppImplIncomplete<HasTokenStore extends boolean, ProjectId extends string> extends _StackServerAppImplIncomplete<HasTokenStore, ProjectId>
+export class _StackAdminAppImplIncomplete<HasTokenStore extends boolean, ProjectId extends string> extends _StackServerAppImplIncomplete<HasTokenStore, ProjectId> implements StackAdminApp<HasTokenStore, ProjectId>
 {
   declare protected _interface: StackAdminInterface;
 

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -58,7 +58,7 @@ const process = (globalThis as any).process ?? { env: {} }; // THIS_LINE_PLATFOR
 
 const allClientApps = new Map<string, [checkString: string, app: StackClientApp<any, any>]>();
 
-export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, ProjectId extends string = string> {
+export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, ProjectId extends string = string> implements StackClientApp<HasTokenStore, ProjectId> {
   /**
    * There is a circular dependency between the admin app and the client app, as the former inherits from the latter and
    * the latter needs to use the former when creating a new instance of an internal project.

--- a/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
@@ -19,7 +19,7 @@ import { ServerContactChannel, ServerContactChannelCreateOptions, ServerContactC
 import { AdminTeamPermission, AdminTeamPermissionDefinition } from "../../permissions";
 import { EditableTeamMemberProfile, ServerListUsersOptions, ServerTeam, ServerTeamCreateOptions, ServerTeamUpdateOptions, ServerTeamUser, Team, TeamInvitation, serverTeamCreateOptionsToCrud, serverTeamUpdateOptionsToCrud } from "../../teams";
 import { ProjectCurrentServerUser, ServerUser, ServerUserCreateOptions, ServerUserUpdateOptions, serverUserCreateOptionsToCrud, serverUserUpdateOptionsToCrud } from "../../users";
-import { StackServerAppConstructorOptions } from "../interfaces/server-app";
+import { StackServerApp, StackServerAppConstructorOptions } from "../interfaces/server-app";
 import { _StackClientAppImplIncomplete } from "./client-app-impl";
 import { clientVersion, createCache, createCacheBySession, getBaseUrl, getDefaultProjectId, getDefaultPublishableClientKey, getDefaultSecretServerKey } from "./common";
 


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->


> [!IMPORTANT]
> Enhance email configuration handling, add email listing endpoint and tests, and update schemas for improved security and functionality.
> 
>   - **Email Configuration**:
>     - Refactor `prismaModelToCrud` in `crud.tsx` to expand `sender_config` into detailed fields.
>     - Use `emailConfigWithoutPasswordSchema` in `emails.ts` for `sender_config`.
>   - **API Changes**:
>     - Update `internalEmailsCrudHandlers` in `crud.tsx` to use `auth.tenancy.id` for filtering emails and limit results to 100.
>     - Add `route.tsx` to export `GET` handler for listing emails.
>   - **Testing**:
>     - Add `email.test.ts` to test email listing, project isolation, and admin access restrictions.
>     - Add `resetContext` function in `backend-helpers.ts` to reset test context.
>   - **Miscellaneous**:
>     - Implement `emailConfigWithoutPasswordSchema` in `projects.ts` to exclude password from email config.
>     - Update `snapshot-serializer.ts` to strip `sent_at_millis` field.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 6721f4e13af3f91679a02f67aa1671499ebf39a6. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->