### PR TITLE
Fix Apple OAuth

### DIFF
--- a/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
@@ -66,7 +66,7 @@ const handler = createSmartRouteHandler({
     body: yupMixed().optional(),
   }),
   response: yupObject({
-    statusCode: yupNumber().oneOf([307]).defined(),
+    statusCode: yupNumber().oneOf([307, 303]).defined(),
     bodyType: yupString().oneOf(["json"]).defined(),
     body: yupMixed().defined(),
     headers: yupMixed().defined(),

--- a/apps/backend/src/app/api/latest/auth/oauth/oauth-helpers.tsx
+++ b/apps/backend/src/app/api/latest/auth/oauth/oauth-helpers.tsx
@@ -2,7 +2,7 @@ import { SmartResponse } from "@/route-handlers/smart-response";
 import { Response as OAuthResponse } from "@node-oauth/oauth2-server";
 import { StackAssertionError, StatusError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
 
-export function oauthResponseToSmartResponse(oauthResponse: OAuthResponse): SmartResponse {
+export function oauthResponseToSmartResponse(oauthResponse: OAuthResponse) {
   if (!oauthResponse.status) {
     throw new StackAssertionError(`OAuth response status is missing`, { oauthResponse });
   } else if (oauthResponse.status >= 500 && oauthResponse.status < 600) {
@@ -10,14 +10,12 @@ export function oauthResponseToSmartResponse(oauthResponse: OAuthResponse): Smar
   } else if (oauthResponse.status >= 200 && oauthResponse.status < 500) {
     return {
       statusCode: {
-        // our API never returns 301 or 302 by convention, so transform them to 307 or 308
-        301: 308,
-        302: 307,
+        302: 303,
       }[oauthResponse.status] ?? oauthResponse.status,
       bodyType: "json",
       body: oauthResponse.body,
       headers: Object.fromEntries(Object.entries(oauthResponse.headers || {}).map(([k, v]) => ([k, [v]]))),
-    };
+    } as const satisfies SmartResponse;
   } else {
     throw new StackAssertionError(`Invalid OAuth response status code: ${oauthResponse.status}`, { oauthResponse });
   }

--- a/apps/backend/src/middleware.tsx
+++ b/apps/backend/src/middleware.tsx
@@ -38,7 +38,8 @@ const corsAllowedRequestHeaders = [
   // Vercel
   'x-vercel-protection-bypass',
 
-  'ngrok-skip-browser-warning',
+    // ngrok
+    'ngrok-skip-browser-warning',
 ];
 
 const corsAllowedResponseHeaders = [

--- a/apps/backend/src/middleware.tsx
+++ b/apps/backend/src/middleware.tsx
@@ -38,8 +38,8 @@ const corsAllowedRequestHeaders = [
   // Vercel
   'x-vercel-protection-bypass',
 
-    // ngrok
-    'ngrok-skip-browser-warning',
+  // ngrok
+  'ngrok-skip-browser-warning',
 ];
 
 const corsAllowedResponseHeaders = [

--- a/apps/backend/src/middleware.tsx
+++ b/apps/backend/src/middleware.tsx
@@ -37,6 +37,8 @@ const corsAllowedRequestHeaders = [
 
   // Vercel
   'x-vercel-protection-bypass',
+
+  'ngrok-skip-browser-warning',
 ];
 
 const corsAllowedResponseHeaders = [

--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -706,7 +706,7 @@ export namespace Auth {
         },
       });
       expect(response).toMatchObject({
-        status: 307,
+        status: 303,
         headers: expect.any(Headers),
         body: {},
       });

--- a/packages/stack-shared/src/interface/clientInterface.ts
+++ b/packages/stack-shared/src/interface/clientInterface.ts
@@ -295,6 +295,7 @@ export class StackClientInterface {
         ...(adminTokenObj ? {
           "X-Stack-Admin-Access-Token": adminTokenObj.accessToken.token,
         } : {}),
+        'ngrok-skip-browser-warning': 'true',
         /**
          * Next.js until v15 would cache fetch requests by default, and forcefully disabling it was nearly impossible.
          *

--- a/packages/stack-shared/src/interface/clientInterface.ts
+++ b/packages/stack-shared/src/interface/clientInterface.ts
@@ -295,6 +295,7 @@ export class StackClientInterface {
         ...(adminTokenObj ? {
           "X-Stack-Admin-Access-Token": adminTokenObj.accessToken.token,
         } : {}),
+        // don't show a warning when proxying the API through ngrok (only relevant if the API url is an ngrok site)
         'ngrok-skip-browser-warning': 'true',
         /**
          * Next.js until v15 would cache fetch requests by default, and forcefully disabling it was nearly impossible.

--- a/packages/stack-shared/src/interface/clientInterface.ts
+++ b/packages/stack-shared/src/interface/clientInterface.ts
@@ -295,8 +295,6 @@ export class StackClientInterface {
         ...(adminTokenObj ? {
           "X-Stack-Admin-Access-Token": adminTokenObj.accessToken.token,
         } : {}),
-        // don't show a warning when proxying the API through ngrok (only relevant if the API url is an ngrok site)
-        'ngrok-skip-browser-warning': 'true',
         /**
          * Next.js until v15 would cache fetch requests by default, and forcefully disabling it was nearly impossible.
          *
@@ -306,6 +304,8 @@ export class StackClientInterface {
          * the case (I haven't actually tested.)
          */
         "X-Stack-Random-Nonce": generateSecureRandomString(),
+        // don't show a warning when proxying the API through ngrok (only relevant if the API url is an ngrok site)
+        'ngrok-skip-browser-warning': 'true',
         ...this.options.extraRequestHeaders,
         ...options.headers,
       },


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->


----

> [!IMPORTANT]
> Fix Apple OAuth by updating response status codes and adding ngrok compatibility.
> 
>   - **Behavior**:
>     - Update `statusCode` in `route.tsx` to accept 303 in addition to 307 for OAuth responses.
>     - Modify `oauthResponseToSmartResponse()` in `oauth-helpers.tsx` to map 302 to 303.
>     - Add `ngrok-skip-browser-warning` header in `middleware.tsx` and `clientInterface.ts` for ngrok compatibility.
>   - **Tests**:
>     - Update expected status to 303 in `backend-helpers.ts` for OAuth tests.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for ae3ec66e968b442b83edaca930dcb871668573b3. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>


<!-- ELLIPSIS_HIDDEN -->