### PR TITLE
[Fix] Bulldozer Studio and SpaceTime DB port conflict

### DIFF
--- a/apps/backend/scripts/run-bulldozer-studio.ts
+++ b/apps/backend/scripts/run-bulldozer-studio.ts
@@ -111,7 +111,7 @@ type StudioTableRecord = {
   table: StudioTable,
 };
 
-const STUDIO_PORT = Number(`${getEnvVariable("NEXT_PUBLIC_STACK_PORT_PREFIX", "81")}39`);
+const STUDIO_PORT = Number(`${getEnvVariable("NEXT_PUBLIC_STACK_PORT_PREFIX", "81")}40`);
 const STUDIO_HOST = "127.0.0.1";
 const BULLDOZER_LOCK_ID = 7857391;
 const STUDIO_INSTANCE_ID = `${Date.now()}-${Math.random().toString(36).slice(2, 10)}`;

--- a/apps/dev-launchpad/public/index.html
+++ b/apps/dev-launchpad/public/index.html
@@ -345,7 +345,7 @@
         },
         {
           name: "Bulldozer Studio",
-          portSuffix: "39",
+          portSuffix: "40",
           description: [
             "Bulldozer table graph and editor",
             "Includes raw storage debug browser",


### PR DESCRIPTION
### Context
Bulldozer Studio is what we use for debugging and inspecting bulldozer tables. Due to a merge conflict, both bulldozer studio and spacetime db were made accessible via the same port, 8139 by default.

### Summary of Changes
Moving the former to 8140. Now they are both visible.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the local development port for Bulldozer Studio from 8139 to 8140, including corresponding configuration adjustments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->