### PR TITLE
fix: allow OAuth sign-in with existing email when sign-ups disabled

### DIFF
--- a/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
@@ -278,10 +278,11 @@ const handler = createSmartRouteHandler({
                   // ========================== sign up user ==========================
 
                   let primaryEmailAuthEnabled = false;
+                  let oldContactChannel = null;
                   if (userInfo.email) {
                     primaryEmailAuthEnabled = true;
 
-                    const oldContactChannel = await getAuthContactChannelWithEmailNormalization(
+                    oldContactChannel = await getAuthContactChannelWithEmailNormalization(
                       prisma,
                       {
                         tenancyId: outerInfo.tenancyId,
@@ -351,6 +352,44 @@ const handler = createSmartRouteHandler({
 
 
                   if (!tenancy.config.auth.allowSignUp) {
+                    // Before rejecting as a new sign-up, check if a user with this email already exists
+                    // (reuse oldContactChannel from above to avoid duplicate database lookup)
+                    // If a user with this email exists (even if email is not used for auth), link the OAuth account
+                    if (oldContactChannel) {
+                      const existingUser = oldContactChannel.projectUser;
+
+                      // Create the OAuth account linked to the existing user
+                      const newOAuthAccount = await createProjectUserOAuthAccount(prisma, {
+                        tenancyId: outerInfo.tenancyId,
+                        providerId: provider.id,
+                        providerAccountId: userInfo.accountId,
+                        email: userInfo.email,
+                        projectUserId: existingUser.projectUserId,
+                      });
+
+                      await prisma.authMethod.create({
+                        data: {
+                          tenancyId: outerInfo.tenancyId,
+                          projectUserId: existingUser.projectUserId,
+                          oauthAuthMethod: {
+                            create: {
+                              projectUserId: existingUser.projectUserId,
+                              configOAuthProviderId: provider.id,
+                              providerAccountId: userInfo.accountId,
+                            }
+                          }
+                        }
+                      });
+
+                      await storeTokens(newOAuthAccount.id);
+                      return {
+                        id: existingUser.projectUserId,
+                        newUser: false,
+                        afterCallbackRedirectUrl,
+                      };
+                    }
+
+                    // No existing user with this email, so throw SIGN_UP_NOT_ENABLED as expected
                     throw new KnownErrors.SignUpNotEnabled();
                   }
 


### PR DESCRIPTION
## Summary

When project sign-ups are disabled, signing in with Google (or another OAuth provider) using an email that already exists as a user currently fails with `SIGN_UP_NOT_ENABLED`.  

This PR updates the OAuth flow so that, if a user with that email already exists, the login is treated as a **sign-in + account link**, not as a new sign-up.

---


## Background / Bug

**Current behavior:**

1. Admin disables sign-ups in **Auth Methods**.
2. Admin enables Google SSO.
3. Admin creates a user in the dashboard with `user@example.com` and marks them verified.
4. The user tries to “Sign in with Google” using the same email.
5. OAuth completes, but Stack Auth returns:

   - `SIGN_UP_NOT_ENABLED`
   - “Creation of new accounts is not enabled for this project…”

Even though the user already exists, the OAuth flow treats this as a new sign-up attempt instead of linking to the existing account.

**Expected behavior:**

- If an OAuth login comes in with an email that already belongs to an existing user:
  - Link the OAuth account to that user.
  - Sign them in successfully.
- Only when no user exists with that email and sign-ups are disabled should `SIGN_UP_NOT_ENABLED` be returned.

---

## Updated OAuth flow

```text
OAuth callback received
  ↓
Check for existing OAuth connected account
  ↓
Found? → ✅ Sign in (existing behavior)
  ↓
Not found → Is email provided?
  ↓
Yes → Check if email is already used for auth by someone else
  ↓
  ├─ Used for auth → Handle merge strategy (existing behavior)
  └─ Not used for auth → Remember the contact channel
  ↓
Are sign-ups disabled?
  ↓
Yes → Does a user exist with this email? (via remembered contact channel)
  ↓
  ├─ Yes → ✅ Link OAuth account to that user + sign in (NEW)
  └─ No → ❌ Throw SIGN_UP_NOT_ENABLED (existing behavior preserved)
  ↓
No (sign-ups enabled) → ✅ Create new user from OAuth profile (existing behavior)

## Rationale

This allows admins to create users via the dashboard while keeping public sign-ups turned off, and still let those users sign in with OAuth using the same email address.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * OAuth sign-ins can be linked to existing user accounts when sign-ups are disabled; users authenticating via OAuth with a matching contact will be connected to their existing account and treated as returning users.

* **Tests**
  * Added end-to-end tests covering OAuth linking when sign-ups are disabled and ensuring the original sign-up-disabled error remains when no matching user exists.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->