### PR TITLE
Updates STACK_EMAILABLE_API_KEY to have default value

### DIFF
--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -95,7 +95,7 @@ async function _sendEmailWithoutRetries(options: SendEmailOptions): Promise<Resu
     let toArray = typeof options.to === 'string' ? [options.to] : options.to;
 
     // use Emailable to check if the email is valid. skip the ones that are not (it's as if they had bounced)
-    const emailableApiKey = getEnvVariable('STACK_EMAILABLE_API_KEY');
+    const emailableApiKey = getEnvVariable('STACK_EMAILABLE_API_KEY', "");
     if (emailableApiKey) {
       await traceSpan('verifying email addresses with Emailable', async () => {
         toArray = (await Promise.all(toArray.map(async (to) => {


### PR DESCRIPTION
<!--

Fixes STACK_EMAILABLE_API_KEY to have a default value. This will prevent users who are self hosting from running into the issue of:

```json
Captured error in route-handler: StackAssertionError: Missing environment variable: STACK_EMAILABLE_API_KEY
```

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
