### PR TITLE
add getUser overload

### DIFF
--- a/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
@@ -19,7 +19,7 @@ import { ServerContactChannel, ServerContactChannelCreateOptions, ServerContactC
 import { AdminTeamPermission, AdminTeamPermissionDefinition } from "../../permissions";
 import { EditableTeamMemberProfile, ServerListUsersOptions, ServerTeam, ServerTeamCreateOptions, ServerTeamUpdateOptions, ServerTeamUser, Team, TeamInvitation, serverTeamCreateOptionsToCrud, serverTeamUpdateOptionsToCrud } from "../../teams";
 import { ProjectCurrentServerUser, ServerUser, ServerUserCreateOptions, ServerUserUpdateOptions, serverUserCreateOptionsToCrud, serverUserUpdateOptionsToCrud } from "../../users";
-import { StackServerApp, StackServerAppConstructorOptions } from "../interfaces/server-app";
+import { StackServerAppConstructorOptions } from "../interfaces/server-app";
 import { _StackClientAppImplIncomplete } from "./client-app-impl";
 import { clientVersion, createCache, createCacheBySession, getBaseUrl, getDefaultProjectId, getDefaultPublishableClientKey, getDefaultSecretServerKey } from "./common";
 

--- a/packages/template/src/lib/stack-app/apps/interfaces/server-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/server-app.ts
@@ -28,6 +28,7 @@ export type StackServerApp<HasTokenStore extends boolean = boolean, ProjectId ex
     getUser(options: GetUserOptions<HasTokenStore> & { or: 'redirect' }): Promise<ProjectCurrentServerUser<ProjectId>>,
     getUser(options: GetUserOptions<HasTokenStore> & { or: 'throw' }): Promise<ProjectCurrentServerUser<ProjectId>>,
     getUser(options?: GetUserOptions<HasTokenStore>): Promise<ProjectCurrentServerUser<ProjectId> | null>,
+    getUser(id: string): Promise<ServerUser | null>,
 
     useUsers(options?: ServerListUsersOptions): ServerUser[] & { nextCursor: string | null }, // THIS_LINE_PLATFORM react-like
     listUsers(options?: ServerListUsersOptions): Promise<ServerUser[] & { nextCursor: string | null }>,


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `getUser` overload to fetch `ServerUser` by ID in `server-app.ts` and `server-app-impl.ts`.
> 
>   - **Functionality**:
>     - Adds `getUser(id: string): Promise<ServerUser | null>` overload to `getUser` in `server-app.ts` and `server-app-impl.ts`.
>     - Allows fetching a `ServerUser` by ID, returning `null` if not found.
>   - **Implementation**:
>     - Updates `getUser` method in `server-app-impl.ts` to handle string ID input and call `getServerUserById`.
>   - **Interface**:
>     - Updates `StackServerApp` type in `server-app.ts` to include new `getUser` overload.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 071bd2a2e6987e944b0be954220e4548ee2c3f26. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->