### PR TITLE
fix error on teams page and improve text when display name not set

### DIFF
--- a/packages/template/src/components-page/account-settings/teams/team-api-keys-section.tsx
+++ b/packages/template/src/components-page/account-settings/teams/team-api-keys-section.tsx
@@ -3,7 +3,7 @@ import { Button } from "@stackframe/stack-ui";
 import { useState } from "react";
 import { CreateApiKeyDialog, ShowApiKeyDialog } from "../../../components/api-key-dialogs";
 import { ApiKeyTable } from "../../../components/api-key-table";
-import { useUser } from "../../../lib/hooks";
+import { useStackApp, useUser } from "../../../lib/hooks";
 import { TeamApiKeyFirstView } from "../../../lib/stack-app/api-keys";
 import { Team } from "../../../lib/stack-app/teams";
 import { useTranslation } from "../../../lib/translations";
@@ -13,13 +13,16 @@ import { Section } from "../section";
 export function TeamApiKeysSection(props: { team: Team }) {
   const user = useUser({ or: 'redirect' });
   const team = user.useTeam(props.team.id);
+  const stackApp = useStackApp();
+  const project = stackApp.useProject();
 
   if (!team) {
     throw new StackAssertionError("Team not found");
   }
 
+  const teamApiKeysEnabled = project.config.allowTeamApiKeys;
   const manageApiKeysPermission = user.usePermission(props.team, '$manage_api_keys');
-  if (!manageApiKeysPermission) {
+  if (!manageApiKeysPermission || !teamApiKeysEnabled) {
     return null;
   }
 

--- a/packages/template/src/components-page/account-settings/teams/team-member-list-section.tsx
+++ b/packages/template/src/components-page/account-settings/teams/team-member-list-section.tsx
@@ -38,7 +38,12 @@ function MemberListSectionInner(props: { team: Team }) {
                   <UserAvatar user={teamProfile} />
                 </TableCell>
                 <TableCell>
-                  <Typography>{teamProfile.displayName}</Typography>
+                  {teamProfile.displayName && (
+                    <Typography>{teamProfile.displayName}</Typography>
+                  )}
+                  {!teamProfile.displayName && (
+                    <Typography className="text-muted-foreground italic">{t("No display name set")}</Typography>
+                  )}
                 </TableCell>
               </TableRow>
             ))}


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fix error on teams page by checking project config and improve display name handling in `team-member-list-section.tsx`.
> 
>   - **Behavior**:
>     - In `team-api-keys-section.tsx`, add `useStackApp` to check `project.config.allowTeamApiKeys` before rendering API keys section.
>     - In `team-member-list-section.tsx`, display "No display name set" when `teamProfile.displayName` is not available.
>   - **Permissions**:
>     - Modify `TeamApiKeysSection` to return `null` if `manageApiKeysPermission` is false or `teamApiKeysEnabled` is false.
>   - **UI**:
>     - Update `MemberListSectionInner` to show italicized, muted text when display name is missing.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for ad84a474e82572c1d9f581298a37cc1eb496b655. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->