### PR TITLE
fix configdb

### DIFF
--- a/apps/backend/src/lib/config.tsx
+++ b/apps/backend/src/lib/config.tsx
@@ -321,7 +321,7 @@ export async function getEnvironmentConfigOverride(options: EnvironmentOptions):
     .sort((a, b) => stringCompare(a.id, b.id));
 
   for (const perm of projectPermissionDefinitions) {
-    configOverride[`teams.projectPermissionDefinitions.${perm.id}`] = filterUndefined({
+    configOverride[`users.userPermissionDefinitions.${perm.id}`] = filterUndefined({
       description: perm.description,
       containedPermissions: typedFromEntries(perm.contained_permission_ids.map(containedPerm => [containedPerm, {}]))
     });

--- a/packages/stack-shared/src/config/format.ts
+++ b/packages/stack-shared/src/config/format.ts
@@ -33,7 +33,7 @@ export function getInvalidConfigReason(c: unknown, options: { configName?: strin
   if (c === null || typeof c !== 'object') return `${configName} must be a non-null object`;
   for (const [key, value] of Object.entries(c)) {
     if (typeof key !== 'string') return `${configName} must have only string keys (found: ${typeof key})`;
-    if (!key.match(/^[a-zA-Z0-9_$][a-zA-Z_$0-9\-]*(?:\.[a-zA-Z0-9_$][a-zA-Z_$0-9\-]*)*$/)) return `All keys of ${configName} must consist of only alphanumeric characters, dots, underscores, dollar signs, or hyphens and start with a character other than a hyphen (found: ${key})`;
+    if (!key.match(/^[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*(?:\.[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*)*$/)) return `All keys of ${configName} must consist of only alphanumeric characters, dots, underscores, dollar signs, or hyphens and start with a character other than a hyphen (found: ${key})`;
 
     const entryName = `${configName}.${key}`;
     const reason = getInvalidConfigValueReason(value, { valueName: entryName });

--- a/packages/stack-shared/src/config/format.ts
+++ b/packages/stack-shared/src/config/format.ts
@@ -33,7 +33,7 @@ export function getInvalidConfigReason(c: unknown, options: { configName?: strin
   if (c === null || typeof c !== 'object') return `${configName} must be a non-null object`;
   for (const [key, value] of Object.entries(c)) {
     if (typeof key !== 'string') return `${configName} must have only string keys (found: ${typeof key})`;
-    if (!key.match(/^[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*(?:\.[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*)*$/)) return `All keys of ${configName} must consist of only alphanumeric characters, dots, underscores, dollar signs, or hyphens and start with a character other than a hyphen (found: ${key})`;
+    if (!key.match(/^[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*(?:\.[a-zA-Z0-9_:$][a-zA-Z_:$0-9\-]*)*$/)) return `All keys of ${configName} must consist of only alphanumeric characters, dots, underscores, colons, dollar signs, or hyphens and start with a character other than a hyphen (found: ${key})`;
 
     const entryName = `${configName}.${key}`;
     const reason = getInvalidConfigValueReason(value, { valueName: entryName });


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix configuration handling by renaming key prefixes and updating regex for key validation.
> 
>   - **Behavior**:
>     - In `config.tsx`, change key prefix from `teams.projectPermissionDefinitions` to `users.userPermissionDefinitions` for project permission definitions.
>     - In `format.ts`, update regex in `getInvalidConfigReason()` to allow colons in keys.
>   - **Misc**:
>     - No other changes or additions are made in this pull request.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 62e61ca68e23e91586ea9d1818dc678570066193. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->