### PR TITLE
no redirect option after signing in with magic link

### DIFF
--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -1343,7 +1343,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
     }
   }
 
-  async signInWithMagicLink(code: string, noRedirect?: boolean): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>> {
+  async signInWithMagicLink(code: string, options?: { noRedirect?: boolean }): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>> {
     this._ensurePersistentTokenStore();
     let result;
     try {
@@ -1359,7 +1359,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
 
     if (result.status === 'ok') {
       await this._signInToAccountWithTokens(result.data);
-      if (!noRedirect) {
+      if (!(options?.noRedirect)) {
         if (result.data.newUser) {
           await this.redirectToAfterSignUp({ replace: true });
         } else {

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -1343,7 +1343,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
     }
   }
 
-  async signInWithMagicLink(code: string): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>> {
+  async signInWithMagicLink(code: string, noRedirect?: boolean): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>> {
     this._ensurePersistentTokenStore();
     let result;
     try {
@@ -1359,10 +1359,12 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
 
     if (result.status === 'ok') {
       await this._signInToAccountWithTokens(result.data);
-      if (result.data.newUser) {
-        await this.redirectToAfterSignUp({ replace: true });
-      } else {
-        await this.redirectToAfterSignIn({ replace: true });
+      if (!noRedirect) {
+        if (result.data.newUser) {
+          await this.redirectToAfterSignUp({ replace: true });
+        } else {
+          await this.redirectToAfterSignIn({ replace: true });
+        }
       }
       return Result.ok(undefined);
     } else {

--- a/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
@@ -50,7 +50,7 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
     acceptTeamInvitation(code: string): Promise<Result<undefined, KnownErrors["VerificationCodeError"]>>,
     getTeamInvitationDetails(code: string): Promise<Result<{ teamDisplayName: string }, KnownErrors["VerificationCodeError"]>>,
     verifyEmail(code: string): Promise<Result<undefined, KnownErrors["VerificationCodeError"]>>,
-    signInWithMagicLink(code: string): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>>,
+    signInWithMagicLink(code: string, options?: { noRedirect?: boolean }): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>>,
 
     redirectToOAuthCallback(): Promise<void>,
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

Looks like this option was added to other sign in methods earlier. For my implementation I need the same option when signing in with magic link.
<!-- ELLIPSIS_HIDDEN -->


- See https://github.com/stack-auth/stack-auth/pull/213 for similar change.
- Unsure how to write tests for this functionality or if they are necessary.


----

> [!IMPORTANT]
> Add `noRedirect` option to `signInWithMagicLink()` in `client-app-impl.ts` to optionally bypass post-sign-in redirection.
> 
>   - **Behavior**:
>     - Add `noRedirect` parameter to `signInWithMagicLink()` in `client-app-impl.ts` to optionally bypass redirection after signing in.
>     - If `noRedirect` is `true`, skips redirecting to `redirectToAfterSignIn` or `redirectToAfterSignUp`.
>   - **Misc**:
>     - Aligns `signInWithMagicLink` behavior with other sign-in methods that support `noRedirect`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for e09de89c1a37aa1efe4e103327d9972ca9719b20. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->