### PR TITLE
docs: add team permissions webhook events to documentation

### DIFF
--- a/packages/stack-shared/src/interface/webhooks.ts
+++ b/packages/stack-shared/src/interface/webhooks.ts
@@ -1,5 +1,6 @@
 import * as yup from "yup";
 import { teamMembershipCreatedWebhookEvent, teamMembershipDeletedWebhookEvent } from "./crud/team-memberships";
+import { teamPermissionCreatedWebhookEvent, teamPermissionDeletedWebhookEvent } from "./crud/team-permissions";
 import { teamCreatedWebhookEvent, teamDeletedWebhookEvent, teamUpdatedWebhookEvent } from "./crud/teams";
 import { userCreatedWebhookEvent, userDeletedWebhookEvent, userUpdatedWebhookEvent } from "./crud/users";
 
@@ -22,4 +23,6 @@ export const webhookEvents = [
   teamDeletedWebhookEvent,
   teamMembershipCreatedWebhookEvent,
   teamMembershipDeletedWebhookEvent,
+  teamPermissionCreatedWebhookEvent,
+  teamPermissionDeletedWebhookEvent,
 ] as const;


### PR DESCRIPTION
## Description
Added team permission webhook events to the documentation. This includes:
- `team_permission.created` - Triggered when a team permission is created
- `team_permission.deleted` - Triggered when a team permission is deleted

## Changes
- Added webhook events to `packages/stack-shared/src/interface/webhooks.ts`
- Generated updated OpenAPI documentation

## Testing
- Verified the webhooks appear in the documentation by running the docs server locally
- Confirmed the webhook payloads match the schema defined in `team-permissions.ts`
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add `teamPermissionCreated` and `teamPermissionDeleted` webhook events to documentation and update OpenAPI docs.
> 
>   - **Webhooks**:
>     - Added `teamPermissionCreatedWebhookEvent` and `teamPermissionDeletedWebhookEvent` to `webhooks.ts`.
>     - Updated `webhookEvents` array to include new team permission events.
>   - **Documentation**:
>     - Generated updated OpenAPI documentation to include new webhook events.
>   - **Testing**:
>     - Verified new webhooks appear in local documentation server.
>     - Confirmed webhook payloads match schema in `team-permissions.ts`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for f54b6554d02065989f054f2d2d0fe3330cd652e6. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->