### PR TITLE
fix(ai): Accept header for docs-tools MCP endpoint

### DIFF
--- a/apps/backend/src/lib/ai/tools/docs.ts
+++ b/apps/backend/src/lib/ai/tools/docs.ts
@@ -25,7 +25,11 @@ async function postDocsToolAction(action: Record<string, unknown>): Promise<stri
 
   const res = await fetch(`${base}/api/internal/docs-tools`, {
     method: "POST",
-    headers: { "Content-Type": "application/json" },
+    headers: {
+      "Content-Type": "application/json",
+      // MCP-style JSON-RPC endpoint requires clients to advertise both JSON and SSE.
+      Accept: "application/json, text/event-stream",
+    },
     body: JSON.stringify(action),
   });
 


### PR DESCRIPTION
## Summary
Production requests to `https://mcp.stack-auth.com/api/internal/docs-tools` were returning **406** with `Not Acceptable: Client must accept both application/json and text/event-stream` because `postDocsToolAction` only set `Content-Type`.

## Change
Set `Accept: application/json, text/event-stream` on the fetch to match the MCP-style JSON-RPC handler.

## Testing
- Verified against `mcp.stack-auth.com`: without this header → 406; with it → request passes Accept validation (no longer 406).

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated API request handling to improve content negotiation for doc tools responses, enabling support for multiple response formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->