### PR TITLE
Fix flaky ClickHouse test: use direct sync in CI

### DIFF
--- a/.github/workflows/e2e-api-tests.yaml
+++ b/.github/workflows/e2e-api-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       STACK_ENABLE_HARDCODED_PASSKEY_CHALLENGE_FOR_TESTING: yes
       STACK_DATABASE_CONNECTION_STRING: "postgres://postgres:PASSWORD-PLACEHOLDER--uqfEC1hmmv@localhost:8128/stackframe"
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
 
     strategy:
       matrix:

--- a/.github/workflows/e2e-custom-base-port-api-tests.yaml
+++ b/.github/workflows/e2e-custom-base-port-api-tests.yaml
@@ -20,7 +20,7 @@ jobs:
       STACK_DATABASE_CONNECTION_STRING: "postgres://postgres:PASSWORD-PLACEHOLDER--uqfEC1hmmv@localhost:6728/stackframe"
       NEXT_PUBLIC_STACK_PORT_PREFIX: "67"
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
 
     strategy:
       matrix:

--- a/.github/workflows/restart-dev-and-test-with-custom-base-port.yaml
+++ b/.github/workflows/restart-dev-and-test-with-custom-base-port.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       NEXT_PUBLIC_STACK_PORT_PREFIX: "69"
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/restart-dev-and-test.yaml
+++ b/.github/workflows/restart-dev-and-test.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubicloud-standard-16
     env:
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/setup-tests-with-custom-base-port.yaml
+++ b/.github/workflows/setup-tests-with-custom-base-port.yaml
@@ -20,7 +20,7 @@ jobs:
     env:
       NEXT_PUBLIC_STACK_PORT_PREFIX: "69"
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
 
     steps:
       - uses: actions/checkout@v6

--- a/.github/workflows/setup-tests.yaml
+++ b/.github/workflows/setup-tests.yaml
@@ -19,7 +19,7 @@ jobs:
     runs-on: ubicloud-standard-16
     env:
       STACK_EXTERNAL_DB_SYNC_MAX_DURATION_MS: "20000"
-      STACK_EXTERNAL_DB_SYNC_DIRECT: "false"
+      STACK_EXTERNAL_DB_SYNC_DIRECT: "true"
     steps:
       - uses: actions/checkout@v6
 


### PR DESCRIPTION
## Summary
- Set `STACK_EXTERNAL_DB_SYNC_DIRECT: "true"` in all 6 CI workflow files
- This makes the poller call the sync-engine endpoint directly (via HTTP to the local backend) instead of going through QStash

## Theory
With `STACK_EXTERNAL_DB_SYNC_DIRECT=false`, all syncs go through QStash with `parallelism: 20`. The ~672 user creations across 79 parallel test files generate hundreds of sync requests that saturate QStash. Individual test tenancies get starved, causing timeouts.

## Test plan
- [ ] CI should pass on this branch
- [ ] The "Updates to user are synced to ClickHouse" test should stop intermittently timing out