### PR TITLE
feat :  add Okta Provider

### DIFF
--- a/apps/backend/src/oauth/index.tsx
+++ b/apps/backend/src/oauth/index.tsx
@@ -14,6 +14,7 @@ import { GoogleProvider } from "./providers/google";
 import { LinkedInProvider } from "./providers/linkedin";
 import { MicrosoftProvider } from "./providers/microsoft";
 import { MockProvider } from "./providers/mock";
+import { OktaProvider } from "./providers/okta";
 import { SpotifyProvider } from "./providers/spotify";
 import { TwitchProvider } from "./providers/twitch";
 import { XProvider } from "./providers/x";
@@ -31,6 +32,7 @@ const _providers = {
   linkedin: LinkedInProvider,
   x: XProvider,
   twitch: TwitchProvider,
+  okta:OktaProvider,
 } as const;
 
 const mockProvider = MockProvider;
@@ -78,6 +80,7 @@ export async function getProvider(provider: Tenancy['config']['auth']['oauth']['
       clientSecret: provider.clientSecret || throwErr("Client secret is required for standard providers"),
       facebookConfigId: provider.facebookConfigId,
       microsoftTenantId: provider.microsoftTenantId,
+      oktaDomain:provider.oktaDomain,
     });
   }
 }

--- a/apps/backend/src/oauth/index.tsx
+++ b/apps/backend/src/oauth/index.tsx
@@ -32,7 +32,7 @@ const _providers = {
   linkedin: LinkedInProvider,
   x: XProvider,
   twitch: TwitchProvider,
-  okta:OktaProvider,
+  okta: OktaProvider,
 } as const;
 
 const mockProvider = MockProvider;
@@ -80,7 +80,7 @@ export async function getProvider(provider: Tenancy['config']['auth']['oauth']['
       clientSecret: provider.clientSecret || throwErr("Client secret is required for standard providers"),
       facebookConfigId: provider.facebookConfigId,
       microsoftTenantId: provider.microsoftTenantId,
-      oktaDomain:provider.oktaDomain,
+      oktaDomain: provider.oktaDomain,
     });
   }
 }

--- a/apps/backend/src/oauth/providers/okta.tsx
+++ b/apps/backend/src/oauth/providers/okta.tsx
@@ -18,9 +18,9 @@ export class OktaProvider extends OAuthBaseProvider {
   static async create(options: {
     clientId: string;
     clientSecret: string;
-    okta_issuer: string;
+    oktaDomain: string;
   }) {
-    const  oktaDomain  = options.okta_issuer;
+    const  oktaDomain  = options.oktaDomain;
 
     if(!oktaDomain) throw new StackAssertionError("Okta domain is required ")
 
@@ -41,7 +41,7 @@ export class OktaProvider extends OAuthBaseProvider {
   }
 
   async postProcessUserInfo(tokenSet: TokenSet): Promise<OAuthUserInfo> {
-    const rawUserInfoRes = await fetch(`${this.oktaDomain}/v1/userinfo`, { 
+    const rawUserInfoRes = await fetch(`https://${this.oktaDomain}/v1/userinfo`,{ 
       headers: {
         Authorization: `Bearer ${tokenSet.accessToken}`,
       },
@@ -69,7 +69,7 @@ export class OktaProvider extends OAuthBaseProvider {
     });
   }
   async checkAccessTokenValidity(accessToken: string): Promise<boolean> {
-    const res = await fetch(`${this.oktaDomain}/v1/userinfo`, {
+    const res = await fetch(`https://${this.oktaDomain}/v1/userinfo`,{
       headers: {
         Authorization: `Bearer ${accessToken}`,
       },

--- a/apps/backend/src/oauth/providers/okta.tsx
+++ b/apps/backend/src/oauth/providers/okta.tsx
@@ -1,0 +1,79 @@
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
+import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
+import { getJwtInfo } from "@stackframe/stack-shared/dist/utils/jwt";
+import { OAuthUserInfo, validateUserInfo } from "../utils";
+import { OAuthBaseProvider, TokenSet } from "./base";
+
+
+export class OktaProvider extends OAuthBaseProvider {
+  private oktaDomain : string;
+  private constructor(
+    oktaDomain: string,
+    ...args: ConstructorParameters<typeof OAuthBaseProvider>
+  ) {
+    super(...args);
+    this.oktaDomain = oktaDomain
+  }
+
+  static async create(options: {
+    clientId: string;
+    clientSecret: string;
+    okta_issuer: string;
+  }) {
+    const  oktaDomain  = options.okta_issuer;
+
+    if(!oktaDomain) throw new StackAssertionError("Okta domain is required ")
+
+    return new OktaProvider(
+      oktaDomain,
+      ...await OAuthBaseProvider.createConstructorArgs({
+        issuer: `https://${oktaDomain}`,
+        authorizationEndpoint: `${oktaDomain}/v1/authorize`,
+        tokenEndpoint: `${oktaDomain}/v1/token`,
+        redirectUri: getEnvVariable("OAUTH_REDIRECT_URI")!,
+        jwksUri: `${oktaDomain}/v1/keys`,
+        baseScope: "openid email profile",
+        authorizationExtraParams: { response_mode: "form_post" },
+        tokenEndpointAuthMethod: "client_secret_basic",
+        ...options,
+      }))
+    ;
+  }
+
+  async postProcessUserInfo(tokenSet: TokenSet): Promise<OAuthUserInfo> {
+    const rawUserInfoRes = await fetch(`${this.oktaDomain}/v1/userinfo`, { 
+      headers: {
+        Authorization: `Bearer ${tokenSet.accessToken}`,
+      },
+    });
+
+    if (!rawUserInfoRes.ok) {
+      throw new StackAssertionError(
+        "Error fetching user information from Okta",
+        {
+          status: rawUserInfoRes.status,
+          body: await rawUserInfoRes.text(),
+          jwtInfo: await getJwtInfo({ jwt: tokenSet.accessToken }),
+        }
+      );
+    }
+
+    const rawUserInfo = await rawUserInfoRes.json();
+
+    return validateUserInfo({
+      accountId: rawUserInfo.sub,
+      displayName: rawUserInfo.name,
+      profileImageUrl: rawUserInfo.picture,
+      email: rawUserInfo.email,
+      emailVerified: rawUserInfo.email_verified,
+    });
+  }
+  async checkAccessTokenValidity(accessToken: string): Promise<boolean> {
+    const res = await fetch(`${this.oktaDomain}/v1/userinfo`, {
+      headers: {
+        Authorization: `Bearer ${accessToken}`,
+      },
+    });
+    return res.ok;
+  }
+}

--- a/apps/backend/src/oauth/providers/okta.tsx
+++ b/apps/backend/src/oauth/providers/okta.tsx
@@ -28,10 +28,10 @@ export class OktaProvider extends OAuthBaseProvider {
       oktaDomain,
       ...await OAuthBaseProvider.createConstructorArgs({
         issuer: `https://${oktaDomain}`,
-        authorizationEndpoint: `${oktaDomain}/v1/authorize`,
-        tokenEndpoint: `${oktaDomain}/v1/token`,
+        authorizationEndpoint: `https://${oktaDomain}/v1/authorize`,
+        tokenEndpoint: `https://${oktaDomain}/v1/token`,
         redirectUri: getEnvVariable("OAUTH_REDIRECT_URI")!,
-        jwksUri: `${oktaDomain}/v1/keys`,
+        jwksUri: `https://${oktaDomain}/v1/keys`,
         baseScope: "openid email profile",
         authorizationExtraParams: { response_mode: "form_post" },
         tokenEndpointAuthMethod: "client_secret_basic",

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -44,7 +44,7 @@ function toTitle(id: string) {
     linkedin: "LinkedIn",
     twitch: "Twitch",
     x: "X",
-    okta:"Okta"
+    okta: "okta"
   }[id];
 }
 
@@ -64,7 +64,7 @@ export const providerFormSchema = yupObject({
     }),
   facebookConfigId: yupString().optional(),
   microsoftTenantId: yupString().optional(),
-  oktaDomain:yupString().optional()
+  oktaDomain: yupString().optional()
 });
 
 export type ProviderFormValues = yup.InferType<typeof providerFormSchema>
@@ -77,7 +77,7 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
     clientSecret: (props.provider as any)?.clientSecret ?? "",
     facebookConfigId: (props.provider as any)?.facebookConfigId ?? "",
     microsoftTenantId: (props.provider as any)?.microsoftTenantId ?? "",
-    oktaDomain:(props.provider as any)?.oktaDomain??"",
+    oktaDomain:(props.provider as any)?.oktaDomain?? "",
   };
 
   const onSubmit = async (values: ProviderFormValues) => {
@@ -91,7 +91,7 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
         clientSecret: values.clientSecret || "",
         facebookConfigId: values.facebookConfigId,
         microsoftTenantId: values.microsoftTenantId,
-        oktaDomain:values.oktaDomain,
+        oktaDomain: values.oktaDomain,
       });
     }
   };

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -44,7 +44,7 @@ function toTitle(id: string) {
     linkedin: "LinkedIn",
     twitch: "Twitch",
     x: "X",
-    okta: "okta"
+    okta: "Okta"
   }[id];
 }
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -44,6 +44,7 @@ function toTitle(id: string) {
     linkedin: "LinkedIn",
     twitch: "Twitch",
     x: "X",
+    okta:"Okta"
   }[id];
 }
 
@@ -63,6 +64,7 @@ export const providerFormSchema = yupObject({
     }),
   facebookConfigId: yupString().optional(),
   microsoftTenantId: yupString().optional(),
+  oktaDomain:yupString().optional()
 });
 
 export type ProviderFormValues = yup.InferType<typeof providerFormSchema>
@@ -75,6 +77,7 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
     clientSecret: (props.provider as any)?.clientSecret ?? "",
     facebookConfigId: (props.provider as any)?.facebookConfigId ?? "",
     microsoftTenantId: (props.provider as any)?.microsoftTenantId ?? "",
+    oktaDomain:(props.provider as any)?.oktaDomain??"",
   };
 
   const onSubmit = async (values: ProviderFormValues) => {
@@ -88,6 +91,7 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
         clientSecret: values.clientSecret || "",
         facebookConfigId: values.facebookConfigId,
         microsoftTenantId: values.microsoftTenantId,
+        oktaDomain:values.oktaDomain,
       });
     }
   };
@@ -164,6 +168,15 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
                   name="microsoftTenantId"
                   label="Tenant ID (required if you are using the organizational directory)"
                   placeholder="Tenant ID"
+                />
+              )}
+
+              {props.id === 'Okta' && (
+                <InputField
+                  control={form.control}
+                  name="oktaDomain"
+                  label="Okta Domain (required if you are using Okta)"
+                  placeholder="oktaDomain"
                 />
               )}
             </>

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
@@ -375,7 +375,7 @@ it("returns an error when the oauth config is misconfigured", async ({ expect })
   expect(invalidTypeResponse).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 400,
-      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch, okta",      "headers": Headers { <some fields may have been hidden> },
+      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch, okta",
     }
   `);
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
@@ -375,8 +375,7 @@ it("returns an error when the oauth config is misconfigured", async ({ expect })
   expect(invalidTypeResponse).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 400,
-      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch,okta",
-      "headers": Headers { <some fields may have been hidden> },
+      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch, okta",      "headers": Headers { <some fields may have been hidden> },
     }
   `);
 });

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
@@ -375,7 +375,7 @@ it("returns an error when the oauth config is misconfigured", async ({ expect })
   expect(invalidTypeResponse).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 400,
-      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch",
+      "body": "auth.oauth.providers.invalid.type must be one of the following values: google, github, microsoft, spotify, facebook, discord, gitlab, bitbucket, linkedin, apple, x, twitch,okta",
       "headers": Headers { <some fields may have been hidden> },
     }
   `);


### PR DESCRIPTION
Closes #19

This PR adds the `OktaProvider` implementation to Stack Auth, extending the existing OAuth provider system.  
It introduces support for retrieving and validating user info from Okta and ensures consistency with the project's existing OAuth providers.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added Okta as a new OAuth provider option.
  * Dashboard auth settings let you enter an Okta domain when choosing Okta.
  * Okta integration retrieves user info and validates access tokens automatically.

* **Tests**
  * Backend tests updated to include "okta" in allowed OAuth provider values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->