### PR TITLE
[Fix]: Localhost not loading due to client-interface oauth functions not pulling env variables correctly

### DIFF
--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -5,7 +5,6 @@ import { KnownError, KnownErrors } from '../known-errors';
 import { inlineProductSchema } from '../schema-fields';
 import { AccessToken, InternalSession, RefreshToken } from '../sessions';
 import { generateSecureRandomString } from '../utils/crypto';
-import { getNodeEnvironment } from '../utils/env';
 import { StackAssertionError, throwErr } from '../utils/errors';
 import { globalVar } from '../utils/globals';
 import { HTTP_METHODS, HttpMethod } from '../utils/http';
@@ -166,7 +165,7 @@ export class StackClientInterface {
     };
 
     const clientAuthentication = oauth.ClientSecretPost(this.options.publishableClientKey);
-    const allowInsecure = getNodeEnvironment() === 'test' && tokenEndpoint.startsWith('http://');
+    const allowInsecure = (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') && tokenEndpoint.startsWith('http://');
 
     const response = await this._networkRetryException(async () => {
       const rawResponse = await oauth.refreshTokenGrantRequest(
@@ -1041,8 +1040,7 @@ export class StackClientInterface {
       client_secret: this.options.publishableClientKey,
     };
     const clientAuthentication = oauth.ClientSecretPost(this.options.publishableClientKey);
-    // Allow insecure HTTP requests only in test environment (for localhost testing)
-    const allowInsecure = getNodeEnvironment() === 'test' && tokenEndpoint.startsWith('http://');
+    const allowInsecure = (process.env.NODE_ENV === 'test' || process.env.NODE_ENV === 'development') && tokenEndpoint.startsWith('http://');
 
     let params: URLSearchParams;
     try {


### PR DESCRIPTION
### Summary of Changes
Previously due to the sdk updates, localhost would not load. This is because it was a) using http instead of https  and b) we used `getNodeEnvironment` instead of `process.env` to check node environment. We have fixed this now.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated internal security configuration handling for development and test environments. No user-facing API changes.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->