### PR TITLE
Improve purchase page ui for mobile

### DIFF
--- a/apps/dashboard/src/components/payments/checkout.tsx
+++ b/apps/dashboard/src/components/payments/checkout.tsx
@@ -61,13 +61,13 @@ export function CheckoutForm({ setupSubscription, stripeAccountId, fullCode }: P
   };
 
   return (
-    <div className="flex flex-col gap-6 max-w-md w-full p-6 rounded-md bg-background">
+    <div className="flex flex-col gap-6 max-w-md w-full p-4 md:p-6 rounded-lg bg-background border border-primary/10 shadow-sm">
       <PaymentElement options={paymentElementOptions} />
       <Button
         disabled={!stripe || !elements}
         onClick={handleSubmit}
       >
-        Submit
+        Pay now
       </Button>
       {message && <div className="text-destructive">{message}</div>}
     </div>


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
This PR refactors the `purchase/[code]` page to be mobile-first and visually enhanced.

**Why:**
To improve the user experience on the purchase page by making it responsive across devices and giving it a more polished look.

**What:**
- Implemented a responsive layout for `purchase/[code]`, stacking content on mobile and using a two-column layout on desktop with a sticky left panel.
- Enhanced the styling of price selection cards and the checkout form container for a cleaner, more modern appearance.
- Added a mobile-specific "Continue to payment" button that smooth-scrolls to the checkout section, improving navigation on smaller screens.
- Updated the checkout button text to "Pay now" for clarity.

---
<a href="https://cursor.com/background-agent?bcId=bc-19afa3f1-cf94-41a2-b1cc-6786b5885ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-19afa3f1-cf94-41a2-b1cc-6786b5885ab4">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

