### PR TITLE
[dashboard][fix] - Hide dev port banner in prod

### DIFF
--- a/apps/dashboard/src/app/development-port-display.tsx
+++ b/apps/dashboard/src/app/development-port-display.tsx
@@ -7,7 +7,8 @@ import { getPublicEnvVar } from "../lib/env";
 export function DevelopmentPortDisplay() {
   const [isVisible, setIsVisible] = useState(true);
   const prefix = getPublicEnvVar("NEXT_PUBLIC_STACK_PORT_PREFIX");
-  if (!prefix || !isVisible) return null;
+
+  if (!prefix || !isVisible || process.env.NODE_ENV === "production") return null;
   const color = ({
     "91": "#eee",
     "92": "#fff8e0",


### PR DESCRIPTION
# Hide dev port banner in production

## Problem
The "PORT:81xx" development banner displays in production Docker deployments, even with `ENNVIRONMENT=production`.



## Fix:
Add `process.env.NODE_ENV === "production"` check to the existing condition:

```ts
if (!prefix || !isVisible || process.env.NODE_ENV === "production") return null;
```


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved security by preventing development port information from being displayed in production environments.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->