### PR TITLE
revoke products route and sdk functions

### DIFF
--- a/packages/stack-shared/src/interface/server-interface.ts
+++ b/packages/stack-shared/src/interface/server-interface.ts
@@ -872,6 +872,24 @@ export class StackServerInterface extends StackClientInterface {
     );
   }
 
+  async revokeProduct(
+    options: {
+      customerType: "user" | "team" | "custom",
+      customerId: string,
+      productId: string,
+    },
+  ): Promise<void> {
+    await this.sendServerRequest(
+      urlString`/payments/products/${options.customerType}/${options.customerId}`,
+      {
+        method: "DELETE",
+        headers: { "content-type": "application/json" },
+        body: JSON.stringify({ product_id: options.productId }),
+      },
+      null,
+    );
+  }
+
   async getDataVaultStoreValue(secret: string, storeId: string, key: string) {
     const hashedKey = await hashKey(secret, key);
     const response = await this.sendServerRequestAndCatchKnownError(

--- a/packages/template/src/lib/stack-app/apps/interfaces/server-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/server-app.ts
@@ -1,5 +1,6 @@
 import { KnownErrors } from "@stackframe/stack-shared";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
+import type { XOR } from "@stackframe/stack-shared/dist/utils/types";
 import type { GenericQueryCtx } from "convex/server";
 import { AsyncStoreProperty, GetCurrentPartialUserOptions, GetCurrentUserOptions } from "../../common";
 import { CustomerProductsList, CustomerProductsRequestOptions, InlineProduct, ServerItem } from "../../customers";
@@ -25,9 +26,13 @@ export type StackServerApp<HasTokenStore extends boolean = boolean, ProjectId ex
 
     createUser(options: ServerUserCreateOptions): Promise<ServerUser>,
     grantProduct(options: (
-      ({ userId: string } | { teamId: string } | { customCustomerId: string }) &
-      ({ productId: string } | { product: InlineProduct }) &
+      XOR<[{ userId: string }, { teamId: string }, { customCustomerId: string }]> &
+      XOR<[{ productId: string }, { product: InlineProduct }]> &
       { quantity?: number }
+    )): Promise<void>,
+    revokeProduct(options: (
+      XOR<[{ userId: string }, { teamId: string }, { customCustomerId: string }]> &
+      { productId: string }
     )): Promise<void>,
 
     // IF_PLATFORM react-like

--- a/packages/template/src/lib/stack-app/customers/index.ts
+++ b/packages/template/src/lib/stack-app/customers/index.ts
@@ -80,4 +80,5 @@ export type Customer<IsServer extends boolean = false> =
     grantProduct(
       product: { productId: string, quantity?: number } | { product: InlineProduct, quantity?: number },
     ): Promise<void>,
+    revokeProduct(options: { productId: string }): Promise<void>,
   } : {});

--- a/packages/template/src/lib/stack-app/teams/index.ts
+++ b/packages/template/src/lib/stack-app/teams/index.ts
@@ -91,7 +91,7 @@ export type ServerTeam = {
   addUser(userId: string): Promise<void>,
   inviteUser(options: { email: string, callbackUrl?: string }): Promise<void>,
   removeUser(userId: string): Promise<void>,
-} & Team;
+} & Team & Customer<true>;
 
 export type ServerListUsersOptions = {
   cursor?: string,


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR adds the ability to revoke products from customers (users, teams, and custom customers) in the payments system. It introduces a new `revokeProduct` function at multiple SDK levels, implements a `DELETE` endpoint for the products route, and includes logic to cancel active subscriptions and remove one-time purchases. The changes also include a refactor to extract subscription cancellation logic into a reusable helper function and fix a bug in the product validation logic to properly check for active subscriptions.

⏱️ Estimated Review Time: 15-30 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `packages/template/src/lib/stack-app/customers/index.ts` |
| 2 | `packages/template/src/lib/stack-app/teams/index.ts` |
| 3 | `packages/template/src/lib/stack-app/apps/interfaces/server-app.ts` |
| 4 | `packages/stack-shared/src/interface/server-interface.ts` |
| 5 | `apps/backend/src/lib/payments.tsx` |
| 6 | `apps/backend/src/app/api/latest/payments/products/[customer_type]/[customer_id]/route.ts` |
| 7 | `packages/template/src/lib/stack-app/apps/implementations/server-app-impl.ts` |
| 8 | `apps/e2e/tests/backend/endpoints/api/v1/payments/products.test.ts` |
| 9 | `apps/e2e/tests/js/payments.test.ts` |
</details>

<details>
<summary>⚠️ Inconsistent Changes Detected</summary>

| File Path | Warning |
|-----------|---------|
| `apps/backend/src/lib/payments.tsx` | The changes around lines 465-472 modify the `validatePurchaseSession` function to check for active subscriptions more specifically using `isActiveSubscription`. This appears to be a bug fix unrelated to the main revoke feature addition. |
</details>

[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/c47a738a2cfb165d4f8c3cc7bd51da85be6f4016be0b9cefba44171eed8ac47b/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=940)
<!-- RECURSEML_SUMMARY:END -->
<!-- ELLIPSIS_HIDDEN -->

----

> [!IMPORTANT]
> Adds functionality to revoke products from customers, including API routes, backend logic, SDK updates, and tests.
> 
>   - **API**:
>     - Adds `DELETE` route in `route.ts` to revoke a product from a customer.
>     - Validates customer type and product ownership before revocation.
>   - **Backend Logic**:
>     - Implements `revokeProductFromCustomer()` in `payments.tsx` to handle product revocation.
>     - Cancels active subscriptions and deletes one-time purchases.
>   - **SDK**:
>     - Adds `revokeProduct()` method to `StackServerInterface` in `server-interface.ts`.
>     - Updates `server-app-impl.ts` and `server-app.ts` to support product revocation.
>   - **Tests**:
>     - Adds tests in `products.test.ts` and `payments.test.ts` to verify product revocation for subscriptions and one-time purchases.
>     - Tests cover scenarios for missing products and customer-product mismatches.
> 
> <sup>This description was created by </sup>[<img alt="Ellipsis" src="https://img.shields.io/badge/Ellipsis-blue?color=175173">](https://www.ellipsis.dev?ref=stack-auth%2Fstack-auth&utm_source=github&utm_medium=referral)<sup> for 0b82d30b63f1042b305c99b693c8e2010337a065. You can [customize](https://app.ellipsis.dev/stack-auth/settings/summaries) this summary. It will automatically update as commits are pushed.</sup>

<!-- ELLIPSIS_HIDDEN -->