### PR TITLE
Fix openrouter proxy baseURL to honor FORWARD_TO_PRODUCTION

### DIFF
--- a/apps/backend/src/lib/ai/models.ts
+++ b/apps/backend/src/lib/ai/models.ts
@@ -1,5 +1,5 @@
 import { createOpenRouter } from "@openrouter/ai-sdk-provider";
-import { getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 
 export type ModelQuality = "dumb" | "smart" | "smartest";
 export type ModelSpeed = "slow" | "fast";
@@ -59,9 +59,9 @@ export const ALLOWED_MODEL_IDS: ReadonlySet<string> = new Set([
 ]);
 
 export function createOpenRouterProvider() {
-  const baseURL = getNodeEnvironment() === "development"
-    ? "http://localhost:8102/api/latest/integrations/ai-proxy/v1"
-    : "https://api.stack-auth.com/api/latest/integrations/ai-proxy/v1";
+  const baseURL = getEnvVariable("STACK_OPENROUTER_API_KEY", "") === "FORWARD_TO_PRODUCTION"
+    ? "https://api.stack-auth.com/api/latest/integrations/ai-proxy/v1"
+    : `${getEnvVariable("NEXT_PUBLIC_STACK_API_URL")}/api/latest/integrations/ai-proxy/v1`;
   return createOpenRouter({
     apiKey: "forwarded",
     baseURL,


### PR DESCRIPTION
Previously the AI proxy baseURL was chosen based on NODE_ENV alone, which caused dev requests to loop back to the local proxy and forward "Bearer FORWARD_TO_PRODUCTION" upstream. Switch on the env var instead and use NEXT_PUBLIC_STACK_API_URL as the default base.

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated AI service endpoint routing to use environment-based configuration instead of local development settings, enabling improved flexibility across deployment environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->