### PR TITLE
don't show password option if not enabled

### DIFF
--- a/packages/template/src/components-page/account-settings.tsx
+++ b/packages/template/src/components-page/account-settings.tsx
@@ -722,6 +722,7 @@ function PasswordSection() {
   const contactChannels = user.useContactChannels();
   const [changingPassword, setChangingPassword] = useState(false);
   const [loading, setLoading] = useState(false);
+  const project = useStackApp().useProject();
 
   const passwordSchema = yupObject({
     oldPassword: user.hasPassword ? schemaFieldsPasswordSchema.defined().nonEmpty(t('Please enter your old password')) : yupString(),
@@ -766,6 +767,10 @@ function PasswordSection() {
 
   const registerPassword = register('newPassword');
   const registerPasswordRepeat = register('newPasswordRepeat');
+
+  if (!project.config.credentialEnabled) {
+    return null;
+  }
 
   return (
     <Section


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add conditional rendering to `PasswordSection` in `account-settings.tsx` to hide password option if `credentialEnabled` is false.
> 
>   - **Behavior**:
>     - In `PasswordSection` in `account-settings.tsx`, add a check for `project.config.credentialEnabled`.
>     - If `credentialEnabled` is false, `PasswordSection` returns `null`, hiding the password option.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 9c65ddb4f95a3ee8d55f97f362c12cd23878aedc. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->