### PR TITLE
[Fix] Token Store Overrides are now Respected 

### DIFF
--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -229,7 +229,6 @@ export class StackClientInterface {
       refreshToken: null,
     });
 
-
     return await this._networkRetry(
       () => this.sendClientRequestInner(path, requestOptions, session!, requestType),
       session,

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -317,8 +317,9 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
 
   private _anonymousSignUpInProgress: Promise<{ accessToken: string, refreshToken: string }> | null = null;
 
-  protected async _createCookieHelper(): Promise<CookieHelper> {
-    if (this._tokenStoreInit === 'nextjs-cookie' || this._tokenStoreInit === 'cookie') {
+  protected async _createCookieHelper(overrideTokenStoreInit?: TokenStoreInit): Promise<CookieHelper> {
+    const tokenStoreInit = overrideTokenStoreInit === undefined ? this._tokenStoreInit : overrideTokenStoreInit;
+    if (tokenStoreInit === 'nextjs-cookie' || tokenStoreInit === 'cookie') {
       return await createCookieHelper();
     } else {
       return await createPlaceholderCookieHelper();
@@ -877,7 +878,7 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
   }
 
   protected async _getSession(overrideTokenStoreInit?: TokenStoreInit): Promise<InternalSession> {
-    const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper(), overrideTokenStoreInit);
+    const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper(overrideTokenStoreInit), overrideTokenStoreInit);
     const session = this._getSessionFromTokenStore(tokenStore);
     return session;
   }


### PR DESCRIPTION
### Context
Recently, a user raised [this issue](https://github.com/stack-auth/stack-auth/issues/1144), which indicated that `tokenOverrides` were not being respected/used in the `getUser()` function. If we trace the flow through this function, we see `this._getSession -> this._getOrCreateTokenStore -> _createCookieHelper -> createCookieHelper -> createNextCookieHelper -> await rscHeaders()`. What this means is that even when a `requestLike tokenOverride` was passed, we would not end up using it because the `createCookieHelper` call occurs before the extant override checking logic in `getOrCreateTokenStore`, and the `createCookieHelper` didn't check the override but only the default `tokenStoreInit`. This caused the error to propagate up.

### Summary of Changes
We check the `tokenStoreOverride` in the `createCookieHelper` function now, preventing this issue from happening. We also add extra test coverage to verify that overrides are respected, and don't overwrite the default token store.

### Out of Scope Discussion
The original issue was raised with a `bun` runtime running `next.js` code. There seems to be some incompatibility between `bun 1.3.8` and `nextjs 15+`, not just with our backend but with fetching and working with responses from any `nextjs` server. 


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added comprehensive authentication flow tests validating token retrieval via cookies and custom headers, covering server/client resolution and ensuring token-store overrides don’t leak into the app’s default store.

* **Refactor**
  * Improved token store initialization to support per-call overrides, allowing more flexible authentication handling for cookie-based flows.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->