### PR TITLE
fix dashboard shared email provider display for self-hosted env config

### DIFF
--- a/apps/backend/src/lib/config.tsx
+++ b/apps/backend/src/lib/config.tsx
@@ -1165,6 +1165,9 @@ export const renderedOrganizationConfigToProjectCrud = (renderedConfig: Complete
 
     email_config: renderedConfig.emails.server.isShared ? {
       type: 'shared',
+      host: getEnvVariable("STACK_EMAIL_HOST"),
+      port: parseInt(getEnvVariable("STACK_EMAIL_PORT")),
+      sender_email: getEnvVariable("STACK_EMAIL_SENDER"),
     } : renderedConfig.emails.server.provider === "managed" ? {
       type: 'standard',
       host: "smtp.resend.com",

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-settings/domain-settings.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-settings/domain-settings.tsx
@@ -34,7 +34,7 @@ type ServerFieldConfig = {
 };
 
 const SERVER_TYPE_LABELS: Record<ServerType, string> = {
-  shared: "Shared (noreply@stackframe.co)",
+  shared: "Shared (environment-configured)",
   managed: "Managed (via managed domain setup)",
   resend: "Resend",
   standard: "Custom SMTP",
@@ -87,9 +87,16 @@ function getServerTypeFromConfig(config: CompleteConfig["emails"]["server"]): Se
   return "standard";
 }
 
-function getFormValuesFromConfig(config: CompleteConfig["emails"]["server"], projectName: string): Record<string, string> {
+function getFormValuesFromConfig(
+  config: CompleteConfig["emails"]["server"],
+  projectName: string,
+  sharedSenderEmail: string | null,
+): Record<string, string> {
   if (config.isShared) {
-    return { senderEmail: "noreply@stackframe.co", senderName: projectName };
+    return {
+      senderEmail: sharedSenderEmail ?? "Configured via STACK_EMAIL_SENDER",
+      senderName: projectName,
+    };
   }
   if (config.provider === "managed") {
     const senderEmail = config.managedSubdomain && config.managedSenderLocalPart
@@ -357,12 +364,21 @@ export function DomainSettings() {
   const stackAdminApp = useAdminApp();
   const project = stackAdminApp.useProject();
   const emailConfig = project.useConfig().emails.server;
+  const sharedSenderEmail = project.config.emailConfig?.type === "shared"
+    && "senderEmail" in project.config.emailConfig
+    && typeof project.config.emailConfig.senderEmail === "string"
+    ? project.config.emailConfig.senderEmail
+    : null;
   const updateConfig = useUpdateConfig();
   const { toast } = useToast();
   const isEmulator = getPublicEnvVar("NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR") === "true";
 
   const savedServerType = getServerTypeFromConfig(emailConfig);
-  const savedValues = getFormValuesFromConfig(emailConfig, project.displayName);
+  const savedValues = getFormValuesFromConfig(
+    emailConfig,
+    project.displayName,
+    sharedSenderEmail,
+  );
 
   const [serverType, setServerType] = useState<ServerType>(savedServerType);
   const [formValues, setFormValues] = useState<Record<string, string>>(savedValues);
@@ -541,8 +557,10 @@ export function DomainSettings() {
           <div className="space-y-1.5">
             <Label className="text-xs font-medium text-muted-foreground uppercase tracking-wider">Sender Email</Label>
             {isShared ? (
-              <SimpleTooltip tooltip="Sender email is fixed on the shared server">
-                <Typography className="text-sm font-medium text-foreground/60 cursor-default py-1">noreply@stackframe.co</Typography>
+              <SimpleTooltip tooltip="Sender email is read from STACK_EMAIL_SENDER on the server.">
+                <Typography className="text-sm font-medium text-foreground/60 cursor-default py-1">
+                  {sharedSenderEmail ?? "Configured via STACK_EMAIL_SENDER"}
+                </Typography>
               </SimpleTooltip>
             ) : serverType === "managed" ? (
               <SimpleTooltip tooltip="Sender email is configured through the managed domain setup">

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/emails/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/emails/page-client.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { TeamMemberSearchTable } from "@/components/data-table/team-member-search-table";
+import { DesignAnalyticsCard } from "@/components/design-components";
 import { FormDialog } from "@/components/form-dialog";
 import { InputField, SelectField, TextAreaField } from "@/components/form-fields";
 import { ActionDialog, Alert, AlertDescription, AlertTitle, Button, DataTable, DataTableColumnHeader, DataTableViewOptions, SimpleTooltip, Tooltip, TooltipContent, TooltipProvider, TooltipTrigger, Typography, useToast } from "@/components/ui";
@@ -19,7 +20,6 @@ import * as yup from "yup";
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
-import { DesignAnalyticsCard } from "@/components/design-components";
 
 // Section header with icon following design guide
 function SectionHeader({ icon: Icon, title }: { icon: ElementType, title: string }) {
@@ -59,6 +59,11 @@ export default function PageClient() {
   const stackAdminApp = useAdminApp();
   const project = stackAdminApp.useProject();
   const emailConfig = project.useConfig().emails.server;
+  const sharedSenderEmail = project.config.emailConfig?.type === "shared"
+    && "senderEmail" in project.config.emailConfig
+    && typeof project.config.emailConfig.senderEmail === "string"
+    ? project.config.emailConfig.senderEmail
+    : null;
   const isLocalEmulator = getPublicEnvVar("NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR") === "true";
 
   return (
@@ -82,7 +87,7 @@ export default function PageClient() {
           {isLocalEmulator && <EmulatorModeCard />}
 
           {/* Email Server Card */}
-          <EmailServerCard emailConfig={emailConfig} />
+          <EmailServerCard emailConfig={emailConfig} sharedSenderEmail={sharedSenderEmail} />
 
           {/* Email Log Card */}
           <EmailLogCard />
@@ -130,16 +135,22 @@ function EmulatorModeCard() {
   );
 }
 
-function EmailServerCard({ emailConfig }: { emailConfig: CompleteConfig['emails']['server'] }) {
+function EmailServerCard({
+  emailConfig,
+  sharedSenderEmail,
+}: {
+  emailConfig: CompleteConfig['emails']['server'],
+  sharedSenderEmail: string | null,
+}) {
   const isLocalEmulator = getPublicEnvVar("NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR") === "true";
   const serverType = emailConfig.isShared
-    ? 'Shared'
+    ? 'Shared (environment-configured)'
     : emailConfig.provider === 'managed'
       ? 'Managed By Stack Auth'
       : (emailConfig.provider === 'resend' ? 'Resend' : 'Custom SMTP');
 
   const senderEmail = emailConfig.isShared
-    ? 'noreply@stackframe.co'
+    ? (sharedSenderEmail ?? 'Configured via STACK_EMAIL_SENDER')
     : emailConfig.provider === 'managed' && emailConfig.managedSubdomain && emailConfig.managedSenderLocalPart
       ? `${emailConfig.managedSenderLocalPart}@${emailConfig.managedSubdomain}`
       : emailConfig.senderEmail;
@@ -207,7 +218,7 @@ function EmailServerCard({ emailConfig }: { emailConfig: CompleteConfig['emails'
             <div className="flex items-center gap-2">
               <span className="text-sm font-medium text-foreground">{serverType}</span>
               {emailConfig.isShared && (
-                <SimpleTooltip tooltip="When you use the shared email server, all the emails are sent from Stack's email address" type='info' />
+                <SimpleTooltip tooltip="Shared email settings are read from STACK_EMAIL_* environment variables on the server." type='info' />
               )}
             </div>
           </div>
@@ -820,7 +831,7 @@ function EditEmailServerDialog(props: {
           name="type"
           control={form.control}
           options={[
-            { label: "Shared (noreply@stackframe.co)", value: 'shared' },
+            { label: "Shared (environment-configured)", value: 'shared' },
             { label: "Managed (via managed domain setup)", value: 'managed' },
             { label: "Resend (your own email address)", value: 'resend' },
             { label: "Custom SMTP server (your own email address)", value: 'standard' },

--- a/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/admin-app-impl.ts
@@ -22,7 +22,7 @@ import { InternalApiKey, InternalApiKeyBase, InternalApiKeyBaseCrudRead, Interna
 import { AdminProjectPermission, AdminProjectPermissionDefinition, AdminProjectPermissionDefinitionCreateOptions, AdminProjectPermissionDefinitionUpdateOptions, AdminTeamPermission, AdminTeamPermissionDefinition, AdminTeamPermissionDefinitionCreateOptions, AdminTeamPermissionDefinitionUpdateOptions, adminProjectPermissionDefinitionCreateOptionsToCrud, adminProjectPermissionDefinitionUpdateOptionsToCrud, adminTeamPermissionDefinitionCreateOptionsToCrud, adminTeamPermissionDefinitionUpdateOptionsToCrud } from "../../permissions";
 import { AdminOwnedProject, AdminProject, AdminProjectUpdateOptions, PushConfigOptions, adminProjectUpdateOptionsToCrud } from "../../projects";
 import type { AdminSessionReplay, AdminSessionReplayChunk, ListSessionReplayChunksOptions, ListSessionReplayChunksResult, ListSessionReplaysOptions, ListSessionReplaysResult, SessionReplayAllEventsResult } from "../../session-replays";
-import { ManagedEmailProviderListItem, ManagedEmailProviderSetupResult, ManagedEmailProviderStatus, EmailOutboxUpdateOptions, StackAdminApp, StackAdminAppConstructorOptions } from "../interfaces/admin-app";
+import { EmailOutboxUpdateOptions, ManagedEmailProviderListItem, ManagedEmailProviderSetupResult, ManagedEmailProviderStatus, StackAdminApp, StackAdminAppConstructorOptions } from "../interfaces/admin-app";
 import { clientVersion, createCache, getDefaultExtraRequestHeaders, getDefaultProjectId, getDefaultPublishableClientKey, getDefaultSecretServerKey, getDefaultSuperSecretAdminKey, resolveApiUrls, resolveConstructorOptions } from "./common";
 import { _StackServerAppImplIncomplete } from "./server-app-impl";
 
@@ -208,7 +208,10 @@ export class _StackAdminAppImplIncomplete<HasTokenStore extends boolean, Project
           appleBundleIds: p.apple_bundle_ids,
         } as const))),
         emailConfig: data.config.email_config.type === 'shared' ? {
-          type: 'shared'
+          type: 'shared',
+          senderEmail: data.config.email_config.sender_email,
+          host: data.config.email_config.host,
+          port: data.config.email_config.port,
         } : {
           type: 'standard',
           host: data.config.email_config.host ?? throwErr("Email host is missing"),

--- a/packages/template/src/lib/stack-app/project-configs/index.ts
+++ b/packages/template/src/lib/stack-app/project-configs/index.ts
@@ -52,6 +52,9 @@ export type AdminEmailConfig = (
   }
   | {
     type: "shared",
+    senderEmail?: string,
+    host?: string,
+    port?: number,
   }
 );
 


### PR DESCRIPTION
## Summary

This PR fixes a dashboard/config mismatch for shared email provider mode in self-hosted setups.

- Shared email sending already uses `STACK_EMAIL_*` env vars at runtime.
- Dashboard previously showed hard-coded shared sender text (`noreply@stackframe.co`), which was misleading.
- Shared config now surfaces safe env-derived metadata and dashboard renders it with fallback text.

## Root Cause

Two different paths existed:

- **Runtime send path** (`apps/backend/src/lib/emails.tsx`) reads shared SMTP env vars directly.
- **Project config path** (`apps/backend/src/lib/config.tsx`) returned only `email_config.type = "shared"` with no sender/host/port, so dashboard had no real values and hard-coded Stack sender text.

This made it look like env vars were ignored even when sending behavior was correct.

## Changes

- **Backend config serialization**
  - Updated shared `email_config` to include non-secret fields:
    - `host` from `STACK_EMAIL_HOST`
    - `port` from `STACK_EMAIL_PORT`
    - `sender_email` from `STACK_EMAIL_SENDER`
- **Template/admin mapping**
  - Extended shared `AdminEmailConfig` shape to optionally include:
    - `senderEmail`, `host`, `port`
  - Mapped those fields in admin app implementation.
- **Dashboard UI**
  - Replaced hard-coded shared sender display with env-driven value when available.
  - Added safe fallback text: `Configured via STACK_EMAIL_SENDER`.
  - Updated shared server labels/tooltips to `Shared (environment-configured)`.

## Security Considerations

- Exposed only non-secret metadata for shared mode.
- Did **not** expose shared credentials (`username`, `password`).

## Test Plan

**Executed**

- `pnpm -C packages/template typecheck` ✅

**Attempted (blocked by local infra)**

- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts` ❌
- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/internal/projects.test.ts` ❌
- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts` ❌

Failure mode for all above:

- `ECONNREFUSED 127.0.0.1:8102` (backend endpoint unavailable in local environment)

## Risk / Impact

- Low-to-moderate risk.
- Change is additive for shared config metadata and UI consumption.
- Non-shared modes (managed/resend/custom SMTP) remain unchanged.
- Dashboard includes fallback text to avoid runtime display breakage when metadata is absent.

## Follow-up Validation (CI / reviewer environment)

Please rerun:

- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts`
- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/internal/projects.test.ts`
- `pnpm test run apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts`

with backend available on expected local test endpoint.

## Issue

Closes #818

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed shared email configuration to properly utilize environment variables for host, port, and sender email instead of displaying placeholder values.

* **New Features**
  * Updated UI labels to display "environment-configured" for shared email servers, reflecting actual runtime settings from environment variables.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->