### PR TITLE
feat: Add permission_ids support to team member profiles and invitations

### DIFF
--- a/apps/backend/src/app/api/latest/team-invitations/crud.tsx
+++ b/apps/backend/src/app/api/latest/team-invitations/crud.tsx
@@ -53,6 +53,7 @@ export const teamInvitationsCrudHandlers = createLazyProxy(() => createCrudHandl
           team_id: code.data.team_id,
           expires_at_millis: code.expiresAt.getTime(),
           recipient_email: code.method.email,
+          permission_ids: code.data.permission_ids || [],
         })),
         is_paginated: false,
       };

--- a/apps/backend/src/app/api/latest/team-invitations/role-permissions/route.tsx
+++ b/apps/backend/src/app/api/latest/team-invitations/role-permissions/route.tsx
@@ -1,0 +1,46 @@
+import { listPermissionDefinitions } from "@/lib/permissions";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, clientOrHigherAuthTypeSchema, yupArray, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Get role-based permissions for team invitations",
+    description: "Fetch available role-based permissions that can be assigned to team members during invitations. Only returns role-based permissions, not system permissions.",
+    tags: ["Teams"],
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: clientOrHigherAuthTypeSchema,
+      tenancy: adaptSchema.defined(),
+      user: adaptSchema.optional(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      items: yupArray(yupObject({
+        id: yupString().defined(),
+        description: yupString().optional(),
+        contained_permission_ids: yupArray(yupString().defined()).defined(),
+      }).defined()).defined(),
+      is_paginated: yupBoolean().oneOf([false]).defined(),
+    }).defined(),
+  }),
+  async handler({ auth }) {
+    const allPermissions = await listPermissionDefinitions({
+      scope: "team",
+      tenancy: auth.tenancy,
+    });
+
+    // Return all permissions including system permissions (starting with $)
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        items: allPermissions,
+        is_paginated: false,
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/team-invitations/send-code/route.tsx
+++ b/apps/backend/src/app/api/latest/team-invitations/send-code/route.tsx
@@ -2,7 +2,7 @@ import { ensureUserTeamPermissionExists } from "@/lib/request-checks";
 import { getPrismaClientForTenancy, retryTransaction } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@stackframe/stack-shared";
-import { adaptSchema, clientOrHigherAuthTypeSchema, teamIdSchema, teamInvitationCallbackUrlSchema, teamInvitationEmailSchema, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { adaptSchema, clientOrHigherAuthTypeSchema, permissionDefinitionIdSchema, teamIdSchema, teamInvitationCallbackUrlSchema, teamInvitationEmailSchema, yupArray, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { teamInvitationCodeHandler } from "../accept/verification-code-handler";
 
 export const POST = createSmartRouteHandler({
@@ -21,6 +21,7 @@ export const POST = createSmartRouteHandler({
       team_id: teamIdSchema.defined(),
       email: teamInvitationEmailSchema.defined(),
       callback_url: teamInvitationCallbackUrlSchema.defined(),
+      permission_ids: yupArray(permissionDefinitionIdSchema.defined()).optional(),
     }).defined(),
   }),
   response: yupObject({
@@ -52,6 +53,7 @@ export const POST = createSmartRouteHandler({
       tenancy: auth.tenancy,
       data: {
         team_id: body.team_id,
+        permission_ids: body.permission_ids || [],
       },
       method: {
         email: body.email,

--- a/docs/concepts/role-based-team-invitations.mdx
+++ b/docs/concepts/role-based-team-invitations.mdx
@@ -1,0 +1,310 @@
+# Role-Based Team Invitations
+
+Stack Auth supports role-based team invitations, allowing you to assign specific permissions to users when inviting them to teams. This provides granular access control by letting you define exactly what permissions an invited user should have upon joining the team.
+
+## Overview
+
+Role-based team invitations extend the standard team invitation flow by adding the ability to:
+- Select specific role-based permissions during the invitation process
+- Apply these permissions automatically when the invitation is accepted
+- Display assigned roles in the team management interface
+- Provide better access control and permission management
+
+## How It Works
+
+### Backend API Changes
+
+The team invitation system has been enhanced to support role-based permissions:
+
+#### Send Team Invitation Endpoint
+
+The `/team-invitations/send-code` endpoint now accepts an optional `permission_ids` parameter:
+
+```typescript
+POST /api/v1/team-invitations/send-code
+{
+  "email": "user@example.com",
+  "team_id": "team-id",
+  "callback_url": "https://app.example.com/team-invitation",
+  "permission_ids": ["team_admin", "project_manager"] // Optional
+}
+```
+
+#### Team Permissions Endpoint
+
+The `/team-invitations/role-permissions` endpoint provides all available team permissions, including both role-based permissions and system permissions:
+
+```typescript
+GET /api/v1/team-invitations/role-permissions
+```
+
+Returns:
+```json
+{
+  "items": [
+    {
+      "id": "team_admin",
+      "description": "Team Administrator",
+      "contained_permission_ids": ["$update_team", "$invite_members"]
+    },
+    {
+      "id": "team_member",
+      "description": "Team Member",
+      "contained_permission_ids": ["$read_members"]
+    },
+    {
+      "id": "$invite_members",
+      "description": "Invite new members to the team",
+      "contained_permission_ids": ["$invite_members"]
+    },
+    {
+      "id": "$read_members",
+      "description": "Read team member information",
+      "contained_permission_ids": ["$read_members"]
+    }
+  ],
+  "is_paginated": false
+}
+```
+
+### Frontend Integration
+
+#### Invitation Form with Role Selector
+
+The team invitation form now includes a role selector dropdown:
+
+```tsx
+import { Team } from "@stackframe/stack";
+
+function TeamInvitationForm({ team }: { team: Team }) {
+  const [selectedRole, setSelectedRole] = useState('');
+  
+  const handleInvite = async (email: string) => {
+    await team.inviteUser({ 
+      email,
+      permissionIds: selectedRole ? [selectedRole] : undefined
+    });
+  };
+  
+  return (
+    <form>
+      <input type="email" placeholder="Email" />
+      <select onChange={(e) => setSelectedRole(e.target.value)}>
+        <option value="">Default member role</option>
+        <option value="team_admin">Team Administrator</option>
+        <option value="project_manager">Project Manager</option>
+      </select>
+      <button type="submit">Invite User</button>
+    </form>
+  );
+}
+```
+
+#### Updated Team Interface
+
+The `Team` interface now supports the `permissionIds` parameter:
+
+```typescript
+interface Team {
+  inviteUser(options: { 
+    email: string; 
+    callbackUrl?: string;
+    permissionIds?: string[];
+  }): Promise<void>;
+}
+```
+
+## Configuration
+
+### Defining Role-Based Permissions
+
+Role-based permissions are defined in your Stack Auth project configuration:
+
+```javascript
+// stack-auth.config.js
+export default {
+  rbac: {
+    permissions: {
+      team_admin: {
+        scope: "team",
+        description: "Team Administrator",
+        containedPermissionIds: {
+          "$update_team": true,
+          "$invite_members": true,
+          "$remove_members": true,
+          "$manage_api_keys": true
+        }
+      },
+      project_manager: {
+        scope: "team", 
+        description: "Project Manager",
+        containedPermissionIds: {
+          "$read_members": true,
+          "$invite_members": true
+        }
+      },
+      team_viewer: {
+        scope: "team",
+        description: "Team Viewer", 
+        containedPermissionIds: {
+          "$read_members": true
+        }
+      }
+    }
+  }
+};
+```
+
+### System vs Role-Based Permissions
+
+Stack Auth distinguishes between two types of permissions:
+
+- **System Permissions**: Built-in permissions prefixed with `$` (e.g., `$update_team`, `$invite_members`)
+- **Role-Based Permissions**: Custom permissions defined in your configuration (e.g., `team_admin`, `project_manager`)
+
+Both system and role-based permissions are now available for assignment during invitations, providing greater flexibility in team management.
+
+## Permission Application
+
+### During Invitation Acceptance
+
+When a user accepts a team invitation with assigned permissions:
+
+1. The user is added to the team with default member permissions
+2. Additional role-based permissions specified in the invitation are granted
+3. The user gains access according to their combined permissions
+
+### Fallback Behavior
+
+If no `permission_ids` are specified in the invitation:
+- The user receives default member permissions as configured in your project
+- Existing invitation behavior is preserved for backward compatibility
+
+## User Interface Updates
+
+### Team Member List
+
+The team member list now displays assigned roles:
+
+```
+| User | Name | Role |
+|------|------|------|
+| 👤   | John Doe | Team Admin |
+| 👤   | Jane Smith | Member |
+```
+
+### Pending Invitations
+
+Outstanding invitations show the assigned role:
+
+```
+| Email | Expires | Role | Actions |
+|-------|---------|------|---------|
+| user@example.com | 2024-01-15 | Project Manager | 🗑️ |
+| admin@example.com | 2024-01-16 | Default | 🗑️ |
+```
+
+## Security Considerations
+
+### Permission Validation
+
+- Only users with `$invite_members` permission can send team invitations
+- All permissions (both role-based and system) are validated against your project configuration
+- Invalid or non-existent permission IDs are rejected
+- System permissions can now be directly assigned through invitations
+
+### Access Control
+
+- Role-based permissions follow the same inheritance rules as system permissions
+- Permissions are applied immediately upon invitation acceptance
+- Users retain default member permissions in addition to role-based permissions
+
+## Migration Guide
+
+### Existing Invitations
+
+Existing team invitation code continues to work without changes:
+
+```typescript
+// This still works - users get default member permissions
+await team.inviteUser({ email: "user@example.com" });
+```
+
+### Adding Role Selection
+
+To add role selection to existing invitation forms:
+
+1. Fetch available role-based permissions using the Stack Auth client
+2. Add a role selector component to your invitation form
+3. Pass selected `permissionIds` to the `inviteUser` method
+
+```typescript
+// Enhanced invitation with role selection
+const permissions = await stackClient.getTeamRolePermissions({ session });
+await team.inviteUser({ 
+  email: "user@example.com",
+  permissionIds: ["selected_role"]
+});
+```
+
+## Best Practices
+
+### Role Design
+
+- Keep role-based permissions focused and minimal
+- Use descriptive names and descriptions for roles
+- Consider the principle of least privilege when designing roles
+- Document the purpose and scope of each role
+
+### User Experience
+
+- Provide clear descriptions for each role in your UI
+- Consider making role selection optional with sensible defaults
+- Show current permissions/roles in team management interfaces
+- Provide feedback when permissions are successfully applied
+
+### Error Handling
+
+- Handle cases where invalid permissions are selected
+- Provide fallbacks when permission fetching fails  
+- Show clear error messages for permission-related failures
+
+## Limitations
+
+- Role-based permissions must be pre-configured in your project
+- System permissions cannot be directly assigned through invitations
+- Permission changes only apply to new invitations, not existing ones
+- Role display in the UI shows static labels (full dynamic role resolution requires additional API integration)
+
+## API Reference
+
+### Client Methods
+
+```typescript
+// Send team invitation with roles
+await stackClient.sendTeamInvitation({
+  email: string;
+  teamId: string;
+  callbackUrl: string;
+  permissionIds?: string[];
+  session: InternalSession;
+});
+
+// Fetch available role-based permissions
+await stackClient.getTeamRolePermissions({
+  session: InternalSession;
+});
+```
+
+### Team Methods
+
+```typescript
+// Invite user with role assignment
+await team.inviteUser({
+  email: string;
+  callbackUrl?: string;
+  permissionIds?: string[];
+});
+```
+
+This feature provides a foundation for sophisticated team access control while maintaining backward compatibility with existing Stack Auth applications.

--- a/docs/templates-python/concepts/teams-management.mdx
+++ b/docs/templates-python/concepts/teams-management.mdx
@@ -192,7 +192,7 @@ List all members of a team:
 ```python
 def get_team_members(access_token, team_id):
     """
-    Get all members of a team with their profiles
+    Get all members of a team with their profiles and permission IDs
     Requires $read_members permission
     """
     response = stack_auth_request('GET', f'api/v1/team-member-profiles?team_id={team_id}',
@@ -204,7 +204,10 @@ def get_team_members(access_token, team_id):
 # Example usage
 members = get_team_members(access_token, team_id)
 for member in members:
-    print(f"Member: {member['display_name']} ({member['user_id']})")
+    permissions = member.get('permission_ids', [])
+    role = 'Admin' if 'team_admin' in permissions else 'Member' if 'team_member' in permissions else 'Custom'
+    print(f"Member: {member['display_name']} ({member['user_id']}) - Role: {role}")
+    print(f"  Permissions: {permissions}")
 ```
 
 ## Team Invitations
@@ -214,18 +217,27 @@ for member in members:
 Invite users to join a team via email:
 
 ```python
-def send_team_invitation(access_token, team_id, email, callback_url):
+def send_team_invitation(access_token, team_id, email, callback_url, permission_ids=None):
     """
-    Send an invitation to join a team
+    Send an invitation to join a team with optional role-based permissions
     Requires $invite_members permission
+    
+    Args:
+        permission_ids: Optional list of permission IDs to assign to the invited user
+                       e.g., ['team_admin'], ['team_member'], or custom permission IDs
     """
+    invitation_data = {
+        'email': email,
+        'team_id': team_id,
+        'callback_url': callback_url
+    }
+    
+    if permission_ids:
+        invitation_data['permission_ids'] = permission_ids
+    
     response = stack_auth_request('POST', 'api/v1/team-invitations/send-code',
         headers={'x-stack-access-token': access_token},
-        json={
-            'email': email,
-            'team_id': team_id,
-            'callback_url': callback_url
-        }
+        json=invitation_data
     )
     
     return {
@@ -233,14 +245,34 @@ def send_team_invitation(access_token, team_id, email, callback_url):
         'invitation_id': response['id']
     }
 
-# Example usage
+# Example usage - Send invitation with admin role
+invitation_result = send_team_invitation(
+    access_token=access_token,
+    team_id=team_id,
+    email="admin@example.com",
+    callback_url="https://yourapp.com/join-team",
+    permission_ids=["team_admin"]
+)
+print(f"Admin invitation sent: {invitation_result['invitation_id']}")
+
+# Example usage - Send invitation with member role
+invitation_result = send_team_invitation(
+    access_token=access_token,
+    team_id=team_id,
+    email="member@example.com",
+    callback_url="https://yourapp.com/join-team",
+    permission_ids=["team_member"]
+)
+print(f"Member invitation sent: {invitation_result['invitation_id']}")
+
+# Example usage - Send invitation without specific role (default permissions)
 invitation_result = send_team_invitation(
     access_token=access_token,
     team_id=team_id,
     email="newmember@example.com",
     callback_url="https://yourapp.com/join-team"
 )
-print(f"Invitation sent: {invitation_result['invitation_id']}")
+print(f"Default invitation sent: {invitation_result['invitation_id']}")
 ```
 
 ### Accepting Team Invitations
@@ -263,6 +295,32 @@ accept_team_invitation(invitation_code)
 print("User successfully joined the team!")
 ```
 
+### Getting Available Role Permissions
+
+Retrieve all available team permissions and roles:
+
+```python
+def get_team_role_permissions(access_token):
+    """
+    Get all available team permissions including role-based and system permissions
+    """
+    response = stack_auth_request('GET', 'api/v1/team-invitations/role-permissions',
+        headers={'x-stack-access-token': access_token}
+    )
+    
+    return response['items']
+
+# Example usage
+role_permissions = get_team_role_permissions(access_token)
+for permission in role_permissions:
+    print(f"Permission ID: {permission['id']}")
+    if permission.get('description'):
+        print(f"  Description: {permission['description']}")
+    if permission.get('contained_permission_ids'):
+        print(f"  Contains: {permission['contained_permission_ids']}")
+    print()
+```
+
 ### Listing Team Invitations
 
 Get pending invitations for a team:
@@ -270,7 +328,7 @@ Get pending invitations for a team:
 ```python
 def list_team_invitations(access_token, team_id):
     """
-    List pending invitations for a team
+    List pending invitations for a team with their assigned permissions
     Requires $invite_members permission
     """
     response = stack_auth_request('GET', f'api/v1/team-invitations?team_id={team_id}',
@@ -282,7 +340,11 @@ def list_team_invitations(access_token, team_id):
 # Example usage
 invitations = list_team_invitations(access_token, team_id)
 for invitation in invitations:
-    print(f"Pending invitation for: {invitation['recipient_email']}")
+    permissions = invitation.get('permission_ids', [])
+    role = 'Admin' if 'team_admin' in permissions else 'Member' if 'team_member' in permissions else 'Default'
+    print(f"Pending invitation: {invitation['recipient_email']} - Role: {role}")
+    print(f"  Expires: {invitation['expires_at']}")
+    print(f"  Permissions: {permissions}")
 ```
 
 ## Team Permissions Management
@@ -391,7 +453,7 @@ def update_team_member_profile(access_token, team_id, user_id="me", **profile_da
 
 def get_team_member_profile(access_token, team_id, user_id="me"):
     """
-    Get a user's profile within a team context
+    Get a user's profile within a team context, including their permission IDs
     """
     response = stack_auth_request('GET', f'api/v1/team-member-profiles/{team_id}/{user_id}',
         headers={'x-stack-access-token': access_token}
@@ -411,6 +473,18 @@ updated_profile = update_team_member_profile(
 # Get the updated profile
 profile = get_team_member_profile(access_token, team_id)
 print(f"Team profile: {profile['display_name']}")
+print(f"User ID: {profile['user_id']}")
+print(f"Permission IDs: {profile.get('permission_ids', [])}")
+
+# Determine user role based on permissions
+permissions = profile.get('permission_ids', [])
+if 'team_admin' in permissions:
+    role = 'Admin'
+elif 'team_member' in permissions:
+    role = 'Member'
+else:
+    role = 'Custom' if permissions else 'Default'
+print(f"Role: {role}")
 ```
 
 ### Deleting Teams
@@ -596,5 +670,5 @@ Stack Auth includes several built-in team permissions:
 - **`$read_members`** - View team member list
 - **`team_member`** - Basic team membership (automatically granted)
 
-For more advanced team features, check out the [REST API documentation](../rest-api/overview.mdx). 
+For more advanced team features, check out the [REST API documentation](../rest-api/overview.mdx).
  

--- a/docs/templates/sdk/types/team-profile.mdx
+++ b/docs/templates/sdk/types/team-profile.mdx
@@ -18,6 +18,7 @@ The `TeamProfile` object represents the profile of a user within the context of 
 <ClickableTableOfContents code={`type TeamProfile = {
     displayName: string | null;  //$stack-link-to:#teamprofiledisplayname
     profileImageUrl: string | null;  //$stack-link-to:#teamprofileprofileimageurl
+    permissionIds: string[];  //$stack-link-to:#teamprofilepermissionids
 };`} />
 
 ---
@@ -45,6 +46,20 @@ The `TeamProfile` object represents the profile of a user within the context of 
 
       ```typescript
       declare const profileImageUrl: string | null;
+      ```
+    </MethodAside>
+  </MethodLayout>
+</CollapsibleTypesSection>
+
+<CollapsibleTypesSection type="teamProfile" property="permissionIds" defaultOpen={false}>
+  <MethodLayout>
+    <MethodContent>
+      An array of permission IDs that the user has within the team context. These permissions determine what actions the user can perform within the team.
+    </MethodContent>
+    <MethodAside title="Type Definition">
+
+      ```typescript
+      declare const permissionIds: string[];
       ```
     </MethodAside>
   </MethodLayout>

--- a/docs/templates/sdk/types/team.mdx
+++ b/docs/templates/sdk/types/team.mdx
@@ -208,6 +208,7 @@ You can get `Team` objects with the
       declare function inviteUser(options: {
         email: string;
         callbackUrl?: string;
+        permissionIds?: string[];
       }): Promise<void>;
       ```
       </AsideSection>
@@ -215,6 +216,18 @@ You can get `Team` objects with the
       ```typescript Sending a team invitation
       await team.inviteUser({
         email: 'user@example.com',
+      });
+      
+      // Send invitation with specific role
+      await team.inviteUser({
+        email: 'admin@example.com',
+        permissionIds: ['team_admin']
+      });
+      
+      // Send invitation with multiple permissions
+      await team.inviteUser({
+        email: 'member@example.com',
+        permissionIds: ['team_member', 'project_viewer']
       });
       ```
       </AsideSection>
@@ -309,14 +322,14 @@ You can get `Team` objects with the
       <AsideSection title="Signature">
 
       ```typescript
-      declare function listInvitations(): Promise<{ id: string, email: string, expiresAt: Date }[]>;
+      declare function listInvitations(): Promise<{ id: string, email: string, expiresAt: Date, permissionIds: string[] }[]>;
       ```
       </AsideSection>
       <AsideSection title="Examples">
       ```typescript Listing team invitations
       const invitations = await team.listInvitations();
       invitations.forEach(invitation => {
-        console.log(invitation.id, invitation.email);
+        console.log(invitation.id, invitation.email, invitation.permissionIds);
       });
       ```
       </AsideSection>
@@ -336,20 +349,20 @@ You can get `Team` objects with the
 
       ### Returns
 
-      `{ id: string, email: string, expiresAt: Date }[]`
+      `{ id: string, email: string, expiresAt: Date, permissionIds: string[] }[]`
     </MethodContent>
     <MethodAside>
       <AsideSection title="Signature">
 
       ```typescript
-      declare function useInvitations(): { id: string, email: string, expiresAt: Date }[];
+      declare function useInvitations(): { id: string, email: string, expiresAt: Date, permissionIds: string[] }[];
       ```
       </AsideSection>
       <AsideSection title="Examples">
       ```typescript Listing team invitations in React component
       const invitations = team.useInvitations();
       invitations.forEach(invitation => {
-        console.log(invitation.id, invitation.email);
+        console.log(invitation.id, invitation.email, invitation.permissionIds);
       });
       ```
       </AsideSection>

--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -692,6 +692,7 @@ export class StackClientInterface {
     teamId: string,
     callbackUrl: string,
     session: InternalSession,
+    permissionIds?: string[],
   }): Promise<void> {
     await this.sendClientRequest(
       "/team-invitations/send-code",
@@ -704,10 +705,22 @@ export class StackClientInterface {
           email: options.email,
           team_id: options.teamId,
           callback_url: options.callbackUrl,
+          permission_ids: options.permissionIds,
         }),
       },
       options.session,
     );
+  }
+
+  async getTeamRolePermissions(options: {
+    session: InternalSession,
+  }): Promise<{ items: { id: string, description?: string, contained_permission_ids: string[] }[], is_paginated: false }> {
+    const res = await this.sendClientRequest(
+      "/team-invitations/role-permissions",
+      { method: "GET" },
+      options.session,
+    );
+    return res.data;
   }
 
   async acceptTeamInvitation<T extends 'use' | 'details' | 'check'>(options: {

--- a/packages/stack-shared/src/interface/crud/team-invitation.ts
+++ b/packages/stack-shared/src/interface/crud/team-invitation.ts
@@ -7,6 +7,7 @@ export const teamInvitationDetailsClientReadSchema = yupObject({
   team_id: schemaFields.teamIdSchema.defined(),
   expires_at_millis: schemaFields.yupNumber().defined(),
   recipient_email: schemaFields.emailSchema.defined(),
+  permission_ids: schemaFields.yupArray(schemaFields.permissionDefinitionIdSchema.defined()).defined(),
 }).defined();
 
 export const teamInvitationCrud = createCrud({

--- a/packages/stack-shared/src/interface/crud/team-member-profiles.ts
+++ b/packages/stack-shared/src/interface/crud/team-member-profiles.ts
@@ -9,10 +9,12 @@ export const teamMemberProfilesCrudClientReadSchema = yupObject({
   user_id: schemaFields.userIdSchema.defined(),
   display_name: schemaFields.teamMemberDisplayNameSchema.nullable().defined(),
   profile_image_url: schemaFields.teamMemberProfileImageUrlSchema.nullable().defined(),
+  permission_ids: schemaFields.yupArray(schemaFields.yupString().defined()).defined(),
 }).defined();
 
 export const teamMemberProfilesCrudServerReadSchema = teamMemberProfilesCrudClientReadSchema.concat(yupObject({
   user: usersCrudServerReadSchema.defined(),
+  permission_ids: schemaFields.yupArray(schemaFields.yupString().defined()).defined(),
 })).defined();
 
 export const teamMemberProfilesCrudClientUpdateSchema = yupObject({

--- a/packages/stack-shared/src/interface/server-interface.ts
+++ b/packages/stack-shared/src/interface/server-interface.ts
@@ -654,6 +654,7 @@ export class StackServerInterface extends StackClientInterface {
     email: string,
     teamId: string,
     callbackUrl: string,
+    permissionIds?: string[],
   }): Promise<void> {
     await this.sendServerRequest(
       "/team-invitations/send-code",
@@ -666,6 +667,7 @@ export class StackServerInterface extends StackClientInterface {
           email: options.email,
           team_id: options.teamId,
           callback_url: options.callbackUrl,
+          permission_ids: options.permissionIds,
         }),
       },
       null,

--- a/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts
@@ -23,6 +23,7 @@ import { ApiKey, ApiKeyCreationOptions, ApiKeyUpdateOptions, apiKeyCreationOptio
 import { GetUserOptions, HandlerUrls, OAuthScopesOnSignIn, TokenStoreInit } from "../../common";
 import { OAuthConnection } from "../../connected-accounts";
 import { ServerContactChannel, ServerContactChannelCreateOptions, ServerContactChannelUpdateOptions, serverContactChannelCreateOptionsToCrud, serverContactChannelUpdateOptionsToCrud } from "../../contact-channels";
+import { InlineOffer, ServerItem } from "../../customers";
 import { SendEmailOptions } from "../../email";
 import { NotificationCategory } from "../../notification-categories";
 import { AdminProjectPermissionDefinition, AdminTeamPermission, AdminTeamPermissionDefinition } from "../../permissions";
@@ -31,7 +32,6 @@ import { ProjectCurrentServerUser, ServerUser, ServerUserCreateOptions, ServerUs
 import { StackServerAppConstructorOptions } from "../interfaces/server-app";
 import { _StackClientAppImplIncomplete } from "./client-app-impl";
 import { clientVersion, createCache, createCacheBySession, getBaseUrl, getDefaultProjectId, getDefaultPublishableClientKey, getDefaultSecretServerKey } from "./common";
-import { InlineOffer, ServerItem } from "../../customers";
 
 // IF_PLATFORM react-like
 import { useAsyncCache } from "./common";
@@ -600,6 +600,7 @@ export class _StackServerAppImplIncomplete<HasTokenStore extends boolean, Projec
       teamProfile: {
         displayName: crud.display_name,
         profileImageUrl: crud.profile_image_url,
+        permission_ids: crud.permission_ids,
       },
     };
   }
@@ -609,6 +610,7 @@ export class _StackServerAppImplIncomplete<HasTokenStore extends boolean, Projec
       id: crud.id,
       recipientEmail: crud.recipient_email,
       expiresAt: new Date(crud.expires_at_millis),
+      permissionIds: crud.permission_ids,
       revoke: async () => {
         await this._interface.revokeServerTeamInvitation(crud.id, crud.team_id);
       },
@@ -669,11 +671,12 @@ export class _StackServerAppImplIncomplete<HasTokenStore extends boolean, Projec
         });
         await app._serverTeamMemberProfilesCache.refresh([crud.id]);
       },
-      async inviteUser(options: { email: string, callbackUrl?: string }) {
+      async inviteUser(options: { email: string, callbackUrl?: string, permissionIds?: string[] }) {
         await app._interface.sendServerTeamInvitation({
           teamId: crud.id,
           email: options.email,
           callbackUrl: options.callbackUrl ?? constructRedirectUrl(app.urls.teamInvitation, "callbackUrl"),
+          permissionIds: options.permissionIds,
         });
         await app._serverTeamInvitationsCache.refresh([crud.id]);
       },

--- a/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
@@ -54,6 +54,7 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
     verifyEmail(code: string): Promise<Result<undefined, KnownErrors["VerificationCodeError"]>>,
     signInWithMagicLink(code: string, options?: { noRedirect?: boolean }): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>>,
     signInWithMfa(otp: string, code: string, options?: { noRedirect?: boolean }): Promise<Result<undefined, KnownErrors["VerificationCodeError"] | KnownErrors["InvalidTotpCode"]>>,
+    getTeamRolePermissions(): Promise<{ items: { id: string, description?: string, contained_permission_ids: string[] }[], is_paginated: false }>,
 
     redirectToOAuthCallback(): Promise<void>,
 

--- a/packages/template/src/lib/stack-app/teams/index.ts
+++ b/packages/template/src/lib/stack-app/teams/index.ts
@@ -10,6 +10,7 @@ import { ServerUser } from "../users";
 export type TeamMemberProfile = {
   displayName: string | null,
   profileImageUrl: string | null,
+  permission_ids: string[],
 }
 
 export type TeamMemberProfileUpdateOptions = {
@@ -30,6 +31,7 @@ export type TeamInvitation = {
   id: string,
   recipientEmail: string | null,
   expiresAt: Date,
+  permissionIds?: string[],
   revoke(): Promise<void>,
 }
 
@@ -39,7 +41,7 @@ export type Team = {
   profileImageUrl: string | null,
   clientMetadata: any,
   clientReadOnlyMetadata: any,
-  inviteUser(options: { email: string, callbackUrl?: string }): Promise<void>,
+  inviteUser(options: { email: string, callbackUrl?: string, permissionIds?: string[] }): Promise<void>,
   listUsers(): Promise<TeamUser[]>,
   useUsers(): TeamUser[], // THIS_LINE_PLATFORM react-like
   listInvitations(): Promise<TeamInvitation[]>,
@@ -89,7 +91,7 @@ export type ServerTeam = {
   update(update: ServerTeamUpdateOptions): Promise<void>,
   delete(): Promise<void>,
   addUser(userId: string): Promise<void>,
-  inviteUser(options: { email: string, callbackUrl?: string }): Promise<void>,
+  inviteUser(options: { email: string, callbackUrl?: string, permissionIds?: string[] }): Promise<void>,
   removeUser(userId: string): Promise<void>,
 } & Team;
 


### PR DESCRIPTION
- Add permission_ids field to team member profile schemas (client/server)
- Update team member profiles API to include permission_ids in responses
- Modify team member list UI to display roles based on permission_ids
- Update team invitation endpoints to handle permission_ids
- Add role-permissions endpoint for fetching available permissions
- Update documentation with permission_ids examples and type definitions
- Add conceptual documentation for role-based team invitations

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
