### PR TITLE
Fix project transfers

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/page-client.tsx
@@ -41,7 +41,7 @@ export default function PageClient() {
 
     setIsTransferring(true);
     try {
-      await project.transfer(user, selectedTeamId);
+      await user.transferProject(project.id, selectedTeamId);
 
       // Reload the page to reflect changes
       // we don't actually need this, but it's a nicer UX as it clearly indicates to the user that a "big" change was made

--- a/packages/stack-shared/src/interface/admin-interface.ts
+++ b/packages/stack-shared/src/interface/admin-interface.ts
@@ -317,23 +317,6 @@ export class StackAdminInterface extends StackServerInterface {
     );
   }
 
-  async transferProject(session: InternalSession, newTeamId: string): Promise<void> {
-    await this.sendAdminRequest(
-      "/internal/projects/transfer",
-      {
-        method: "POST",
-        headers: {
-          "content-type": "application/json",
-        },
-        body: JSON.stringify({
-          project_id: this.options.projectId,
-          new_team_id: newTeamId,
-        }),
-      },
-      session,
-    );
-  }
-
   async getMetrics(includeAnonymous: boolean = false): Promise<any> {
     const params = new URLSearchParams();
     if (includeAnonymous) {

--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -1797,5 +1797,25 @@ export class StackClientInterface {
     const { url } = await response.json() as { url: string };
     return url;
   }
+
+  async transferProject(internalProjectSession: InternalSession, projectIdToTransfer: string, newTeamId: string): Promise<void> {
+    if (this.options.projectId !== "internal") {
+      throw new StackAssertionError("StackClientInterface.transferProject() is only available for internal projects (please specify the project ID in the constructor)");
+    }
+    await this.sendClientRequest(
+      "/internal/projects/transfer",
+      {
+        method: "POST",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({
+          project_id: projectIdToTransfer,
+          new_team_id: newTeamId,
+        }),
+      },
+      internalProjectSession,
+    );
+  }
 }
 

--- a/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
@@ -9,7 +9,7 @@ import { StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/uti
 import { pick } from "@stackframe/stack-shared/dist/utils/objects";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
 import { useMemo } from "react"; // THIS_LINE_PLATFORM react-like
-import { AdminSentEmail, CurrentUser } from "../..";
+import { AdminSentEmail } from "../..";
 import { EmailConfig, stackAppInternalsSymbol } from "../../common";
 import { AdminEmailTemplate } from "../../email-templates";
 import { InternalApiKey, InternalApiKeyBase, InternalApiKeyBaseCrudRead, InternalApiKeyCreateOptions, InternalApiKeyFirstView, internalApiKeyCreateOptionsToCrud } from "../../internal-api-keys";
@@ -195,10 +195,6 @@ export class _StackAdminAppImplIncomplete<HasTokenStore extends boolean, Project
       },
       async delete() {
         await app._interface.deleteProject();
-      },
-      async transfer(user: CurrentUser, newTeamId: string) {
-        await app._interface.transferProject(user._internalSession, newTeamId);
-        await onRefresh();
       },
       async getProductionModeErrors() {
         return getProductionModeErrors(data);

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -1250,7 +1250,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
       async transferProject(projectIdToTransfer: string, newTeamId: string): Promise<void> {
         await app._interface.transferProject(session, projectIdToTransfer, newTeamId);
         await app._refreshProject();
-      }
+      },
       listOwnedProjects() {
         return app._listOwnedProjects(session);
       },

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -1247,6 +1247,10 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
       createProject(newProject: AdminProjectUpdateOptions & { displayName: string, teamId: string }) {
         return app._createProject(session, newProject);
       },
+      async transferProject(projectIdToTransfer: string, newTeamId: string): Promise<void> {
+        await app._interface.transferProject(session, projectIdToTransfer, newTeamId);
+        await app._refreshProject();
+      }
       listOwnedProjects() {
         return app._listOwnedProjects(session);
       },

--- a/packages/template/src/lib/stack-app/users/index.ts
+++ b/packages/template/src/lib/stack-app/users/index.ts
@@ -265,6 +265,7 @@ export type UserExtra = {
 export type InternalUserExtra =
   & {
     createProject(newProject: AdminProjectCreateOptions): Promise<AdminOwnedProject>,
+    transferProject(projectIdToTransfer: string, newTeamId: string): Promise<void>,
   }
   & AsyncStoreProperty<"ownedProjects", [], AdminOwnedProject[], true>
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the project transfer functionality by moving the `transferProject` method from the `Project` object to the `User` object. The implementation is relocated from the admin interface (`StackAdminInterface`) to the client interface (`StackClientInterface`), and the dashboard now calls `user.transferProject()` instead of `project.transfer()`. This change maintains the same underlying API call but reorganizes the ownership and invocation pattern for better architectural alignment.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `packages/template/src/lib/stack-app/users/index.ts` |
| 2 | `packages/stack-shared/src/interface/client-interface.ts` |
| 3 | `packages/stack-shared/src/interface/admin-interface.ts` |
| 4 | `packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts` |
| 5 | `packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts` |
| 6 | `apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/page-client.tsx` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)

<!-- RECURSEML_SUMMARY:END -->