### PR TITLE
Improve user table loading with skeletons

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/users/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/users/page-client.tsx
@@ -7,11 +7,22 @@ import { UserDialog } from "@/components/user-dialog";
 import { Alert, Button } from "@stackframe/stack-ui";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
+import React, { Suspense } from "react";
+
+function FirstUserNotice() {
+  const stackAdminApp = useAdminApp();
+  const firstUser = stackAdminApp.useUsers({ limit: 1 });
+  if (firstUser.length > 0) return null;
+  return (
+    <Alert variant='success'>
+      Congratulations on starting your project! Check the <StyledLink href="https://docs.stack-auth.com">documentation</StyledLink> to add your first users.
+    </Alert>
+  );
+}
 
 export default function PageClient() {
   const stackAdminApp = useAdminApp();
   const data = (stackAdminApp as any)[stackAppInternalsSymbol].useMetrics();
-  const firstUser = stackAdminApp.useUsers({ limit: 1 });
 
   return (
     <PageLayout
@@ -22,11 +33,9 @@ export default function PageClient() {
         trigger={<Button>Create User</Button>}
       />}
     >
-      {firstUser.length > 0 ? null : (
-        <Alert variant='success'>
-          Congratulations on starting your project! Check the <StyledLink href="https://docs.stack-auth.com">documentation</StyledLink> to add your first users.
-        </Alert>
-      )}
+      <Suspense fallback={null}>
+        <FirstUserNotice />
+      </Suspense>
 
       <UserTable />
     </PageLayout>


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
**Feat: Implement skeleton loading for User Table**

This PR improves the user experience of the dashboard's user table by:

*   **Displaying skeletons on initial load:** The table now renders immediately with skeleton rows while user data is being fetched.
*   **Showing skeletons during search/filter updates:** When a user types in the search bar or applies filters, the table remains visible and displays skeletons until new data is loaded.

This was achieved by:
*   Adding `isLoading` state and skeleton rendering logic to the shared `DataTableManualPagination` and `TableView` components.
*   Refactoring `UserTable` to manage its own data fetching and pass a `refreshKey` to the data table, ensuring loading states are correctly triggered.
*   Wrapping the "first user" notice in `Suspense` to prevent it from blocking the table's initial render.

---
<a href="https://cursor.com/background-agent?bcId=bc-768edd5f-2250-4e2a-b803-cab7af488a3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-768edd5f-2250-4e2a-b803-cab7af488a3e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

