### PR TITLE
Fix dead link in cli-authentication.mdx

### DIFF
--- a/docs/fern/docs/pages-template/others/cli-authentication.mdx
+++ b/docs/fern/docs/pages-template/others/cli-authentication.mdx
@@ -5,7 +5,7 @@ description: How to authenticate a command line application using Stack Auth
 
 If you're building a command line application that runs in a terminal, you can use Stack Auth to let your users log in to their accounts.
 
-To do so, we provide a Python template that you can use as a starting point. [Download it here](https://github.com/stack-auth/stack-auth/docs/examples/stack_auth_cli_template.py) and copy it into your project, for example:
+To do so, we provide a Python template that you can use as a starting point. [Download it here](https://github.com/stack-auth/stack-auth/tree/master/docs/examples/stack_auth_cli_template.py) and copy it into your project, for example:
 
 ```py
 └─ my-python-app

--- a/docs/fern/docs/pages-template/others/cli-authentication.mdx
+++ b/docs/fern/docs/pages-template/others/cli-authentication.mdx
@@ -5,7 +5,7 @@ description: How to authenticate a command line application using Stack Auth
 
 If you're building a command line application that runs in a terminal, you can use Stack Auth to let your users log in to their accounts.
 
-To do so, we provide a Python template that you can use as a starting point. [Download it here](https://github.com/stack-auth/stack-auth/tree/master/docs/examples/stack_auth_cli_template.py) and copy it into your project, for example:
+To do so, we provide a Python template that you can use as a starting point. [Download it here](https://github.com/stack-auth/stack-auth/tree/main/docs/examples/stack_auth_cli_template.py) and copy it into your project, for example:
 
 ```py
 └─ my-python-app


### PR DESCRIPTION
I've noticed that the `Download it here` link leads to a 404 not found because the `/tree/main` prefix is missing. This PR fixes this.