### PR TITLE
impr: run migration as part of provision endpoint and fix create user

### DIFF
--- a/apps/backend/src/prisma-client.tsx
+++ b/apps/backend/src/prisma-client.tsx
@@ -36,7 +36,7 @@ function getNeonPrismaClient(connectionString: string) {
   let neonPrismaClient = prismaClientsStore.neon.get(connectionString);
   if (!neonPrismaClient) {
     const schema = getSchemaFromConnectionString(connectionString);
-    const adapter = new PrismaNeon({ connectionString }, schema ? { schema } : undefined);
+    const adapter = new PrismaNeon({ connectionString }, { schema });
     neonPrismaClient = new PrismaClient({ adapter });
     prismaClientsStore.neon.set(connectionString, neonPrismaClient);
   }

--- a/apps/backend/src/prisma-client.tsx
+++ b/apps/backend/src/prisma-client.tsx
@@ -35,7 +35,8 @@ export const globalPrismaSchema = dbString === "" ? "public" : getSchemaFromConn
 function getNeonPrismaClient(connectionString: string) {
   let neonPrismaClient = prismaClientsStore.neon.get(connectionString);
   if (!neonPrismaClient) {
-    const adapter = new PrismaNeon({ connectionString });
+    const schema = getSchemaFromConnectionString(connectionString);
+    const adapter = new PrismaNeon({ connectionString }, schema ? { schema } : undefined);
     neonPrismaClient = new PrismaClient({ adapter });
     prismaClientsStore.neon.set(connectionString, neonPrismaClient);
   }
@@ -77,7 +78,8 @@ export async function getPrismaClientForSourceOfTruth(sourceOfTruth: Organizatio
       }
       const connectionString = sourceOfTruth.connectionStrings[branchId];
       const neonPrismaClient = getNeonPrismaClient(connectionString);
-      await runMigrationNeeded({ prismaClient: neonPrismaClient, schema: getSchemaFromConnectionString(connectionString) });
+      const schema = getSchemaFromConnectionString(connectionString);
+      await runMigrationNeeded({ prismaClient: neonPrismaClient, schema: schema });
       return neonPrismaClient;
     }
     case 'postgres': {


### PR DESCRIPTION


- [x] As part of the `/neon/projects/provision` endpoint run the migration to create required tables under specified schema. Runs migrations for all `connectionStrings` 
- [x] Fix `POST /users` endpoint to create new user in specified schema instead of `public` 

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Run migrations in `/neon/projects/provision` endpoint and fix user creation schema in `route.tsx` and `prisma-client.tsx`.
> 
>   - **Behavior**:
>     - `/neon/projects/provision` endpoint now runs migrations for all `connectionStrings` in `route.tsx`.
>     - `POST /users` endpoint creates users in specified schema instead of `public`.
>   - **Functions**:
>     - `getPrismaClientForSourceOfTruth` in `prisma-client.tsx` now runs migrations with the correct schema.
>     - `getNeonPrismaClient` in `prisma-client.tsx` sets schema from connection string.
>   - **Misc**:
>     - Refactored `sourceOfTruth` object creation in `route.tsx` for clarity.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for eda5deb6ed1c14073a950ceb1898dceaf671d2e4. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Neon integrations now automatically run database migrations per branch when branch connection details are provided, reducing manual steps.
  * Neon connection handling now detects and uses the schema from the connection string for migrations and connections, improving reliability with custom schemas.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->