### PR TITLE
Fix flaky ClickHouse test: add FINAL to metadata query

### DIFF
--- a/apps/backend/src/lib/external-db-sync.ts
+++ b/apps/backend/src/lib/external-db-sync.ts
@@ -460,7 +460,7 @@ async function getClickhouseLastSyncedSequenceId(
   const resultSet = await client.query({
     query: `
       SELECT last_synced_sequence_id
-      FROM analytics_internal._stack_sync_metadata
+      FROM analytics_internal._stack_sync_metadata FINAL
       WHERE tenancy_id = {tenancy_id:UUID}
         AND mapping_name = {mapping_name:String}
       ORDER BY updated_at DESC


### PR DESCRIPTION
## Summary
- Add `FINAL` keyword to the `getClickhouseLastSyncedSequenceId` query against the `_stack_sync_metadata` table

## Theory
`_stack_sync_metadata` is a `ReplacingMergeTree(updated_at)` table. Without the `FINAL` keyword, unmerged rows can cause `ORDER BY updated_at DESC LIMIT 1` to return a stale high value, causing the sync engine to skip data. This could make the test wait forever for data that was already "synced" according to a stale metadata row.

## Test plan
- [ ] CI should pass on this branch
- [ ] The "Updates to user are synced to ClickHouse" test should stop intermittently timing out