### PR TITLE
Auto select team on creation

### DIFF
--- a/apps/backend/src/app/api/latest/users/crud.tsx
+++ b/apps/backend/src/app/api/latest/users/crud.tsx
@@ -728,7 +728,7 @@ export const usersCrudHandlers = createLazyProxy(() => createCrudHandlers(usersC
     });
 
     if (auth.tenancy.config.create_team_on_sign_up) {
-      await teamsCrudHandlers.adminCreate({
+      const team = await teamsCrudHandlers.adminCreate({
         data: {
           display_name: data.display_name ?
             `${data.display_name}'s Team` :
@@ -739,6 +739,19 @@ export const usersCrudHandlers = createLazyProxy(() => createCrudHandlers(usersC
         },
         tenancy: auth.tenancy,
         user: result,
+      });
+
+      await prismaClient.teamMember.update({
+        where: {
+          tenancyId_projectUserId_teamId: {
+            tenancyId: auth.tenancy.id,
+            projectUserId: result.id,
+            teamId: team.id,
+          },
+        },
+        data: {
+          isSelected: BooleanTrue.TRUE,
+        },
       });
     }
 

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -856,6 +856,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
       async createTeam(data: TeamCreateOptions) {
         const crud = await app._interface.createClientTeam(teamCreateOptionsToCrud(data, 'me'), session);
         await app._currentUserTeamsCache.refresh([session]);
+        await this.update({ selectedTeamId: crud.id });
         return app._clientTeamFromCrud(crud, session);
       },
       async leaveTeam(team: Team) {

--- a/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
@@ -308,6 +308,7 @@ export class _StackServerAppImplIncomplete<HasTokenStore extends boolean, Projec
           ...data,
         }));
         await app._serverTeamsCache.refresh([undefined]);
+        await app._updateServerUser(crud.id, { selectedTeamId: team.id });
         return app._serverTeamFromCrud(team);
       },
       leaveTeam: async (team: Team) => {


### PR DESCRIPTION
- Updated usersCrudHandlers to create a team upon user sign-up and set the team member's selection status.
- Modified client and server app implementations to ensure the selected team ID is updated after team creation.

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Automatically select a team upon user creation by updating backend and client/server logic to set the selected team ID after team creation.
> 
>   - **Backend**:
>     - In `usersCrudHandlers` in `crud.tsx`, create a team on user sign-up and set `isSelected` to `BooleanTrue.TRUE` for the team member.
>   - **Client**:
>     - In `_StackClientAppImplIncomplete` in `client-app-impl.ts`, update `createTeam()` to set `selectedTeamId` after team creation.
>   - **Server**:
>     - In `_StackServerAppImplIncomplete` in `server-app-impl.ts`, update `createTeam()` to set `selectedTeamId` after team creation.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 0321b6c7247985c7aaaffb68a0ec2ce23e71c708. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->