### PR TITLE
Fix brand icons

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
@@ -9,7 +9,7 @@ import { useState } from "react";
 import { CardSubtitle } from "../../../../../../../../../packages/stack-ui/dist/components/ui/card";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
-import { ProviderSettingDialog, ProviderSettingSwitch, TurnOffProviderDialog } from "./providers";
+import { ProviderIcon, ProviderSettingDialog, ProviderSettingSwitch, TurnOffProviderDialog } from "./providers";
 
 type OAuthAccountMergeStrategy = 'link_method' | 'raise_error' | 'allow_duplicates';
 
@@ -272,12 +272,7 @@ export default function PageClient() {
             .filter((provider): provider is AdminOAuthProviderConfig => !!provider).map(provider => {
               return <div key={provider.id} className="flex h-10 items-center justify-between">
                 <div className="flex items-center gap-2">
-                  <div
-                    className="flex items-center justify-center w-12 h-12 rounded-md border border-gray-800"
-                    style={{ backgroundColor: provider.id in BrandIcons.BRAND_COLORS ? BrandIcons.BRAND_COLORS[provider.id] : undefined }}
-                  >
-                    <BrandIcons.Mapping iconSize={24} provider={provider.id} />
-                  </div>
+                  <ProviderIcon id={provider.id} />
                   <span className="text-sm font-semibold">{BrandIcons.toTitle(provider.id)}</span>
                   {provider.type === 'shared' && <SimpleTooltip tooltip={SHARED_TOOLTIP}>
                     <Badge variant="secondary">Shared keys</Badge>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -10,6 +10,17 @@ import clsx from "clsx";
 import { useState } from "react";
 import * as yup from "yup";
 
+export function ProviderIcon(props: { id: string }) {
+  return (
+    <div
+      className="flex items-center justify-center w-12 h-12 rounded-md border border-gray-800"
+      style={{ backgroundColor: props.id in BrandIcons.BRAND_COLORS ? BrandIcons.BRAND_COLORS[props.id] : undefined }}
+    >
+      <BrandIcons.Mapping iconSize={24} provider={props.id} />
+    </div>
+  );
+}
+
 type Props = {
   id: string,
   provider?: AdminProject['config']['oauthProviders'][number],
@@ -204,18 +215,17 @@ export function ProviderSettingSwitch(props: Props) {
 
   return (
     <>
-      <div className={clsx("flex flex-col items-center justify-center gap-2 py-2 border border-1 rounded-lg p-2 w-[120px] h-[120px] cursor-pointer transition-all",
-        enabled ? "border-white" : "border-gray-800 hover:border-gray-400"
-      )}
-      onClick={() => {
-        if (enabled) {
-          setTurnOffProviderDialogOpen(true);
-        } else {
-          setProviderSettingDialogOpen(true);
-        }
-      }}
+      <div
+        className={clsx("flex flex-col items-center justify-center gap-2 py-2 border border-1 rounded-lg p-2 w-[120px] h-[120px] cursor-pointer transition-all", enabled ? "border-white" : "border-gray-800 hover:border-gray-400")}
+        onClick={() => {
+          if (enabled) {
+            setTurnOffProviderDialogOpen(true);
+          } else {
+            setProviderSettingDialogOpen(true);
+          }
+        }}
       >
-        <BrandIcons.Mapping iconSize={28} provider={props.id} />
+        <ProviderIcon id={props.id} />
         <span className="text-sm">{toTitle(props.id)}</span>
         {isShared && enabled &&
           <SimpleTooltip tooltip={"Shared keys are automatically created by Stack, but show Stack's logo on the OAuth sign-in page.\n\nYou should replace these before you go into production."}>

--- a/packages/stack-ui/src/components/brand-icons.tsx
+++ b/packages/stack-ui/src/components/brand-icons.tsx
@@ -214,4 +214,5 @@ export const BRAND_COLORS: Record<string, string> = {
   discord: '#5661F5',
   linkedin: '#0A66C2',
   x: '#000000',
+  apple: '#000000',
 };


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Refactor provider icon handling by introducing `ProviderIcon` component and add Apple brand color.
> 
>   - **Components**:
>     - Introduce `ProviderIcon` component in `providers.tsx` to encapsulate icon rendering logic.
>     - Replace inline icon rendering with `ProviderIcon` in `page-client.tsx` and `ProviderSettingSwitch` in `providers.tsx`.
>   - **Brand Icons**:
>     - Add `apple` to `BRAND_COLORS` in `brand-icons.tsx`.
>   - **Misc**:
>     - Update imports in `page-client.tsx` to include `ProviderIcon`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 9a6dd99a97d760f4a27e65bcaa7526cf6f1b4072. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->