### PR TITLE
Fix OTP docs

### DIFF
--- a/apps/backend/src/app/api/latest/auth/otp/send-sign-in-code/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/otp/send-sign-in-code/route.tsx
@@ -32,7 +32,7 @@ export const POST = createSmartRouteHandler({
     statusCode: yupNumber().oneOf([200]).defined(),
     bodyType: yupString().oneOf(["json"]).defined(),
     body: yupObject({
-      nonce: yupString().defined(),
+      nonce: yupString().defined().meta({ openapiField: { description: "A token that must be stored temporarily and provided when verifying the 6-digit code", exampleValue: "u3h6gn4w24pqc8ya679inrhjwh1rybth6a7thurqhnpf2" } }),
     }).defined(),
   }),
   async handler({ auth: { tenancy }, body: { email, callback_url: callbackUrl }, clientVersion }, fullReq) {

--- a/apps/backend/src/app/api/latest/auth/otp/sign-in/verification-code-handler.tsx
+++ b/apps/backend/src/app/api/latest/auth/otp/sign-in/verification-code-handler.tsx
@@ -13,14 +13,15 @@ export const signInVerificationCodeHandler = createVerificationCodeHandler({
   metadata: {
     post: {
       summary: "Sign in with a code",
-      description: "Sign in with a code",
+      description: "",
       tags: ["OTP"],
     },
     check: {
       summary: "Check sign in code",
       description: "Check if a sign in code is valid without using it",
       tags: ["OTP"],
-    }
+    },
+    codeDescription: `A 45-character verification code. For magic links, this is the code found in the "code" URL query parameter. For OTP, this is formed by concatenating the nonce (received during code creation) with the 6-digit code entered by the user`,
   },
   type: VerificationCodeType.ONE_TIME_PASSWORD,
   data: yupObject({

--- a/apps/backend/src/app/api/latest/integrations/neon/projects/transfer/confirm/verification-code-handler.tsx
+++ b/apps/backend/src/app/api/latest/integrations/neon/projects/transfer/confirm/verification-code-handler.tsx
@@ -10,6 +10,9 @@ export const neonIntegrationProjectTransferCodeHandler = createVerificationCodeH
     post: {
       hidden: true,
     },
+    check: {
+      hidden: true,
+    },
   },
   type: VerificationCodeType.NEON_INTEGRATION_PROJECT_TRANSFER,
   data: yupObject({

--- a/apps/backend/src/route-handlers/verification-code-handler.tsx
+++ b/apps/backend/src/route-handlers/verification-code-handler.tsx
@@ -123,7 +123,7 @@ export function createVerificationCodeHandler<
         user: adaptSchema,
       }).defined(),
       body: yupObject({
-        code: yupString().length(45).defined().meta({ openapiField: { description: options.metadata?.codeDescription, exampleValue: "u3h6gn4w24pqc8ya679inrhjwh1rybth6a7thurqhnpf2" } }),
+        code: yupString().length(45).defined().meta({ openapiField: { description: options.metadata?.codeDescription || "A 45 character code", exampleValue: "u3h6gn4w24pqc8ya679inrhjwh1rybth6a7thurqhnpf2" } }),
       // we cast to undefined as a typehack because the types are a bit icky
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       }).concat((handlerType === 'post' ? options.requestBody : undefined) as undefined ?? yupObject({})).defined(),

--- a/apps/backend/src/route-handlers/verification-code-handler.tsx
+++ b/apps/backend/src/route-handlers/verification-code-handler.tsx
@@ -79,6 +79,7 @@ export function createVerificationCodeHandler<
     post?: SmartRouteHandlerOverloadMetadata,
     check?: SmartRouteHandlerOverloadMetadata,
     details?: SmartRouteHandlerOverloadMetadata,
+    codeDescription?: string,
   },
   type: VerificationCodeType,
   data: yup.Schema<Data>,
@@ -122,7 +123,7 @@ export function createVerificationCodeHandler<
         user: adaptSchema,
       }).defined(),
       body: yupObject({
-        code: yupString().length(45).defined(),
+        code: yupString().length(45).defined().meta({ openapiField: { description: options.metadata?.codeDescription, exampleValue: "u3h6gn4w24pqc8ya679inrhjwh1rybth6a7thurqhnpf2" } }),
       // we cast to undefined as a typehack because the types are a bit icky
       // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
       }).concat((handlerType === 'post' ? options.requestBody : undefined) as undefined ?? yupObject({})).defined(),

--- a/packages/stack-shared/src/interface/crud/team-invitation.ts
+++ b/packages/stack-shared/src/interface/crud/team-invitation.ts
@@ -18,6 +18,16 @@ export const teamInvitationCrud = createCrud({
       description: "",
       tags: ["Teams"],
     },
+    clientList: {
+      summary: "List team invitations",
+      description: "",
+      tags: ["Teams"],
+    },
+    clientDelete: {
+      summary: "Delete a team invitation",
+      description: "",
+      tags: ["Teams"],
+    },
   },
 });
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enhance OTP and team invitation documentation by adding metadata and descriptions across various handlers.
> 
>   - **OTP Documentation**:
>     - Add `codeDescription` metadata to `signInVerificationCodeHandler` in `verification-code-handler.tsx`.
>     - Update `nonce` field in `send-sign-in-code/route.tsx` with OpenAPI metadata.
>   - **Neon Integration**:
>     - Add `check` metadata to `neonIntegrationProjectTransferCodeHandler` in `verification-code-handler.tsx`.
>   - **Team Invitation**:
>     - Add `clientList` and `clientDelete` metadata in `team-invitation.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 6bc1461d223d42728c435bc53b37823283e04ce9. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->