### PR TITLE
oauth sign in scope and test

### DIFF
--- a/apps/e2e/tests/js/js-helpers.ts
+++ b/apps/e2e/tests/js/js-helpers.ts
@@ -1,7 +1,8 @@
+import type { StackClientAppConstructorOptions, StackServerAppConstructorOptions } from '@stackframe/js';
 import { AdminProjectCreateOptions, StackAdminApp, StackClientApp, StackServerApp } from '@stackframe/js';
+import { throwErr } from '@stackframe/stack-shared/dist/utils/errors';
 import { Result } from '@stackframe/stack-shared/dist/utils/results';
 import { STACK_BACKEND_BASE_URL, STACK_INTERNAL_PROJECT_ADMIN_KEY, STACK_INTERNAL_PROJECT_CLIENT_KEY, STACK_INTERNAL_PROJECT_SERVER_KEY } from '../helpers';
-import { throwErr } from '@stackframe/stack-shared/dist/utils/errors';
 
 export async function scaffoldProject(body?: Omit<AdminProjectCreateOptions, 'displayName' | 'teamId'> & { displayName?: string }) {
   const internalApp = new StackAdminApp({
@@ -37,7 +38,13 @@ export async function scaffoldProject(body?: Omit<AdminProjectCreateOptions, 'di
   };
 }
 
-export async function createApp(body?: Parameters<typeof scaffoldProject>[0]) {
+export async function createApp(
+  body?: Parameters<typeof scaffoldProject>[0],
+  appOverrides?: {
+    client?: Partial<StackClientAppConstructorOptions<true, string>>,
+    server?: Partial<StackServerAppConstructorOptions<true, string>>,
+  },
+) {
   const { project, adminUser } = await scaffoldProject(body);
   const adminApp = new StackAdminApp({
     projectId: project.id,
@@ -60,6 +67,7 @@ export async function createApp(body?: Parameters<typeof scaffoldProject>[0]) {
     publishableClientKey: apiKey.publishableClientKey,
     secretServerKey: apiKey.secretServerKey,
     tokenStore: "memory",
+    ...(appOverrides?.server ?? {}),
   });
 
   const clientApp = new StackClientApp({
@@ -67,6 +75,7 @@ export async function createApp(body?: Parameters<typeof scaffoldProject>[0]) {
     projectId: project.id,
     publishableClientKey: apiKey.publishableClientKey,
     tokenStore: "memory",
+    ...(appOverrides?.client ?? {}),
   });
 
   return {

--- a/apps/e2e/tests/js/oauth.test.ts
+++ b/apps/e2e/tests/js/oauth.test.ts
@@ -1,0 +1,67 @@
+import { it, localRedirectUrl } from "../helpers";
+import { createApp } from "./js-helpers";
+
+it("adds provider_scope from oauthScopesOnSignIn for authenticate flow", async ({ expect }) => {
+  const { clientApp } = await createApp(
+    {
+      config: {
+        oauthProviders: [
+          {
+            id: "github",
+            type: "standard",
+            clientId: "test_client_id",
+            clientSecret: "test_client_secret",
+          },
+        ],
+      },
+    },
+    {
+      client: {
+        oauthScopesOnSignIn: {
+          github: ["repo"],
+        },
+      },
+    }
+  );
+
+  // Patch window/document and call the real SDK API (signInWithOAuth)
+  const previousWindow = globalThis.window;
+  const previousDocument = globalThis.document;
+  let assignedUrl: string | null = null;
+  globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+  globalThis.window = {
+    location: {
+      href: localRedirectUrl,
+      assign: (url: string) => {
+        assignedUrl = url;
+        throw new Error("INTENTIONAL_TEST_ABORT");
+      },
+    },
+  } as any;
+
+  try {
+    await expect(clientApp.signInWithOAuth("github")).rejects.toThrowError("INTENTIONAL_TEST_ABORT");
+  } finally {
+    globalThis.window = previousWindow;
+    globalThis.document = previousDocument;
+  }
+
+  const parsed = new URL(assignedUrl!);
+  expect(parsed.searchParams.get("provider_scope")).toBe("repo");
+  const response = await fetch(assignedUrl!, { redirect: "manual" });
+  expect(response).toMatchInlineSnapshot(`
+    Response {
+      "status": 307,
+      "headers": Headers {
+        "location": "https://github.com/login/oauth/authorize?client_id=test_client_id&scope=user%3Aemail+repo&response_type=code&redirect_uri=%3Cstripped+query+param%3E&code_challenge_method=S256&code_challenge=%3Cstripped+query+param%3E&state=%3Cstripped+query+param%3E&access_type=offline&prompt=consent",
+        "set-cookie": <setting cookie "stack-oauth-inner-<stripped cookie name key>" at path "/" to "true">,
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+  const redirectUrl = new URL(response.headers.get("location")!);
+  const scope = decodeURIComponent(redirectUrl.searchParams.get("scope")!);
+  expect(scope).toBe("user:email repo");
+}, { timeout: 40_000 });
+
+

--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -982,11 +982,8 @@ export class StackClientInterface {
     if (options.afterCallbackRedirectUrl) {
       url.searchParams.set("after_callback_redirect_url", options.afterCallbackRedirectUrl);
     }
-
-    if (options.type === "link") {
-      if (options.providerScope) {
-        url.searchParams.set("provider_scope", options.providerScope);
-      }
+    if (options.providerScope) {
+      url.searchParams.set("provider_scope", options.providerScope);
     }
 
     return url.toString();


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds `provider_scope` handling to OAuth requests and tests it in a new `oauth.test.ts` file.
> 
>   - **Behavior**:
>     - Adds `provider_scope` handling in `getOAuthUrl()` in `client-interface.ts` for OAuth requests.
>     - New test `oauth.test.ts` to verify `provider_scope` is set correctly during OAuth sign-in.
>   - **Functions**:
>     - Modifies `getOAuthUrl()` in `client-interface.ts` to always set `provider_scope` if provided.
>   - **Tests**:
>     - Adds `oauth.test.ts` to test `provider_scope` addition in OAuth sign-in flow.
>     - Updates `createApp()` in `js-helpers.ts` to accept `appOverrides` for client and server configurations.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 1873f395b88e4147dd4f6c0055f9a865c2e3108c. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->

<!-- RECURSEML_SUMMARY:START -->
## Review by RecurseML

 _🔍 Review performed on [1596315..1873f39](https://github.com/stack-auth/stack-auth/compare/15963155e86f7b178e49296296a628edf51424df...1873f395b88e4147dd4f6c0055f9a865c2e3108c)_

| Severity | Location | Issue | Action |
|----------|----------|-------|--------|
| ![Medium](https://img.shields.io/badge/Medium-yellow?style=plastic) | [apps/e2e/tests/js/oauth.test.ts:49](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335145911) | Non-null assertion used instead of ?? throwErr pattern | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/d1f3c6917fae7e4099609c6944e677f5d4a5fa047479809ea0c6388ef85831c9/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |
| ![Medium](https://img.shields.io/badge/Medium-yellow?style=plastic) | [apps/e2e/tests/js/oauth.test.ts:51](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335145939) | Non-null assertion used instead of ?? throwErr pattern | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/23c319564c85305145b7f50755df9aefe5eb30e257dedad42a34018fdea44c73/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |
| ![Medium](https://img.shields.io/badge/Medium-yellow?style=plastic) | [apps/e2e/tests/js/oauth.test.ts:30](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335145974) | OAuth variable missing type prefix in name | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/8508261a37dec2d23a50aeb0cac10f60fe0e13985147335da65d3fffe8c52ac3/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |
| ![Medium](https://img.shields.io/badge/Medium-yellow?style=plastic) | [apps/e2e/tests/js/oauth.test.ts:62](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335146011) | Non-null assertion used instead of ?? throwErr pattern | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/3dbdbb46e7bdc62ce34ad46f510d22ef0f0d4ab097777d8f438cc21002c3a56e/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |
| ![Medium](https://img.shields.io/badge/Medium-yellow?style=plastic) | [apps/e2e/tests/js/oauth.test.ts:63](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335146041) | Non-null assertion used instead of ?? throwErr pattern | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/94c02a9e989b85f7a56120719af150570729122827179edfe7a66474a3bb54d7/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |
| ![Low](https://img.shields.io/badge/Low-green?style=plastic) | [apps/e2e/tests/js/js-helpers.ts:43](https://github.com/stack-auth/stack-auth/pull/887#discussion_r2335146078) | Variable name 'appOverrides' should be more descriptive to better indicate its purpose and context | [![Dismiss](https://img.shields.io/badge/Dismiss-lightgray?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/57ad8fdfe7f53ea8ee15f7f706784924cbf2ee62ed8f53b281b4abba87bf5510/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=887) |

<details>
<summary>✅ Files analyzed, no issues (1)</summary>

  • `packages/stack-shared/src/interface/client-interface.ts`
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)
<!-- RECURSEML_SUMMARY:END -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * OAuth sign-in and linking now support specifying provider-specific scopes. When provided, these scopes are included in the authorization request, ensuring consistent behavior across flows.

* **Bug Fixes**
  * Ensures provider-specific OAuth scopes are correctly appended to the authorization URL whenever supplied.

* **Tests**
  * Added end-to-end test validating OAuth redirect behavior and scope handling with a GitHub provider, including verification of the resulting authorization URL and parameters.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->