### PR TITLE
pin adobe/s3mock to 4.12.2 to fix CI bucket creation

### DIFF
--- a/docker/dependencies/docker.compose.yaml
+++ b/docker/dependencies/docker.compose.yaml
@@ -203,7 +203,7 @@ services:
   # ================= Adobe S3 Mock =================
   
   s3mock:
-    image: adobe/s3mock:latest
+    image: adobe/s3mock:4.12.2
     ports:
       - "${NEXT_PUBLIC_STACK_PORT_PREFIX:-81}21:9090"
     environment:


### PR DESCRIPTION
s3mock 5.0.0 was released today and latest now points to it. The major version bump breaks initialBuckets env var handling, causing NoSuchBucket errors in CI.

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Pinned service dependency to a specific version for improved deployment consistency and stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->