### PR TITLE
fix: enable prompt caching for Anthropic agent requests

### DIFF
--- a/apps/backend/src/app/api/latest/ai/query/[mode]/route.ts
+++ b/apps/backend/src/app/api/latest/ai/query/[mode]/route.ts
@@ -53,11 +53,25 @@ export const POST = createSmartRouteHandler({
     const isDocsOrSearch = systemPromptId === "docs-ask-ai" || systemPromptId === "command-center-ask-ai";
     const stepLimit = toolsArg == null ? 1 : isDocsOrSearch ? 50 : 5;
 
+    // Anthropic models require an explicit cache_control breakpoint for prompt caching
+    // to work via OpenRouter (whether routed to Anthropic, Bedrock, or Google Vertex).
+    // Mark the static system prompt as an ephemeral cache breakpoint.
+    const isAnthropic = model.modelId.startsWith("anthropic/");
+    const systemMessage: ModelMessage = {
+      role: "system",
+      content: systemPrompt,
+      ...(isAnthropic && {
+        providerOptions: {
+          openrouter: { cacheControl: { type: "ephemeral" } },
+        },
+      }),
+    };
+    const fullMessages: ModelMessage[] = [systemMessage, ...(messages as ModelMessage[])];
+
     if (mode === "stream") {
       const result = streamText({
         model,
-        system: systemPrompt,
-        messages: messages as ModelMessage[],
+        messages: fullMessages,
         tools: toolsArg,
         stopWhen: stepCountIs(stepLimit),
       });
@@ -71,8 +85,7 @@ export const POST = createSmartRouteHandler({
       const timeoutId = setTimeout(() => controller.abort(), 120_000);
       const result = await generateText({
         model,
-        system: systemPrompt,
-        messages: messages as ModelMessage[],
+        messages: fullMessages,
         tools: toolsArg,
         abortSignal: controller.signal,
         stopWhen: stepCountIs(stepLimit),


### PR DESCRIPTION
## Summary

The AI agent's Claude requests were never hitting the prompt cache. The OpenRouter activity log showed `tokens_cached = 0` on **every** `anthropic/claude-*` call, across hundreds of rows, re-paying for the full system prompt each request.

**Root cause:** OpenRouter requires an explicit `cache_control: { type: 'ephemeral' }` breakpoint to enable prompt caching for Anthropic models — on *any* upstream provider (Anthropic direct, Amazon Bedrock, Google Vertex). The agent sent none.

**Fix:** Prepend the system prompt as a `ModelMessage` with `providerOptions.openrouter.cacheControl = { type: 'ephemeral' }`, gated to `anthropic/*` models (other providers already cache automatically on OpenRouter).

## Validation

Ran live OpenRouter calls with an identical ~4.4K-token system prompt, back-to-back:

| Config | Provider | 2nd-call cached | Cost |
|---|---|---|---|
| No cache_control (status quo) | Bedrock | **0** | full price |
| + `cache_control: ephemeral` | Anthropic | **4415 / 4422 (99.8%)** | ~12x cheaper |
| + `cache_control: ephemeral` | Bedrock | **4408 / 4417** | ~12x cheaper |
| + `cache_control: ephemeral` | Google | **4408 / 4417** | ~12x cheaper |

Provider routing was **not** the problem — the missing cache marker was.

## Test plan

- [x] `pnpm typecheck` passes in `apps/backend`
- [x] `pnpm lint` passes in `apps/backend`
- [x] Live OpenRouter validation shows 2nd identical call hits cache (~99%)
- [ ] After merge, OpenRouter activity dashboard should show `tokens_cached > 0` and negative `cost_cache` on `anthropic/claude-*` rows

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Restructured AI query message handling to standardize message formatting across model providers
  * Added performance optimization with cache control support for Anthropic models

<!-- end of auto-generated comment: release notes by coderabbit.ai -->