### PR TITLE
analytics: reduce batch size limit

### DIFF
--- a/apps/backend/src/app/api/latest/session-replays/batch/route.tsx
+++ b/apps/backend/src/app/api/latest/session-replays/batch/route.tsx
@@ -14,7 +14,7 @@ const gzip = promisify(gzipCb);
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-8][0-9a-f]{3}-[089ab][0-9a-f]{3}-[0-9a-f]{12}$/i;
 
-const MAX_BODY_BYTES = 5_000_000;
+const MAX_BODY_BYTES = 1_000_000;
 const MAX_EVENTS = 5_000;
 
 function extractEventTimesMs(events: unknown[], fallbackMs: number) {

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -293,8 +293,8 @@ it("rejects oversized payloads", async ({ expect }) => {
   await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
   await Auth.Otp.signIn();
 
-  // Backend limit is 5_000_000 bytes; a single large string is sufficient to exceed it.
-  const hugeString = "a".repeat(5_100_000);
+  // Backend limit is 1_000_000 bytes; a single large string is sufficient to exceed it.
+  const hugeString = "a".repeat(1_100_000);
 
   const res = await niceBackendFetch("/api/v1/session-replays/batch", {
     method: "POST",


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **API Changes**
  * Session replay batch upload endpoint now enforces a maximum payload size of 1MB, reduced from 5MB. Requests exceeding the new limit will receive a payload-too-large error response.

* **Tests**
  * Updated batch upload tests to validate behavior under the new 1MB maximum payload size constraint.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->