### PR TITLE
fix: local development with docker_compose needs this extra var

### DIFF
--- a/docker/server/.env
+++ b/docker/server/.env
@@ -26,6 +26,7 @@ STACK_EMAIL_SENDER=
 
 # Set these if you want to use webhooks
 STACK_SVIX_SERVER_URL=# this is only needed if you self-host the Svix service
+NEXT_PUBLIC_STACK_SVIX_SERVER_URL=# this is only needed when runnning local dev with docker compose, this should be refering to localhost
 STACK_SVIX_API_KEY=
 
 


### PR DESCRIPTION
When developing Locally with docker compose stack sets the env var NEXT_PUBLIC_STACK_SVIX_SERVER_URL to STACK_SVIX_SERVER_URL, this then breaks webhooks due to the fact that STACK_SVIX_SERVER_URL is called within docker and NEXT_PUBLIC_STACK_SVIX_SERVER_URL is called from the frontend, in my specific case:
NEXT_PUBLIC_STACK_SVIX_SERVER_URL=http://localhost:8071
STACK_SVIX_SERVER_URL=http://svix:8071

Hopefully this helps the next person 😃 
