### PR TITLE
add spinner to redirect page

### DIFF
--- a/packages/template/src/components-page/oauth-callback.tsx
+++ b/packages/template/src/components-page/oauth-callback.tsx
@@ -2,12 +2,12 @@
 
 import { captureError } from "@stackframe/stack-shared/dist/utils/errors";
 import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
+import { Spinner, cn } from "@stackframe/stack-ui";
 import { useEffect, useRef, useState } from "react";
 import { useStackApp } from "..";
+import { MaybeFullPage } from "../components/elements/maybe-full-page";
 import { StyledLink } from "../components/link";
 import { useTranslation } from "../lib/translations";
-import { Spinner, Typography, cn } from "@stackframe/stack-ui";
-import { MaybeFullPage } from "../components/elements/maybe-full-page";
 
 export function OAuthCallback({ fullPage }: { fullPage?: boolean }) {
   const { t } = useTranslation();
@@ -47,8 +47,7 @@ export function OAuthCallback({ fullPage }: { fullPage?: boolean }) {
         )}
       >
         <div className="flex flex-col justify-center items-center gap-4">
-          <Spinner />
-          <Typography type='h3'>{t("Redirecting")}</Typography>
+          <Spinner size={20} />
         </div>
         {showRedirectLink ? <p>{t('If you are not redirected automatically, ')}<StyledLink className="whitespace-nowrap" href={app.urls.home}>{t("click here")}</StyledLink></p> : null}
         {error ? <div>

--- a/packages/template/src/components-page/oauth-callback.tsx
+++ b/packages/template/src/components-page/oauth-callback.tsx
@@ -5,10 +5,11 @@ import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises"
 import { useEffect, useRef, useState } from "react";
 import { useStackApp } from "..";
 import { StyledLink } from "../components/link";
-import { MessageCard } from "../components/message-cards/message-card";
 import { useTranslation } from "../lib/translations";
+import { Spinner, Typography, cn } from "@stackframe/stack-ui";
+import { MaybeFullPage } from "../components/elements/maybe-full-page";
 
-export function OAuthCallback(props: { fullPage?: boolean }) {
+export function OAuthCallback({ fullPage }: { fullPage?: boolean }) {
   const { t } = useTranslation();
   const app = useStackApp();
   const called = useRef(false);
@@ -21,7 +22,7 @@ export function OAuthCallback(props: { fullPage?: boolean }) {
     let hasRedirected = false;
     try {
       hasRedirected = await app.callOAuthCallback();
-    } catch (e: any) {
+    } catch (e) {
       captureError("<OAuthCallback />", e);
       setError(e);
     }
@@ -34,12 +35,28 @@ export function OAuthCallback(props: { fullPage?: boolean }) {
     setTimeout(() => setShowRedirectLink(true), 3000);
   }, []);
 
-  return <MessageCard title='Redirecting...' fullPage={props.fullPage}>
-    {showRedirectLink ? <p>{t('If you are not redirected automatically, ')}<StyledLink href={app.urls.home}>{t("click here")}</StyledLink></p> : null}
-    {error ? <div>
-      <p>{t("Something went wrong while processing the OAuth callback:")}</p>
-      <pre>{JSON.stringify(error, null, 2)}</pre>
-      <p>{t("This is most likely an error in Stack. Please report it.")}</p>
-    </div> : null}
-  </MessageCard>;
+  return (
+    <MaybeFullPage
+      fullPage={fullPage ?? false}
+      containerClassName="flex items-center justify-center"
+    >
+      <div
+        className={cn(
+          "text-center justify-center items-center stack-scope flex flex-col gap-4 max-w-[380px]",
+          fullPage ? "p-4" : "p-0"
+        )}
+      >
+        <div className="flex flex-col justify-center items-center gap-4">
+          <Spinner />
+          <Typography type='h3'>{t("Redirecting")}</Typography>
+        </div>
+        {showRedirectLink ? <p>{t('If you are not redirected automatically, ')}<StyledLink className="whitespace-nowrap" href={app.urls.home}>{t("click here")}</StyledLink></p> : null}
+        {error ? <div>
+          <p>{t("Something went wrong while processing the OAuth callback:")}</p>
+          <pre>{JSON.stringify(error, null, 2)}</pre>
+          <p>{t("This is most likely an error in Stack. Please report it.")}</p>
+        </div> : null}
+      </div>
+    </MaybeFullPage>
+  );
 }


### PR DESCRIPTION
Adds a spinner to the oauth callback page. Not sure if this is an ideal solution though, maybe it would be better to just allow customization of the redirect page contents directly in configuration.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add spinner to `OAuthCallback` in `oauth-callback.tsx` for improved user feedback during redirection.
> 
>   - **UI Enhancement**:
>     - Add `Spinner` to `OAuthCallback` in `oauth-callback.tsx` for visual feedback during redirection.
>     - Replace `MessageCard` with `MaybeFullPage` for better full-page rendering.
>   - **Layout**:
>     - Adjust layout to center spinner and text using `flex` and `cn` classes.
>     - Maintain existing error and redirect link logic.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for e2c6e56c9c26744ede84d6420b298284ed9da56f. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->