### PR TITLE
Project config override size limit

### DIFF
--- a/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
@@ -8,7 +8,7 @@ import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
 import { stringCompare } from "@stackframe/stack-shared/dist/utils/strings";
 import { projectsCrudHandlers } from "../../../internal/projects/current/crud";
 
-const domainSchema = schemaFields.urlSchema.defined()
+const domainSchema = schemaFields.wildcardUrlSchema.max(300).defined()
   .matches(/^https?:\/\//, 'URL must start with http:// or https://')
   .meta({ openapiField: { description: 'URL. Must start with http:// or https://', exampleValue: 'https://example.com' } });
 

--- a/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
@@ -57,7 +57,7 @@ export const domainCrudHandlers = createLazyProxy(() => createCrudHandlers(domai
   }),
   onCreate: async ({ auth, data, params }) => {
     const oldDomains = auth.tenancy.config.domains.trustedDomains;
-    if (oldDomains.length > 1000) {
+    if (Object.keys(oldDomains).length > 1000) {
       throw new StatusError(400, "This project has more than 1000 trusted domains. This is not supported. Please delete some domains to add a new one, or use wildcard domains instead.");
     }
     await projectsCrudHandlers.adminUpdate({

--- a/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/custom/domains/crud.tsx
@@ -57,6 +57,9 @@ export const domainCrudHandlers = createLazyProxy(() => createCrudHandlers(domai
   }),
   onCreate: async ({ auth, data, params }) => {
     const oldDomains = auth.tenancy.config.domains.trustedDomains;
+    if (oldDomains.length > 1000) {
+      throw new StatusError(400, "This project has more than 1000 trusted domains. This is not supported. Please delete some domains to add a new one, or use wildcard domains instead.");
+    }
     await projectsCrudHandlers.adminUpdate({
       data: {
         config: {

--- a/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
@@ -56,7 +56,7 @@ export const domainCrudHandlers = createLazyProxy(() => createCrudHandlers(domai
   }),
   onCreate: async ({ auth, data, params }) => {
     const oldDomains = auth.tenancy.config.domains.trustedDomains;
-    if (oldDomains.length > 1000) {
+    if (Object.keys(oldDomains).length > 1000) {
       throw new StatusError(400, "This project has more than 1000 trusted domains. This is not supported. Please delete some domains to add a new one, or use wildcard domains instead.");
     }
     await projectsCrudHandlers.adminUpdate({

--- a/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
@@ -8,7 +8,7 @@ import { createLazyProxy } from "@stackframe/stack-shared/dist/utils/proxies";
 import { stringCompare } from "@stackframe/stack-shared/dist/utils/strings";
 import { projectsCrudHandlers } from "../../../internal/projects/current/crud";
 
-const domainSchema = schemaFields.urlSchema.defined()
+const domainSchema = schemaFields.wildcardUrlSchema.max(300).defined()
   .matches(/^https?:\/\//, 'URL must start with http:// or https://')
   .meta({ openapiField: { description: 'URL. Must start with http:// or https://', exampleValue: 'https://example.com' } });
 

--- a/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
+++ b/apps/backend/src/app/api/latest/integrations/neon/domains/crud.tsx
@@ -56,6 +56,9 @@ export const domainCrudHandlers = createLazyProxy(() => createCrudHandlers(domai
   }),
   onCreate: async ({ auth, data, params }) => {
     const oldDomains = auth.tenancy.config.domains.trustedDomains;
+    if (oldDomains.length > 1000) {
+      throw new StatusError(400, "This project has more than 1000 trusted domains. This is not supported. Please delete some domains to add a new one, or use wildcard domains instead.");
+    }
     await projectsCrudHandlers.adminUpdate({
       data: {
         config: {

--- a/apps/backend/src/lib/config.tsx
+++ b/apps/backend/src/lib/config.tsx
@@ -1,14 +1,13 @@
 import { Prisma } from "@prisma/client";
-import { Config, getInvalidConfigReason, normalize, override } from "@stackframe/stack-shared/dist/config/format";
-import { BranchConfigOverride, BranchConfigOverrideOverride, BranchIncompleteConfig, BranchRenderedConfig, CompleteConfig, EnvironmentConfigOverride, EnvironmentConfigOverrideOverride, EnvironmentIncompleteConfig, EnvironmentRenderedConfig, OrganizationConfigOverride, OrganizationConfigOverrideOverride, OrganizationIncompleteConfig, ProjectConfigOverride, ProjectConfigOverrideOverride, ProjectIncompleteConfig, ProjectRenderedConfig, applyBranchDefaults, applyEnvironmentDefaults, applyOrganizationDefaults, applyProjectDefaults, assertNoConfigOverrideErrors, branchConfigSchema, environmentConfigSchema, getConfigOverrideErrors, getIncompleteConfigWarnings, migrateConfigOverride, organizationConfigSchema, projectConfigSchema, sanitizeBranchConfig, sanitizeEnvironmentConfig, sanitizeOrganizationConfig, sanitizeProjectConfig } from "@stackframe/stack-shared/dist/config/schema";
+import { normalize, override } from "@stackframe/stack-shared/dist/config/format";
+import { BranchConfigOverride, BranchConfigOverrideOverride, BranchRenderedConfig, CompleteConfig, EnvironmentConfigOverride, EnvironmentConfigOverrideOverride, EnvironmentRenderedConfig, OrganizationConfigOverride, ProjectConfigOverride, ProjectConfigOverrideOverride, ProjectRenderedConfig, applyBranchDefaults, applyEnvironmentDefaults, applyOrganizationDefaults, applyProjectDefaults, assertNoConfigOverrideErrors, branchConfigSchema, environmentConfigSchema, migrateConfigOverride, organizationConfigSchema, projectConfigSchema, sanitizeBranchConfig, sanitizeEnvironmentConfig, sanitizeOrganizationConfig, sanitizeProjectConfig } from "@stackframe/stack-shared/dist/config/schema";
 import { ProjectsCrud } from "@stackframe/stack-shared/dist/interface/crud/projects";
-import { yupBoolean, yupMixed, yupObject, yupRecord, yupString, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
+import { yupMixed, yupObject } from "@stackframe/stack-shared/dist/schema-fields";
 import { isTruthy } from "@stackframe/stack-shared/dist/utils/booleans";
 import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
 import { filterUndefined, typedEntries } from "@stackframe/stack-shared/dist/utils/objects";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
 import { deindent, stringCompare } from "@stackframe/stack-shared/dist/utils/strings";
-import * as yup from "yup";
 import { RawQuery, globalPrismaClient, rawQuery } from "../prisma-client";
 import { listPermissionDefinitionsFromConfig } from "./permissions";
 import { DEFAULT_BRANCH_ID } from "./tenancies";
@@ -243,6 +242,16 @@ export async function overrideEnvironmentConfigOverride(options: {
     oldConfig,
     options.environmentConfigOverrideOverride,
   );
+
+  // large configs make our DB slow; let's prevent them early
+  const newConfigString = JSON.stringify(newConfig);
+  if (newConfigString.length > 1_000_000) {
+    captureError("override-environment-config-too-large", new StackAssertionError(`Environment config override for ${options.projectId}/${options.branchId} is ${(newConfigString.length/1_000_000).toFixed(1)}MB long!`));
+  }
+  if (newConfigString.length > 5_000_000) {
+    throw new StackAssertionError(`Environment config override for ${options.projectId}/${options.branchId} is too large.`);
+  }
+
   await assertNoConfigOverrideErrors(environmentConfigSchema, newConfig);
   await globalPrismaClient.environmentConfigOverride.upsert({
     where: {

--- a/packages/stack-shared/src/config/schema.ts
+++ b/packages/stack-shared/src/config/schema.ts
@@ -213,8 +213,8 @@ export const environmentConfigSchema = branchConfigSchema.concat(yupObject({
     trustedDomains: yupRecord(
       userSpecifiedIdSchema("trustedDomainId"),
       yupObject({
-        baseUrl: schemaFields.wildcardUrlSchema,
-        handlerPath: schemaFields.handlerPathSchema,
+        baseUrl: schemaFields.wildcardUrlSchema.max(300),
+        handlerPath: schemaFields.handlerPathSchema.max(300),
       }),
     ),
   })),


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Enforce size limits on project/environment config overrides and trusted domains to prevent performance issues.
> 
>   - **Behavior**:
>     - Enforce a limit of 1000 trusted domains in `onCreate` in `custom/domains/crud.tsx` and `neon/domains/crud.tsx`.
>     - Limit `baseUrl` and `handlerPath` to 300 characters in `environmentConfigSchema` in `schema.ts`.
>     - Add size checks for project and environment config overrides in `overrideProjectConfigOverride` and `overrideEnvironmentConfigOverride` in `config.tsx`.
>   - **Schema**:
>     - Change `urlSchema` to `wildcardUrlSchema` with a max length of 300 in `custom/domains/crud.tsx` and `neon/domains/crud.tsx`.
>   - **Misc**:
>     - Remove unused imports in `config.tsx`.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for b5840ff0fdf04a0f483b454706c9afbf7150e5db. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Support wildcard trusted domains, with validation for http(s) and a 300-character maximum.
  * Enforce 300-character maximums for domain URLs and handler paths in configuration.
* **Bug Fixes**
  * Prevent adding more than 1,000 trusted domains, returning a clear error with guidance.
* **Chores**
  * Add safeguards against oversized configuration overrides: soft capture above ~1MB and hard failure above ~5MB, with clear error messages to improve reliability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->