### PR TITLE
Revert "Fix/disable forgot password when auth disabled"

### DIFF
--- a/packages/template/src/components-page/stack-handler.tsx
+++ b/packages/template/src/components-page/stack-handler.tsx
@@ -77,15 +77,11 @@ function renderComponent(props: {
   redirectIfNotHandler?: (name: keyof HandlerUrls) => void,
   onNotFound: () => any,
   app: StackClientApp<any> | StackServerApp<any>,
-  user: any,
 }) {
-  const { path, searchParams, fullPage, componentProps, redirectIfNotHandler, onNotFound, app, user } = props;
+  const { path, searchParams, fullPage, componentProps, redirectIfNotHandler, onNotFound, app } = props;
 
   switch (path) {
     case availablePaths.signIn: {
-      if (user) {
-        redirect(app.urls.afterSignIn);
-      }
       redirectIfNotHandler?.('signIn');
       return <SignIn
         fullPage={fullPage}
@@ -94,9 +90,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.signUp: {
-      if (user) {
-        redirect(app.urls.afterSignUp);
-      }
       redirectIfNotHandler?.('signUp');
       return <SignUp
         fullPage={fullPage}
@@ -113,9 +106,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.passwordReset: {
-      if (user) {
-        redirect(app.urls.afterSignIn);
-      }
       redirectIfNotHandler?.('passwordReset');
       return <PasswordReset
         searchParams={searchParams}
@@ -124,9 +114,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.forgotPassword: {
-      if (user) {
-        redirect(app.urls.afterSignIn);
-      }
       redirectIfNotHandler?.('forgotPassword');
       return <ForgotPassword
         fullPage={fullPage}
@@ -134,9 +121,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.signOut: {
-      if (!user) {
-        redirect(app.urls.signIn);
-      }
       redirectIfNotHandler?.('signOut');
       return <SignOut
         fullPage={fullPage}
@@ -144,9 +128,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.oauthCallback: {
-      if (user) {
-        redirect(app.urls.afterSignIn);
-      }
       redirectIfNotHandler?.('oauthCallback');
       return <OAuthCallback
         fullPage={fullPage}
@@ -154,9 +135,6 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.magicLinkCallback: {
-      if (user) {
-        redirect(app.urls.afterSignIn);
-      }
       redirectIfNotHandler?.('magicLinkCallback');
       return <MagicLinkCallback
         searchParams={searchParams}
@@ -173,17 +151,12 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.accountSettings: {
-      if (!user) {
-        redirect(app.urls.signIn);
-      }
-      redirectIfNotHandler?.('accountSettings');
       return <AccountSettings
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.AccountSettings)}
       />;
     }
     case availablePaths.error: {
-      redirectIfNotHandler?.('error');
       return <ErrorPage
         searchParams={searchParams}
         fullPage={fullPage}
@@ -227,7 +200,7 @@ async function NextStackHandler<HasTokenStore extends boolean>(props: BaseHandle
   const routeProps = "routeProps" in props ? props.routeProps as RouteProps : pick(props, ["params", "searchParams"] as any);
   const params = await routeProps.params;
   const searchParams = await routeProps.searchParams;
-  const user = await props.app.getUser();
+
   if (!params?.stack) {
     return (
       <MessageCard title="Invalid Stack Handler Setup" fullPage={props.fullPage}>
@@ -264,7 +237,6 @@ async function NextStackHandler<HasTokenStore extends boolean>(props: BaseHandle
     redirectIfNotHandler,
     onNotFound: () => notFound(),
     app: props.app,
-    user,
   });
 
   if (result && 'redirect' in result) {
@@ -305,8 +277,6 @@ function ReactStackHandler<HasTokenStore extends boolean>(props: BaseHandlerProp
     };
   }, [props.location, props.app.urls.handler]);
 
-  const user = props.app.useUser();
-
   const redirectIfNotHandler = (name: keyof HandlerUrls) => {
     const url = props.app.urls[name];
     const handlerUrl = props.app.urls.handler;
@@ -340,7 +310,6 @@ function ReactStackHandler<HasTokenStore extends boolean>(props: BaseHandlerProp
       </MessageCard>
     ),
     app: props.app,
-    user,
   });
 
   if (result && 'redirect' in result) {


### PR DESCRIPTION
Reverts stack-auth/stack-auth#562
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Reverts user checks and redirects in `stack-handler.tsx`, restoring previous behavior for authentication-related paths.
> 
>   - **Revert Changes**:
>     - Reverts user checks and redirects in `renderComponent()` for paths: `signIn`, `signUp`, `passwordReset`, `forgotPassword`, `signOut`, `oauthCallback`, `magicLinkCallback`, `accountSettings`.
>     - Removes `user` parameter from `renderComponent()` and related functions.
>   - **Functions Affected**:
>     - `NextStackHandler()` and `ReactStackHandler()` no longer fetch or use `user` data.
>     - `redirectIfNotHandler` logic remains unchanged but no longer depends on `user` state.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 863b3368483eaf258f3df0c7aaad454812fa8919. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->