### PR TITLE
Fix(seed): Handle missing permissions during database seeding

### DIFF
--- a/apps/backend/prisma/seed.ts
+++ b/apps/backend/prisma/seed.ts
@@ -1,7 +1,7 @@
 /* eslint-disable no-restricted-syntax */
 import { usersCrudHandlers } from '@/app/api/latest/users/crud';
 import { overrideEnvironmentConfigOverride } from '@/lib/config';
-import { grantTeamPermission, updatePermissionDefinition } from '@/lib/permissions';
+import { ensurePermissionDefinition, grantTeamPermission } from '@/lib/permissions';
 import { createOrUpdateProjectWithLegacyConfig, getProject } from '@/lib/projects';
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from '@/lib/tenancies';
 import { getPrismaClientForTenancy, globalPrismaClient } from '@/prisma-client';
@@ -197,30 +197,28 @@ async function seed() {
     }
   });
 
-  await updatePermissionDefinition(
+  await ensurePermissionDefinition(
     globalPrismaClient,
     internalPrisma,
     {
-      oldId: "team_member",
+      id: "team_member",
       scope: "team",
       tenancy: internalTenancy,
       data: {
-        id: "team_member",
         description: "1",
         contained_permission_ids: ["$read_members"],
       }
     }
   );
   const updatedInternalTenancy = await getSoleTenancyFromProjectBranch("internal", DEFAULT_BRANCH_ID);
-  await updatePermissionDefinition(
+  await ensurePermissionDefinition(
     globalPrismaClient,
     internalPrisma,
     {
-      oldId: "team_admin",
+      id: "team_admin",
       scope: "team",
       tenancy: updatedInternalTenancy,
       data: {
-        id: "team_admin",
         description: "2",
         contained_permission_ids: ["$read_members", "$remove_members", "$update_team"],
       }

--- a/apps/backend/src/lib/permissions.tsx
+++ b/apps/backend/src/lib/permissions.tsx
@@ -334,6 +334,47 @@ export async function updatePermissionDefinition(
   };
 }
 
+export async function ensurePermissionDefinition(
+  globalTx: PrismaTransaction,
+  sourceOfTruthTx: PrismaTransaction,
+  options: {
+    scope: "team" | "project",
+    tenancy: Tenancy,
+    id: string,
+    data: {
+      description?: string,
+      contained_permission_ids?: string[],
+    },
+  }
+) {
+  const existingPermission = options.tenancy.config.rbac.permissions[options.id];
+
+  if (existingPermission) {
+    // permission already exists, update it
+    return await updatePermissionDefinition(globalTx, sourceOfTruthTx, {
+      scope: options.scope,
+      tenancy: options.tenancy,
+      oldId: options.id,
+      data: {
+        id: options.id,
+        description: options.data.description,
+        contained_permission_ids: options.data.contained_permission_ids,
+      },
+    });
+  } else {
+    // permission doesn't exist, create it
+    return await createPermissionDefinition(globalTx, {
+      scope: options.scope,
+      tenancy: options.tenancy,
+      data: {
+        id: options.id,
+        description: options.data.description,
+        contained_permission_ids: options.data.contained_permission_ids,
+      },
+    });
+  }
+}
+
 export async function deletePermissionDefinition(
   globalTx: PrismaTransaction,
   sourceOfTruthTx: PrismaTransaction,


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->
## Problem

Fixes #868. The problem was that database seeding fails with `Permission "team_member" not found` error in certain edge cases. This happens when the internal project record exists in the database but the `team_member` and `team_admin` permissions are missing from the project configuration. The seed script then skips permission creation (since the project exists) but still attempts to update the missing permissions, causing the error.

I'm not sure, but I guess this edge case can occur during Docker re-deployments with persistent databases, interrupted setup processes, or maybe database corruption/version mismatches.

## Solution

I added a new `ensurePermissionDefinition()` function in `permissions.tsx` that safely handles both scenarios. If the permission exists, it updates it using the existing `updatePermissionDefinition()` function. If the permission doesn't exist, it creates it using the existing `createPermissionDefinition()` function.

The seed script `seed.ts` now uses this new function for both `team_member` and `team_admin` permissions instead of always trying to update them.

I thought of adding `ensurePermissionDefinition()` as a helper function in `seed.ts` itself, since it has no usage anywhere else, but ultimately put it in `permissions.tsx`, to keep all permission handling functions in one place. (Let me know if you'd like it otherwise)