### PR TITLE
Fix: Magic Link (Email OTP) Login Fails Due to Case-Sensitive Email Matching

### DIFF
--- a/apps/backend/src/app/api/latest/auth/otp/send-sign-in-code/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/otp/send-sign-in-code/route.tsx
@@ -1,3 +1,4 @@
+import { normalizeEmail } from "@/lib/emails";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, clientOrHigherAuthTypeSchema, emailOtpSignInCallbackUrlSchema, signInEmailSchema, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
@@ -31,11 +32,12 @@ export const POST = createSmartRouteHandler({
       nonce: yupString().defined().meta({ openapiField: { description: "A token that must be stored temporarily and provided when verifying the 6-digit code", exampleValue: "u3h6gn4w24pqc8ya679inrhjwh1rybth6a7thurqhnpf2" } }),
     }).defined(),
   }),
-  async handler({ auth: { tenancy }, body: { email, callback_url: callbackUrl }, clientVersion }, fullReq) {
+  async handler({ auth: { tenancy }, body: { email: rawEmail, callback_url: callbackUrl }, clientVersion }, fullReq) {
     if (!tenancy.config.auth.otp.allowSignIn) {
       throw new StatusError(StatusError.Forbidden, "OTP sign-in is not enabled for this project");
     }
 
+    const email = normalizeEmail(rawEmail);
     const user = await ensureUserForEmailAllowsOtp(tenancy, email);
 
     let type: "legacy" | "standard";

--- a/apps/backend/src/app/api/latest/auth/password/sign-in/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/password/sign-in/route.tsx
@@ -1,4 +1,5 @@
 import { getAuthContactChannel } from "@/lib/contact-channel";
+import { normalizeEmail } from "@/lib/emails";
 import { createAuthTokens } from "@/lib/tokens";
 import { getPrismaClientForTenancy } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
@@ -33,10 +34,12 @@ export const POST = createSmartRouteHandler({
       user_id: yupString().defined(),
     }).defined(),
   }),
-  async handler({ auth: { tenancy }, body: { email, password } }, fullReq) {
+  async handler({ auth: { tenancy }, body: { email: rawEmail, password } }, fullReq) {
     if (!tenancy.config.auth.password.allowSignIn) {
       throw new KnownErrors.PasswordAuthenticationNotEnabled();
     }
+
+    const email = normalizeEmail(rawEmail);
 
     const prisma = await getPrismaClientForTenancy(tenancy);
     const contactChannel = await getAuthContactChannel(

--- a/apps/backend/src/app/api/latest/auth/password/sign-up/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/password/sign-up/route.tsx
@@ -1,3 +1,4 @@
+import { normalizeEmail } from "@/lib/emails";
 import { validateRedirectUrl } from "@/lib/redirect-urls";
 import { createAuthTokens } from "@/lib/tokens";
 import { createOrUpgradeAnonymousUser } from "@/lib/users";
@@ -36,7 +37,7 @@ export const POST = createSmartRouteHandler({
       user_id: yupString().defined(),
     }).defined(),
   }),
-  async handler({ auth: { tenancy, user: currentUser }, body: { email, password, verification_callback_url: verificationCallbackUrl } }, fullReq) {
+  async handler({ auth: { tenancy, user: currentUser }, body: { email: rawEmail, password, verification_callback_url: verificationCallbackUrl } }, fullReq) {
     if (!tenancy.config.auth.password.allowSignIn) {
       throw new KnownErrors.PasswordAuthenticationNotEnabled();
     }
@@ -53,6 +54,8 @@ export const POST = createSmartRouteHandler({
     if (passwordError) {
       throw passwordError;
     }
+
+    const email = normalizeEmail(rawEmail);
 
     const createdUser = await createOrUpgradeAnonymousUser(
       tenancy,


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
Fixes #834. Originally, if a user inputs a case-sensitive email to sign-in, the system interprets it as a separate email, and tries to create the user again, but is blocked by the database, leading to the `KnownError:USER_ALREADY_EXISTS`. The fix is to normalize the email input for all the affected routes. 
