### PR TITLE
[Chore] Bump timeout for email monitor

### DIFF
--- a/apps/backend/src/app/health/email/route.tsx
+++ b/apps/backend/src/app/health/email/route.tsx
@@ -103,7 +103,7 @@ const isExpectedVerificationEmail = (email: ResendEmail, testEmail: string): boo
 
 const waitForVerificationEmail = async (testEmail: string, useInbucket: boolean) => {
   await traceSpan("waiting for verification email", async () => {
-    const MAX_POLL_ATTEMPTS = 24;
+    const MAX_POLL_ATTEMPTS = 36;
     const POLL_INTERVAL_MS = 5000;
 
     for (let attempt = 1; attempt <= MAX_POLL_ATTEMPTS; attempt++) {


### PR DESCRIPTION
### Context
A small amount of email monitor requests take slightly less than 3 minutes to complete. This meant our old timeout of 2 minutes was flagging a few kuma pulls as "down" when they weren't.

### Summary of Changes
We just bumped the timeout. This should be ok in prod because the uptime kuma timeout is set to 200 seconds.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email verification reliability by extending the polling window, allowing additional attempts for verification email detection and reducing timeout-related failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->