### PR TITLE
Added entityName prop for custom labels

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,6 +69,7 @@
     "@vitejs/plugin-react": "^4.3.3",
     "chokidar-cli": "^3.0.0",
     "concurrently": "^8.2.2",
+    "esbuild": "^0.24.0",
     "eslint": "8.30.0",
     "eslint-config-next": "^14.2.17",
     "eslint-plugin-import": "^2.31.0",
@@ -77,14 +78,14 @@
     "eslint-plugin-react": "^7.37.2",
     "jsdom": "^24.1.3",
     "only-allow": "^1.2.1",
+    "pluralize": "^8.0.0",
     "rimraf": "^5.0.10",
     "tsup": "^8.3.5",
     "turbo": "^2.2.3",
     "typescript": "5.3.3",
-    "vitest": "^1.6.0",
     "vite-tsconfig-paths": "^4.3.2",
-    "wait-on": "^8.0.1",
-    "esbuild": "^0.24.0"
+    "vitest": "^1.6.0",
+    "wait-on": "^8.0.1"
   },
   "pnpm": {
     "overrides": {

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -56,6 +56,7 @@
     "jose": "^5.2.2",
     "js-cookie": "^3.0.5",
     "lucide-react": "^0.378.0",
+    "pluralize": "^8.0.0",
     "oauth4webapi": "^2.10.3",
     "@oslojs/otp": "^1.1.0",
     "qrcode": "^1.5.4",

--- a/packages/template/src/components-page/account-settings.tsx
+++ b/packages/template/src/components-page/account-settings.tsx
@@ -40,7 +40,7 @@ export function AccountSettings(props: {
   const teams = user.useTeams();
   const stackApp = useStackApp();
   const project = stackApp.useProject();
-  const entityName = props.entityName ? props.entityName : "Team";
+  const entityName = props.entityName ?? "Team";
 
   return (
     <MaybeFullPage fullPage={!!props.fullPage}>

--- a/packages/template/src/components-page/account-settings.tsx
+++ b/packages/template/src/components-page/account-settings.tsx
@@ -15,6 +15,7 @@ import { ProfilePage } from "./account-settings/profile-page/profile-page";
 import { SettingsPage } from './account-settings/settings/settings-page';
 import { TeamCreationPage } from './account-settings/teams/team-creation-page';
 import { TeamPage } from './account-settings/teams/team-page';
+import { pluralize } from "pluralize";
 
 const Icon = ({ name }: { name: keyof typeof icons }) => {
   const LucideIcon = icons[name];
@@ -23,6 +24,7 @@ const Icon = ({ name }: { name: keyof typeof icons }) => {
 
 export function AccountSettings(props: {
   fullPage?: boolean,
+  entityName?: string
   extraItems?: ({
     title: string,
     content: React.ReactNode,
@@ -38,6 +40,7 @@ export function AccountSettings(props: {
   const teams = user.useTeams();
   const stackApp = useStackApp();
   const project = stackApp.useProject();
+  const entityName = props.entityName ? props.entityName : "Team";
 
   return (
     <MaybeFullPage fullPage={!!props.fullPage}>
@@ -101,7 +104,7 @@ export function AccountSettings(props: {
               content: item.content,
             } as const)) || []),
             ...(teams.length > 0 || project.config.clientTeamCreationEnabled) ? [{
-              title: t('Teams'),
+              title: t(`${pluralize(entityName)}`),
               type: 'divider',
             }] as const : [],
             ...teams.map(team => ({
@@ -110,16 +113,16 @@ export function AccountSettings(props: {
                 <Typography className="max-w-[320px] md:w-[90%] truncate">{team.displayName}</Typography>
               </div>,
               type: 'item',
-              id: `team-${team.id}`,
+              id: `${entityName.toLowerCase()}-${team.id}`,
               content: <Suspense fallback={<TeamPageSkeleton/>}>
                 <TeamPage team={team}/>
               </Suspense>,
             } as const)),
             ...project.config.clientTeamCreationEnabled ? [{
-              title: t('Create a team'),
+              title: t(`Create a ${entityName.toLowerCase()}`),
               icon: <Icon name="CirclePlus"/>,
               type: 'item',
-              id: 'team-creation',
+              id: `team-creation`,
               content: <Suspense fallback={<TeamCreationSkeleton/>}>
                 <TeamCreationPage />
               </Suspense>,

--- a/packages/template/src/components-page/team-creation.tsx
+++ b/packages/template/src/components-page/team-creation.tsx
@@ -12,11 +12,15 @@ import { FormWarningText } from "../components/elements/form-warning";
 import { MaybeFullPage } from "../components/elements/maybe-full-page";
 import { useTranslation } from "../lib/translations";
 
-export function TeamCreation(props: { fullPage?: boolean }) {
+export function TeamCreation(props: { 
+  fullPage?: boolean,
+  entityName?: string,
+ }) {
   const { t } = useTranslation();
+  const entityName = props.entityName ? props.entityName : "Team";
 
   const schema = yupObject({
-    displayName: yupString().defined().nonEmpty(t('Please enter a team name')),
+    displayName: yupString().defined().nonEmpty(t(`Please enter ${entityName.toLowerCase()} name`)),
   });
 
   const { register, handleSubmit, formState: { errors } } = useForm({
@@ -29,7 +33,7 @@ export function TeamCreation(props: { fullPage?: boolean }) {
   const navigate = app.useNavigate();
 
   if (!project.config.clientTeamCreationEnabled) {
-    return <MessageCard title={t('Team creation is not enabled')} />;
+    return <MessageCard title={t(`${entityName} creation is not enabled`)} />;
   }
 
   const onSubmit = async (data: yup.InferType<typeof schema>) => {
@@ -48,7 +52,7 @@ export function TeamCreation(props: { fullPage?: boolean }) {
       <div className='stack-scope flex flex-col items-stretch' style={{ maxWidth: '380px', flexBasis: '380px', padding: props.fullPage ? '1rem' : 0 }}>
         <div className="text-center mb-6">
           <Typography type='h2'>
-            {t('Create a Team')}
+            {t(`Create ${entityName}`)}
           </Typography>
         </div>
         <form

--- a/packages/template/src/components/selected-team-switcher.tsx
+++ b/packages/template/src/components/selected-team-switcher.tsx
@@ -18,11 +18,13 @@ import { Suspense, useEffect, useMemo } from "react";
 import { Team, useStackApp, useUser } from "..";
 import { useTranslation } from "../lib/translations";
 import { TeamIcon } from "./team-icon";
+import { pluralize } from 'pluralize';
 
 type SelectedTeamSwitcherProps = {
   urlMap?: (team: Team) => string,
   selectedTeam?: Team,
   noUpdateSelectedTeam?: boolean,
+  entityName?: string,
 };
 
 export function SelectedTeamSwitcher(props: SelectedTeamSwitcherProps) {
@@ -44,6 +46,7 @@ function Inner(props: SelectedTeamSwitcherProps) {
   const selectedTeam = user?.selectedTeam || props.selectedTeam;
   const rawTeams = user?.useTeams();
   const teams = useMemo(() => rawTeams?.sort((a, b) => b.id === selectedTeam?.id ? 1 : -1), [rawTeams, selectedTeam]);
+  const entityName = props.entityName ? props.entityName : "Team";
 
   useEffect(() => {
     if (!props.noUpdateSelectedTeam && props.selectedTeam) {
@@ -58,7 +61,7 @@ function Inner(props: SelectedTeamSwitcherProps) {
         runAsynchronouslyWithAlert(async () => {
           const team = teams?.find(team => team.id === value);
           if (!team) {
-            throw new Error('Team not found, this should not happen');
+            throw new Error(`${entityName} not found, this should not happen`);
           }
 
           if (!props.noUpdateSelectedTeam) {
@@ -71,14 +74,14 @@ function Inner(props: SelectedTeamSwitcherProps) {
       }}
     >
       <SelectTrigger className="stack-scope max-w-64">
-        <SelectValue placeholder="Select team"/>
+        <SelectValue placeholder={`Select ${entityName.toLowerCase()}`}/>
       </SelectTrigger>
       <SelectContent className="stack-scope">
         {user?.selectedTeam ? <SelectGroup>
           <SelectLabel>
             <div className="flex items-center justify-between">
               <span>
-                {t('Current team')}
+                {t(`Current ${entityName.toLowerCase()}`)}
               </span>
               <Button variant='ghost' size='icon' className="h-6 w-6" onClick={() => navigate(`${app.urls.accountSettings}#team-${user.selectedTeam?.id}`)}>
                 <Settings className="h-4 w-4"/>
@@ -95,7 +98,7 @@ function Inner(props: SelectedTeamSwitcherProps) {
 
         {teams?.length ?
           <SelectGroup>
-            <SelectLabel>{t('Other teams')}</SelectLabel>
+            <SelectLabel>{t(`Other ${pluralize(entityName.toLowerCase())}`)}</SelectLabel>
             {teams.filter(team => team.id !== user?.selectedTeam?.id)
               .map(team => (
                 <SelectItem value={team.id} key={team.id}>
@@ -107,7 +110,7 @@ function Inner(props: SelectedTeamSwitcherProps) {
               ))}
           </SelectGroup> :
           <SelectGroup>
-            <SelectLabel>{t('No teams yet')}</SelectLabel>
+            <SelectLabel>{t(`No ${pluralize(entityName.toLowerCase())} yet`)}</SelectLabel>
           </SelectGroup>}
 
         {project.config.clientTeamCreationEnabled && <>
@@ -118,7 +121,7 @@ function Inner(props: SelectedTeamSwitcherProps) {
               className="w-full"
               variant='ghost'
             >
-              <PlusCircle className="mr-2 h-4 w-4"/> {t('Create a team')}
+              <PlusCircle className="mr-2 h-4 w-4"/> {t(`Create ${entityName.toLowerCase()}`)}
             </Button>
           </div>
         </>}


### PR DESCRIPTION
This PR adds the entityName prop to the following components/pages as requested in  #655 issue.
- selected-team-settings
- account-settings
- team-creation

While this addresses part of the issue, it's not a complete solution. Fully supporting this feature would likely require a broader change to the use of "team" terminology across the codebase.

I'm happy to take on this larger refactor if the maintainers agree it's the right direction.
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `entityName` prop for customizable labels in `AccountSettings`, `TeamCreation`, and `SelectedTeamSwitcher`, using `pluralize` for plural forms.
> 
>   - **Behavior**:
>     - Adds `entityName` prop to `AccountSettings`, `TeamCreation`, and `SelectedTeamSwitcher` components for customizable labels.
>     - Defaults to "Team" if `entityName` is not provided.
>     - Uses `pluralize` for handling plural forms of `entityName`.
>   - **Dependencies**:
>     - Adds `pluralize` to `devDependencies` in `package.json` and `packages/template/package.json`.
>   - **Misc**:
>     - Updates various UI text elements to use `entityName` in `account-settings.tsx`, `team-creation.tsx`, and `selected-team-switcher.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 763fff6d43a0e8112f910c1d944cb11648a28635. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->