### PR TITLE
Add Recurse ML rules for naming and code patterns

### DIFF
--- a/.github/.recurseml.yaml
+++ b/.github/.recurseml.yaml
@@ -1,1 +1,2 @@
 report_status_checks: false
+rules: .github/recurseml-rules/

--- a/.github/recurseml-rules/code_patterns.mdc
+++ b/.github/recurseml-rules/code_patterns.mdc
@@ -1,0 +1,25 @@
+---
+description: Code Patterns and Best Practices
+globs: "**/*.{js,ts}"
+alwaysApply: true
+---
+
+The following conventions MUST be followed in new code.
+DON'T report code patterns outside of the examples explicitly listed bellow:
+
+- Never use `void asyncFunction()` or `asyncFunction().catch(console.error)` - use `runAsynchronously(asyncFunction)` instead
+- Use `parseJson`/`stringifyJson` from `stack-shared/utils/json` instead of `JSON.parse`/`JSON.stringify`
+- Instead of Vercel `waitUntil`, use `runAsynchronously(promise, { promiseCallback: waitUntil })`
+- Don't concatenate URLs as strings - avoid patterns like `/users/${userId}`
+- Replace non-null assertions with `?? throwErr("message", { extraData })` pattern
+- Properly handle async operations with try/catch blocks
+- Use helper functions for validation and environment variables
+
+# Solution
+
+Fix code pattern violations by:
+- Wrapping async calls with runAsynchronously
+- Importing parseJson/stringifyJson from stack-shared/utils/json
+- Using runAsynchronously with promiseCallback for waitUntil
+- Using proper URL construction utilities
+- Replacing ! assertions with ?? throwErr pattern

--- a/.github/recurseml-rules/code_patterns.mdc
+++ b/.github/recurseml-rules/code_patterns.mdc
@@ -5,7 +5,7 @@ alwaysApply: true
 ---
 
 The following conventions MUST be followed in new code.
-DON'T report code patterns outside of the examples explicitly listed bellow:
+DON'T report code patterns outside of the examples explicitly listed below:
 
 - Never use `void asyncFunction()` or `asyncFunction().catch(console.error)` - use `runAsynchronously(asyncFunction)` instead
 - Use `parseJson`/`stringifyJson` from `stack-shared/utils/json` instead of `JSON.parse`/`JSON.stringify`

--- a/.github/recurseml-rules/naming.mdc
+++ b/.github/recurseml-rules/naming.mdc
@@ -4,7 +4,7 @@ globs: "**/*.{js,ts}"
 alwaysApply: true
 ---
 
-Code changes MUST follow the naming guideleines below.
+Code changes MUST follow the naming guidelines below.
 DON'T report any other naming issues.
 
 - Use `snake_case` for anything that goes over HTTP in REST APIs, `camelCase` for JavaScript elsewhere

--- a/.github/recurseml-rules/naming.mdc
+++ b/.github/recurseml-rules/naming.mdc
@@ -1,0 +1,21 @@
+---
+description: Naming Conventions
+globs: "**/*.{js,ts}"
+alwaysApply: true
+---
+
+Code changes MUST follow the naming guideleines below.
+DON'T report any other naming issues.
+
+- Use `snake_case` for anything that goes over HTTP in REST APIs, `camelCase` for JavaScript elsewhere
+- `captureError`'s first argument should be a machine-readable ID without whitespaces (e.g., `'user-sign-up-email'` not `'Email failed to send'`)
+- When doing OAuth flows, specify the type (inner/outer/external) in variable names, comments, and error messages
+- Use descriptive names that clearly indicate purpose and context
+- Avoid abbreviations unless they are widely understood
+
+# Solution
+
+Fix naming inconsistencies by:
+- Converting API parameters to snake_case
+- Making captureError IDs machine-readable with hyphens
+- Adding OAuth type prefixes to variable names


### PR DESCRIPTION
This PR adds two custom Recurse ML [rules](https://github.com/sparckles/Robyn/pull/docs.recurse.ml/gh/configs/rules) to enforce naming and usage patterns

**.github/recurseml-rules/naming.mdc:**

- Use `snake_case` for anything that goes over HTTP in REST APIs, `camelCase` for JavaScript elsewhere
- `captureError`'s first argument should be a machine-readable ID without whitespaces (e.g., `'user-sign-up-email'` not `'Email failed to send'`)
- When doing OAuth flows, specify the type (inner/outer/external) in variable names, comments, and error messages

**.github/recurseml-rules/code_patterns.mdc:**

- Never use `void asyncFunction()` or `asyncFunction().catch(console.error)` - use `runAsynchronously(asyncFunction)` instead
- Use `parseJson`/`stringifyJson` from `stack-shared/utils/json` instead of `JSON.parse`/`JSON.stringify`
- Instead of Vercel `waitUntil`, use `runAsynchronously(promise, { promiseCallback: waitUntil })`
- Don't concatenate URLs as strings - avoid patterns like `/users/${userId}`
- Replace non-null assertions with `?? throwErr("message", { extraData })` pattern

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Add Recurse ML rules for naming conventions and code patterns in JavaScript/TypeScript.
> 
>   - **Recurse ML Configuration**:
>     - Adds `rules: .github/recurseml-rules/` to `.github/.recurseml.yaml`.
>   - **Naming Conventions** (`naming.mdc`):
>     - Use `snake_case` for REST API HTTP elements, `camelCase` for JavaScript.
>     - `captureError` IDs must be machine-readable without spaces.
>     - Specify OAuth flow types in variable names, comments, and error messages.
>   - **Code Patterns** (`code_patterns.mdc`):
>     - Use `runAsynchronously` instead of `void asyncFunction()` or `.catch(console.error)`.
>     - Use `parseJson`/`stringifyJson` from `stack-shared/utils/json`.
>     - Use `runAsynchronously` with `promiseCallback` for Vercel `waitUntil`.
>     - Avoid URL string concatenation; use utilities.
>     - Replace non-null assertions with `?? throwErr` pattern.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 9dd35abccec354d8ec30599af0b7bb2595976aab. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->