### PR TITLE
Run backend migrations via Dockerfile entrypoint

### DIFF
--- a/docker/server/Dockerfile
+++ b/docker/server/Dockerfile
@@ -86,6 +86,10 @@ USER root
 COPY --from=builder --chown=node:node /app/apps/backend/.next/standalone ./
 COPY --from=builder --chown=node:node /app/apps/backend/.next/static ./apps/backend/.next/static
 COPY --from=builder --chown=node:node /app/apps/backend/prisma ./apps/backend/prisma
+COPY --from=builder --chown=node:node /app/apps/backend/scripts ./apps/backend/scripts
+COPY --from=builder --chown=node:node /app/apps/backend/src ./apps/backend/src
+COPY --from=builder --chown=node:node /app/apps/backend/tsconfig.json ./apps/backend/tsconfig.json
+COPY --from=builder --chown=node:node /app/apps/backend/package.json ./apps/backend/package.json
 COPY --from=builder --chown=node:node /app/apps/backend/dist/seed.js ./apps/backend
 
 # Copy built dashboard
@@ -107,4 +111,4 @@ ENV DASHBOARD_PORT=8101
 USER node
 
 # Set entrypoint to run both backend and dashboard
-ENTRYPOINT ["./entrypoint.sh"]
+ENTRYPOINT ["bash", "-lc", "if [ \"$STACK_SKIP_MIGRATIONS\" = \"true\" ]; then echo \"Skipping migrations.\"; else echo \"Running migrations...\"; cd /app/apps/backend && tsx scripts/db-migrations.ts migrate; fi && ./entrypoint.sh"]

--- a/docker/server/entrypoint.sh
+++ b/docker/server/entrypoint.sh
@@ -32,15 +32,6 @@ if [ -z "${NEXT_PUBLIC_STACK_SVIX_SERVER_URL}" ]; then
   export NEXT_PUBLIC_STACK_SVIX_SERVER_URL=${STACK_SVIX_SERVER_URL}
 fi
 
-# ============= MIGRATIONS =============
-
-if [ "$STACK_SKIP_MIGRATIONS" = "true" ]; then
-  echo "Skipping migrations."
-else
-  echo "Running migrations..."
-  pnpm run db:migrate
-fi
-
 if [ "$STACK_SKIP_SEED_SCRIPT" = "true" ]; then
   echo "Skipping seed script."
 else


### PR DESCRIPTION
## Summary
- copy the backend sources needed to run database migrations into the runtime image
- execute database migrations from the Dockerfile entrypoint before starting the services
- leave the runtime entrypoint to focus on env setup and seeding only

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ed969c2ee48327baad0f43a62e79b8

<!-- RECURSEML_SUMMARY:START -->
## High-level PR Summary
This PR refactors the database migration execution by moving it from the runtime `entrypoint.sh` script into the Dockerfile's `ENTRYPOINT` command. To support this change, additional backend source files (`scripts`, `src`, `tsconfig.json`, `package.json`) are copied into the runtime image to enable running migrations via `tsx scripts/db-migrations.ts migrate`. The runtime entrypoint script is simplified to focus only on environment setup and seeding, with the migration logic removed.

⏱️ Estimated Review Time: 5-15 minutes

<details>
<summary>💡 Review Order Suggestion</summary>

| Order | File Path |
|-------|-----------|
| 1 | `docker/server/Dockerfile` |
| 2 | `docker/server/entrypoint.sh` |
</details>



[![Need help? Join our Discord](https://img.shields.io/badge/Need%20help%3F%20Join%20our%20Discord-5865F2?style=plastic&logo=discord&logoColor=white)](https://discord.gg/n3SsVDAW6U)


[![Analyze latest changes](https://img.shields.io/badge/Analyze%20latest%20changes-238636?style=plastic)](https://squash-322339097191.europe-west3.run.app/interactive/acb517ac79a379ed882bda96c13050195240e220cf88431c5f72b5fc96a9ed95/?repo_owner=stack-auth&repo_name=stack-auth&pr_number=950)
<!-- RECURSEML_SUMMARY:END -->