### PR TITLE
Fix session fetching when there are no active sessions

### DIFF
--- a/apps/backend/src/app/api/latest/auth/sessions/crud.tsx
+++ b/apps/backend/src/app/api/latest/auth/sessions/crud.tsx
@@ -45,7 +45,9 @@ export const sessionsCrudHandlers = createLazyProxy(() => createCrudHandlers(ses
         SELECT data->>'sessionId' as "sessionId", 
                MAX("eventStartedAt") as "lastActiveAt"
         FROM "Event" 
-        WHERE data->>'sessionId' = ANY(${Prisma.sql`ARRAY[${Prisma.join(refreshTokenObjs.map(s => s.id))}]`})
+        WHERE ${refreshTokenObjs.length > 0
+          ? Prisma.sql`data->>'sessionId' = ANY(${Prisma.sql`ARRAY[${Prisma.join(refreshTokenObjs.map(s => s.id))}]`})`
+          : Prisma.sql`FALSE`}
         AND "systemEventTypeIds" @> '{"$session-activity"}'
         GROUP BY data->>'sessionId'
       )


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Fixes session fetching in `crud.tsx` by handling empty `refreshTokenObjs` in SQL query.
> 
>   - **Behavior**:
>     - Fixes session fetching in `crud.tsx` when `refreshTokenObjs` is empty by modifying the SQL query to return `FALSE` instead of an invalid `ANY` clause.
>   - **SQL Query**:
>     - Adjusts the `WHERE` clause in the `SELECT` statement to handle empty `refreshTokenObjs` by using `Prisma.sql` to conditionally apply `ANY` or `FALSE`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 5fcfaaf9817f94bf55f5db58785917d93afa175a. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->