### PR TITLE
Minor Fern layout fixes

### DIFF
--- a/docs/fern/style.css
+++ b/docs/fern/style.css
@@ -200,3 +200,7 @@ div.stack-350h > span > span > img, img.stack-350h {
   height: 350px !important;
   object-fit: contain !important;
 }
+
+.fern-layout-reference-content {
+  grid-template-columns: repeat(1,minmax(0,1fr)) !important;
+}


### PR DESCRIPTION

<!-- ELLIPSIS_HIDDEN -->



> [!IMPORTANT]
> Adds `.fern-layout-reference-content` class to `style.css` for grid layout adjustment.
> 
>   - **CSS Update**:
>     - Adds `.fern-layout-reference-content` class in `style.css` to set `grid-template-columns` to `repeat(1,minmax(0,1fr))` with `!important`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for d0aad335404592497bb0fa9d946c9342dd02e97e. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->