### PR TITLE
Update docs to hexclave naming

### DIFF
--- a/docs-mintlify/api/overview.mdx
+++ b/docs-mintlify/api/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: "Overview"
-description: "Complete REST API documentation for Stack Auth"
+description: "Complete REST API documentation for Hexclave"
 ---
 
 Stack offers a REST API for backends & frontends of any programming language or framework. This API is used to authenticate users, manage user data, and more.
 
 ## Authentication
 
-Stack Auth uses different authentication patterns depending on whether you're making requests from client-side code (browser, mobile app) or server-side code (your backend).
+Hexclave uses different authentication patterns depending on whether you're making requests from client-side code (browser, mobile app) or server-side code (your backend).
 
 <Warning>
   **Security Critical**: Never expose your secret server key (`ssk_...`) in
@@ -98,7 +98,7 @@ curl https://api.stack-auth.com/api/v1/ \
   </Accordion>
 
   <Accordion title="How do I handle API errors?">
-    Stack Auth API returns standard HTTP status codes. Common error responses include:
+    Hexclave API returns standard HTTP status codes. Common error responses include:
 
     - `400 Bad Request` - Invalid request parameters
     - `401 Unauthorized` - Invalid or missing authentication
@@ -112,7 +112,7 @@ curl https://api.stack-auth.com/api/v1/ \
   </Accordion>
 
   <Accordion title="Are there rate limits?">
-    Yes, Stack Auth implements rate limiting to ensure fair usage and system stability. Rate limits vary by endpoint and access type. When you exceed the rate limit, you'll receive a `429 Too Many Requests` response with headers indicating when you can retry.
+    Yes, Hexclave implements rate limiting to ensure fair usage and system stability. Rate limits vary by endpoint and access type. When you exceed the rate limit, you'll receive a `429 Too Many Requests` response with headers indicating when you can retry.
   </Accordion>
 </AccordionGroup>
 
@@ -123,7 +123,7 @@ curl https://api.stack-auth.com/api/v1/ \
     Check the Getting Started Guide for initial setup.
   </Card>
   <Card title="Documentation" href="/guides/getting-started/setup">
-    Visit the Concepts section for Stack Auth fundamentals.
+    Visit the Concepts section for Hexclave fundamentals.
   </Card>
   <Card title="Discord Community" href="https://discord.stack-auth.com">
     Join the Discord community for support and discussions.

--- a/docs-mintlify/docs.json
+++ b/docs-mintlify/docs.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://mintlify.com/docs.json",
-  "name": "Stack Auth Documentation",
+  "name": "Hexclave Documentation",
   "theme": "mint",
   "logo": {
     "dark": "/images/logo-dark.svg",

--- a/docs-mintlify/guides/apps/analytics/overview.mdx
+++ b/docs-mintlify/guides/apps/analytics/overview.mdx
@@ -4,7 +4,7 @@ description: "Explore events, session replays, and SQL queries in your project's
 icon: "/images/app-icons/analytics.svg"
 ---
 
-The Analytics app gives you direct access to your project's analytics dataset in Stack Auth. You can inspect raw event tables, run ClickHouse SQL queries, and watch session replays to debug real user behavior.
+The Analytics app gives you direct access to your project's analytics dataset in Hexclave. You can inspect raw event tables, run ClickHouse SQL queries, and watch session replays to debug real user behavior.
 
 ## Overview
 
@@ -16,13 +16,13 @@ Analytics is organized into three areas in the dashboard:
 
 ## How Analytics Works
 
-Stack records analytics events and replay chunks, then exposes them through the Analytics app for read-only querying and investigation.
+Hexclave records analytics events and replay chunks, then exposes them through the Analytics app for read-only querying and investigation.
 
-User activity in your app flows into Stack event ingestion, which stores data in ClickHouse. This data powers the Tables view, the SQL query runner, and the Session replay UI.
+User activity in your app flows into Hexclave event ingestion, which stores data in ClickHouse. This data powers the Tables view, the SQL query runner, and the Session replay UI.
 
 ### What Gets Tracked
 
-Stack collects both client-side and server-side analytics events:
+Hexclave collects both client-side and server-side analytics events:
 
 - **Client-side events**: browser interaction events like `$page-view` and `$click`
 - **Server-side events**: currently `$token-refresh` and `$sign-up-rule-trigger`
@@ -31,20 +31,20 @@ Stack collects both client-side and server-side analytics events:
 
 To use analytics in your project:
 
-1. Open your Stack Auth dashboard
+1. Open your Hexclave dashboard
 2. Go to **Apps**
 3. Open **Analytics**
 4. Click **Enable**
 
 ## Quick Start
 
-1. Enable Analytics in your Stack Auth dashboard (**Apps -> Analytics**)
-2. Initialize Stack Auth on your frontend with `StackClientApp`/`StackProvider`
+1. Enable Analytics in your Hexclave dashboard (**Apps -> Analytics**)
+2. Initialize Hexclave on your frontend with `StackClientApp`/`StackProvider`
 3. Sign in with a real user session
 4. Open the app and navigate/click around
 5. Check **Analytics -> Tables** to confirm events are arriving
 
-After setup, Stack automatically captures client-side `$page-view` and `$click` events.
+After setup, Hexclave automatically captures client-side `$page-view` and `$click` events.
 
 If you want replay recordings, also enable `analytics.replays.enabled` in your client app config.
 

--- a/docs-mintlify/guides/apps/api-keys/overview.mdx
+++ b/docs-mintlify/guides/apps/api-keys/overview.mdx
@@ -4,15 +4,15 @@ description: "Create and manage API keys for users and teams"
 icon: "/images/app-icons/api-keys.svg"
 ---
 
-The API Keys app enables your users to generate and manage API keys for programmatic access to your backend services. API keys provide a secure way to authenticate requests, allowing developers to associate API calls with specific users or teams. Stack Auth provides prebuilt UI components for users and teams to manage their own API keys.
+The API Keys app enables your users to generate and manage API keys for programmatic access to your backend services. API keys provide a secure way to authenticate requests, allowing developers to associate API calls with specific users or teams. Hexclave provides prebuilt UI components for users and teams to manage their own API keys.
 
 ## Overview
 
 API keys allow your users to access your backend services programmatically without interactive authentication.
 
-The flow works as follows: a user or client sends an API request with an API key to your application server. Your server validates the API key with Stack Auth, which returns an authenticated User object. Your server then processes the request and returns the response.
+The flow works as follows: a user or client sends an API request with an API key to your application server. Your server validates the API key with Hexclave, which returns an authenticated User object. Your server then processes the request and returns the response.
 
-Stack Auth provides two types of API keys:
+Hexclave provides two types of API keys:
 
 ### User API keys
 
@@ -353,9 +353,9 @@ Team API keys are associated with teams and can be used to provide access to tea
 
 ## Enabling the API Keys App
 
-To use API keys in your application, you need to enable the API Keys app in your Stack Auth dashboard:
+To use API keys in your application, you need to enable the API Keys app in your Hexclave dashboard:
 
-1. Navigate to your Stack Auth dashboard
+1. Navigate to your Hexclave dashboard
 2. Go to the **Apps** section
 3. Find and click on **API Keys** in the app store
 4. Click the **Enable** button
@@ -364,7 +364,7 @@ Once enabled, you can configure User API Keys and Team API Keys in the app setti
 
 ## Prebuilt UI Components
 
-Stack Auth provides prebuilt UI components that allow your users to manage their own API keys without any additional code:
+Hexclave provides prebuilt UI components that allow your users to manage their own API keys without any additional code:
 
 ### User API Keys UI
 

--- a/docs-mintlify/guides/apps/authentication/auth-providers.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers.mdx
@@ -4,11 +4,11 @@ description: "Configure authentication providers for your application"
 sidebarTitle: All Auth Providers
 ---
 
-Stack Auth supports a variety of authentication providers to give your users flexible sign-in options. You can configure these providers through the Stack Auth dashboard.
+Hexclave supports a variety of authentication providers to give your users flexible sign-in options. You can configure these providers through the Hexclave dashboard.
 
 ## Overview
 
-Authentication providers determine how users can sign in to your application. Stack supports the following provider types:
+Authentication providers determine how users can sign in to your application. Hexclave supports the following provider types:
 
 - **Email/Password**: Traditional email and password authentication
 - **Magic Link**: Passwordless authentication via email links
@@ -18,8 +18,8 @@ Authentication providers determine how users can sign in to your application. St
 ## Configuring Providers
 
 <Steps>
-  <Step title="Open the Stack Auth dashboard">
-    Navigate to your project in the Stack Auth dashboard.
+  <Step title="Open the Hexclave dashboard">
+    Navigate to your project in the Hexclave dashboard.
   </Step>
   <Step title="Go to Auth Providers">
     Click on the **Auth Providers** section in the sidebar.
@@ -28,14 +28,14 @@ Authentication providers determine how users can sign in to your application. St
     Toggle the providers you want to enable for your application.
   </Step>
   <Step title="Configure OAuth providers">
-    For OAuth providers, you can use Stack's shared keys for development or configure your own OAuth client ID and client secret for production.
+    For OAuth providers, you can use Hexclave's shared keys for development or configure your own OAuth client ID and client secret for production.
   </Step>
 </Steps>
 
 ## Shared vs. Custom OAuth Keys
 
 <Info>
-  For development and testing, Stack provides shared OAuth keys that work out of the box. For production, you should set up your own OAuth client credentials.
+  For development and testing, Hexclave provides shared OAuth keys that work out of the box. For production, you should set up your own OAuth client credentials.
 </Info>
 
 ### Shared Keys
@@ -48,7 +48,7 @@ For production use, configure your own OAuth client ID and client secret for eac
 
 1. Register your application with the OAuth provider (e.g., Google Cloud Console, GitHub Developer Settings)
 2. Obtain the client ID and client secret
-3. Enter them in the Stack Auth dashboard under the respective provider settings
+3. Enter them in the Hexclave dashboard under the respective provider settings
 
 ## OAuth Providers
 

--- a/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Apple"
-description: "Set up Apple as an authentication provider with Stack Auth"
+description: "Set up Apple as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Apple as an authentication provider with Stack Auth. Sign in with Apple allows users to sign in to your application using their Apple ID.
+This guide explains how to set up Apple as an authentication provider with Hexclave. Sign in with Apple allows users to sign in to your application using their Apple ID.
 
 <Info>
   You will need to create an Apple Developer account, and generate an Apple Services ID, Apple Private Key, Apple Team ID, and Apple Key ID.
@@ -64,9 +64,9 @@ This guide explains how to set up Apple as an authentication provider with Stack
   </Step>
 
   <Step>
-    ### Enable Apple OAuth in Stack Auth
+    ### Enable Apple OAuth in Hexclave
 
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Apple** as the provider.
     3. Set the **Client ID** (your Service ID identifier), **Client Secret** (the generated secret from Supabase), and **Team ID** (your Apple Developer Team ID).
   </Step>
@@ -74,7 +74,7 @@ This guide explains how to set up Apple as an authentication provider with Stack
 
 ## Native App Configuration (iOS/macOS)
 
-Native iOS and macOS apps using the Stack Auth Swift SDK require Bundle ID configuration in addition to the web OAuth setup above. Native apps use Apple's native Sign in with Apple flow (`ASAuthorizationController`) instead of web-based OAuth.
+Native iOS and macOS apps using the Hexclave Swift SDK require Bundle ID configuration in addition to the web OAuth setup above. Native apps use Apple's native Sign in with Apple flow (`ASAuthorizationController`) instead of web-based OAuth.
 
 <Info>
   Bundle IDs are only required for native iOS/macOS apps. Web applications only need the Service ID configuration described above.
@@ -82,7 +82,7 @@ Native iOS and macOS apps using the Stack Auth Swift SDK require Bundle ID confi
 
 ### Add Your Bundle IDs
 
-1. On the Stack Auth dashboard, navigate to **Auth Methods** and select your Apple provider.
+1. On the Hexclave dashboard, navigate to **Auth Methods** and select your Apple provider.
 2. In the Apple configuration modal, add your app's **Bundle ID** (e.g., `com.yourdomain.app`). This is the same Bundle ID from your App ID in Apple Developer Portal (Step 1 above).
 3. If you have multiple apps (e.g., separate iOS and macOS apps), add all their Bundle IDs.
 4. Click **Save**.

--- a/docs-mintlify/guides/apps/authentication/auth-providers/bitbucket.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/bitbucket.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Bitbucket"
-description: "Set up Bitbucket as an authentication provider with Stack Auth"
+description: "Set up Bitbucket as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Bitbucket as an authentication provider with Stack Auth. Bitbucket OAuth allows users to sign in to your application using their Bitbucket account.
+This guide explains how to set up Bitbucket as an authentication provider with Hexclave. Bitbucket OAuth allows users to sign in to your application using their Bitbucket account.
 
 ## Integration Steps
 
@@ -23,8 +23,8 @@ This guide explains how to set up Bitbucket as an authentication provider with S
     8. Note the **Key** (Client ID) and **Secret** values. Save these somewhere secure as you'll need them for the next steps.
   </Step>
 
-  <Step title="Enable Bitbucket OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Bitbucket OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Bitbucket** as the provider.
     3. Set the **Client ID** (the Key from your Bitbucket OAuth consumer) and **Client Secret** you obtained from Bitbucket earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/discord.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/discord.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Discord"
-description: "Set up Discord as an authentication provider with Stack Auth"
+description: "Set up Discord as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Discord as an authentication provider with Stack Auth. Discord OAuth2 allows users to sign in to your application using their Discord account.
+This guide explains how to set up Discord as an authentication provider with Hexclave. Discord OAuth2 allows users to sign in to your application using their Discord account.
 
 ## Integration Steps
 
@@ -19,8 +19,8 @@ This guide explains how to set up Discord as an authentication provider with Sta
     8. Save the **Client ID** and **Client Secret**. You may need to select **Reset Secret** to generate a new one.
   </Step>
 
-  <Step title="Enable Discord OAuth2 in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Discord OAuth2 in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Discord** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from the Discord Developer Portal earlier.
   </Step>
@@ -28,7 +28,7 @@ This guide explains how to set up Discord as an authentication provider with Sta
 
 ### User Profile Data
 
-When a user signs in with Discord, Stack Auth will create a user profile with the following data:
+When a user signs in with Discord, Hexclave will create a user profile with the following data:
 
 - **User ID**: Discord's unique user ID
 - **Username**: The user's Discord username

--- a/docs-mintlify/guides/apps/authentication/auth-providers/facebook.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/facebook.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Facebook"
-description: "Set up Facebook as an authentication provider with Stack Auth"
+description: "Set up Facebook as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Facebook as an authentication provider with Stack Auth. Facebook OAuth allows users to sign in to your application using their Facebook account.
+This guide explains how to set up Facebook as an authentication provider with Hexclave. Facebook OAuth allows users to sign in to your application using their Facebook account.
 
 ## Integration Steps
 
@@ -18,7 +18,7 @@ This guide explains how to set up Facebook as an authentication provider with St
     7. In the **Finalize** step, select **Go to dashboard**. You'll be redirected to the app's Dashboard page.
     8. In the left sidenav, select **Use cases**.
     9. Next to **Authenticate and request data from users with Facebook Login**, select **Customize**.
-    10. On the Permissions tab, next to **email**, select **Add** to allow Stack Auth to read your user's primary email address.
+    10. On the Permissions tab, next to **email**, select **Add** to allow Hexclave to read your user's primary email address.
     11. In the left sidenav, under **Facebook Login**, select **Settings**.
     12. In the **Client OAuth settings** section, in the **Valid OAuth Redirect URIs** field, add `https://api.stack-auth.com/api/v1/auth/oauth/callback/facebook`
     13. Select **Save changes**.
@@ -26,8 +26,8 @@ This guide explains how to set up Facebook as an authentication provider with St
     15. Note your **App ID** and **App Secret** for the next steps.
   </Step>
 
-  <Step title="Enable Facebook OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Facebook OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Facebook** as the provider.
     3. Set the **App ID** and **App Secret** you obtained from the Facebook Developers Portal earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/github.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/github.mdx
@@ -1,12 +1,12 @@
 ---
 title: "GitHub"
-description: "Set up GitHub as an authentication provider with Stack Auth"
+description: "Set up GitHub as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up GitHub as an authentication provider with Stack Auth. GitHub allows users to sign in to your Stack Auth-enabled app using their GitHub account.
+This guide explains how to set up GitHub as an authentication provider with Hexclave. GitHub allows users to sign in to your Hexclave-enabled app using their GitHub account.
 
 <Info>
-  For Development purposes, Stack Auth uses shared keys for this provider. Shared keys are automatically created by Stack, but show Stack's logo on the OAuth sign-in page.
+  For Development purposes, Hexclave uses shared keys for this provider. Shared keys are automatically created by Hexclave, but show Hexclave's logo on the OAuth sign-in page.
   You should replace these before you go into production.
 </Info>
 
@@ -32,9 +32,9 @@ This guide explains how to set up GitHub as an authentication provider with Stac
   </Step>
 
   <Step>
-    ### Enable GitHub Provider in Stack Auth
+    ### Enable GitHub Provider in Hexclave
 
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **GitHub** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from your GitHub App earlier.
   </Step>
@@ -56,9 +56,9 @@ This guide explains how to set up GitHub as an authentication provider with Stac
     </Step>
 
     <Step>
-      ### Enable GitHub OAuth in Stack Auth
+      ### Enable GitHub OAuth in Hexclave
 
-      1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+      1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
       2. Click **Add SSO Providers** and select **GitHub** as the provider.
       3. Set the **Client ID** and **Client Secret** you obtained from GitHub earlier.
     </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/gitlab.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/gitlab.mdx
@@ -1,9 +1,9 @@
 ---
 title: "GitLab"
-description: "Set up GitLab as an authentication provider with Stack Auth"
+description: "Set up GitLab as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up GitLab as an authentication provider with Stack Auth. GitLab OAuth allows users to sign in to your application using their GitLab account.
+This guide explains how to set up GitLab as an authentication provider with Hexclave. GitLab OAuth allows users to sign in to your application using their GitLab account.
 
 ## Integration Steps
 
@@ -21,8 +21,8 @@ This guide explains how to set up GitLab as an authentication provider with Stac
     7. If you're using a self-hosted GitLab instance, you'll also need the URL of your GitLab instance.
   </Step>
 
-  <Step title="Enable GitLab OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable GitLab OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **GitLab** as the provider.
     3. Set the **Application ID** and **Secret** you obtained from GitLab earlier.
     4. If you're using a self-hosted GitLab instance, you'll also need to provide the URL for your instance. For gitlab.com, you can leave this field blank or use the default value.

--- a/docs-mintlify/guides/apps/authentication/auth-providers/google.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/google.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Google"
-description: "Set up Google as an authentication provider with Stack Auth"
+description: "Set up Google as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Google as an authentication provider with Stack Auth. Google OAuth2 allows users to sign in to your application using their Google account.
+This guide explains how to set up Google as an authentication provider with Hexclave. Google OAuth2 allows users to sign in to your application using their Google account.
 
 <Info>
-  For Development purposes, Stack Auth uses shared keys for this provider. Shared keys are automatically created by Stack, but show Stack's logo on the OAuth sign-in page.
+  For Development purposes, Hexclave uses shared keys for this provider. Shared keys are automatically created by Hexclave, but show Hexclave's logo on the OAuth sign-in page.
   You should replace these before you go into production.
 </Info>
 
@@ -28,9 +28,9 @@ This guide explains how to set up Google as an authentication provider with Stac
   </Step>
 
   <Step>
-    ### Enable Google OAuth2 in Stack Auth
+    ### Enable Google OAuth2 in Hexclave
 
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Google** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from Google Cloud Console earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/linkedin.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/linkedin.mdx
@@ -1,9 +1,9 @@
 ---
 title: "LinkedIn"
-description: "Set up LinkedIn as an authentication provider with Stack Auth"
+description: "Set up LinkedIn as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up LinkedIn as an authentication provider with Stack Auth. LinkedIn OAuth2 allows users to sign in to your application using their LinkedIn account.
+This guide explains how to set up LinkedIn as an authentication provider with Hexclave. LinkedIn OAuth2 allows users to sign in to your application using their LinkedIn account.
 
 ## Integration Steps
 
@@ -24,8 +24,8 @@ This guide explains how to set up LinkedIn as an authentication provider with St
     11. Once approved, navigate to the **Auth** tab again to find your **Client ID** and **Client Secret**.
   </Step>
 
-  <Step title="Enable LinkedIn OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable LinkedIn OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **LinkedIn** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from the LinkedIn Developer Portal earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/microsoft.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/microsoft.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Microsoft"
-description: "Set up Microsoft as an authentication provider with Stack Auth"
+description: "Set up Microsoft as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Microsoft as an authentication provider with Stack Auth. Microsoft OAuth allows users to sign in to your application using their Microsoft account.
+This guide explains how to set up Microsoft as an authentication provider with Hexclave. Microsoft OAuth allows users to sign in to your application using their Microsoft account.
 
 <Info>
-  For Development purposes, Stack Auth uses shared keys for this provider. Shared keys are automatically created by Stack, but show Stack's logo on the OAuth sign-in page.
+  For Development purposes, Hexclave uses shared keys for this provider. Shared keys are automatically created by Hexclave, but show Hexclave's logo on the OAuth sign-in page.
   You should replace these before you go into production.
 </Info>
 
@@ -28,8 +28,8 @@ This guide explains how to set up Microsoft as an authentication provider with S
     12. Copy the **Value** of the client secret immediately (you won't be able to see it again).
   </Step>
 
-  <Step title="Enable Microsoft OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Microsoft OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Microsoft** as the provider.
     3. Set the **Client ID** (Application ID) and **Client Secret** you obtained from the Microsoft Entra admin center.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/passkey.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/passkey.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Passkey"
-description: "Set up passkey authentication with Stack Auth using WebAuthn"
+description: "Set up passkey authentication with Hexclave using WebAuthn"
 ---
 
-This guide explains how to set up Passkey authentication with Stack Auth. Passkeys allow users to sign in to your application securely using biometrics, mobile devices, or security keys.
+This guide explains how to set up Passkey authentication with Hexclave. Passkeys allow users to sign in to your application securely using biometrics, mobile devices, or security keys.
 
 <Info>
   Passkeys provide a more secure and convenient authentication method compared to traditional passwords by using WebAuthn standard.
@@ -12,8 +12,8 @@ This guide explains how to set up Passkey authentication with Stack Auth. Passke
 ## Integration Steps
 
 <Steps>
-  <Step title="Enable Passkey Authentication in Stack Auth">
-    1. Log in to the [Stack Auth dashboard](https://app.stack-auth.com/).
+  <Step title="Enable Passkey Authentication in Hexclave">
+    1. Log in to the [Hexclave dashboard](https://app.stack-auth.com/).
     2. Select your project from the dashboard.
     3. In the left sidebar, select **Auth Methods**.
     4. Find the **Passkey** authentication method and toggle it to enable.
@@ -21,12 +21,12 @@ This guide explains how to set up Passkey authentication with Stack Auth. Passke
   </Step>
 
   <Step title="Implement Passkey Authentication in Your Application">
-    1. Make sure you've installed the Stack Auth SDK in your application:
+    1. Make sure you've installed the Hexclave SDK in your application:
        ```bash
        npm install @stackframe/stack
        ```
 
-    2. Add Passkey support to your sign-in component by using the built-in Stack Auth components or creating your own implementation with the SDK.
+    2. Add Passkey support to your sign-in component by using the built-in Hexclave components or creating your own implementation with the SDK.
 
        Using built-in components:
 
@@ -44,9 +44,9 @@ This guide explains how to set up Passkey authentication with Stack Auth. Passke
 
 ## How Passkey Authentication Works
 
-1. **Registration**: When a user creates a new passkey, their device generates a unique public-private key pair. The private key stays on the user's device, while the public key is sent to Stack Auth's servers.
+1. **Registration**: When a user creates a new passkey, their device generates a unique public-private key pair. The private key stays on the user's device, while the public key is sent to Hexclave's servers.
 
-2. **Authentication**: When a user wants to sign in, Stack Auth sends a challenge to the user's device. The device uses the private key to sign the challenge, and sends the signature back to Stack Auth for verification.
+2. **Authentication**: When a user wants to sign in, Hexclave sends a challenge to the user's device. The device uses the private key to sign the challenge, and sends the signature back to Hexclave for verification.
 
 3. **Cross-device authentication**: Users can create passkeys on one device and use them to sign in on another device using QR codes or nearby device detection.
 

--- a/docs-mintlify/guides/apps/authentication/auth-providers/spotify.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/spotify.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Spotify"
-description: "Set up Spotify as an authentication provider with Stack Auth"
+description: "Set up Spotify as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Spotify as an authentication provider with Stack Auth. Spotify OAuth allows users to sign in to your application using their Spotify account.
+This guide explains how to set up Spotify as an authentication provider with Hexclave. Spotify OAuth allows users to sign in to your application using their Spotify account.
 
 <Info>
-  For Development purposes, Stack Auth uses shared keys for this provider. Shared keys are automatically created by Stack, but show Stack's logo on the OAuth sign-in page.
+  For Development purposes, Hexclave uses shared keys for this provider. Shared keys are automatically created by Hexclave, but show Hexclave's logo on the OAuth sign-in page.
   You should replace these before you go into production.
 </Info>
 
@@ -26,8 +26,8 @@ This guide explains how to set up Spotify as an authentication provider with Sta
     10. If needed, you can adjust the app settings, including adding additional redirect URIs.
   </Step>
 
-  <Step title="Enable Spotify OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Spotify OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Spotify** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from the Spotify Developer Dashboard earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/twitch.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/twitch.mdx
@@ -1,9 +1,9 @@
 ---
 title: "Twitch"
-description: "Set up Twitch as an authentication provider with Stack Auth"
+description: "Set up Twitch as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up Twitch as an authentication provider with Stack Auth. Twitch OAuth allows users to sign in to your application using their Twitch account.
+This guide explains how to set up Twitch as an authentication provider with Hexclave. Twitch OAuth allows users to sign in to your application using their Twitch account.
 
 ## Integration Steps
 
@@ -21,8 +21,8 @@ This guide explains how to set up Twitch as an authentication provider with Stac
     10. Copy and save the **Client ID** and **Client Secret**.
   </Step>
 
-  <Step title="Enable Twitch OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable Twitch OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Twitch** as the provider.
     3. Set the **Client ID** and **Client Secret** you obtained from the Twitch Developer Console earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/two-factor-auth.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/two-factor-auth.mdx
@@ -1,31 +1,31 @@
 ---
 title: "Two-Factor Authentication (2FA)"
-description: "Learn how Two-Factor Authentication works with Stack Auth"
+description: "Learn how Two-Factor Authentication works with Hexclave"
 sidebarTitle: "Two-Factor Auth"
 ---
 
-This guide explains how Two-Factor Authentication (2FA) works with Stack Auth. 2FA adds an extra layer of security by requiring users to provide a verification code in addition to their password.
+This guide explains how Two-Factor Authentication (2FA) works with Hexclave. 2FA adds an extra layer of security by requiring users to provide a verification code in addition to their password.
 
 <Info>
-  Stack Auth implements TOTP (Time-based One-Time Password) for two-factor authentication, which is compatible with standard authenticator apps like Google Authenticator, Microsoft Authenticator, and Authy. 2FA is enabled by default at the platform level and can be configured by individual users.
+  Hexclave implements TOTP (Time-based One-Time Password) for two-factor authentication, which is compatible with standard authenticator apps like Google Authenticator, Microsoft Authenticator, and Authy. 2FA is enabled by default at the platform level and can be configured by individual users.
 </Info>
 
 ## Integration Steps
 
 <Steps>
   <Step title="No Developer Configuration Required">
-    2FA is enabled by default on the Stack Auth platform. Unlike other authentication methods, you don't need to enable it specifically for your project.
+    2FA is enabled by default on the Hexclave platform. Unlike other authentication methods, you don't need to enable it specifically for your project.
   </Step>
 
   <Step title="Implement User Settings in Your Application">
     To allow your users to set up 2FA for their accounts:
 
-    1. Make sure you've installed the Stack Auth SDK in your application:
+    1. Make sure you've installed the Hexclave SDK in your application:
        ```bash
        npm install @stackframe/stack
        ```
 
-    2. Use the Stack Auth components to give users access to their account settings, where they can enable 2FA:
+    2. Use the Hexclave components to give users access to their account settings, where they can enable 2FA:
 
        ```jsx
        import { AccountSettings } from "@stackframe/stack";
@@ -35,21 +35,21 @@ This guide explains how Two-Factor Authentication (2FA) works with Stack Auth. 2
        }
        ```
 
-    3. The built-in Stack Auth components will handle the entire 2FA setup process, including QR code generation, verification, and recovery codes.
+    3. The built-in Hexclave components will handle the entire 2FA setup process, including QR code generation, verification, and recovery codes.
   </Step>
 </Steps>
 
-## How Stack Auth 2FA Works
+## How Hexclave 2FA Works
 
-Stack Auth uses the industry-standard TOTP (Time-based One-Time Password) algorithm for two-factor authentication:
+Hexclave uses the industry-standard TOTP (Time-based One-Time Password) algorithm for two-factor authentication:
 
-1. **User Setup**: When a user enables 2FA in their account settings, Stack Auth generates a secret key that is shared with the user's authenticator app (usually via a QR code).
+1. **User Setup**: When a user enables 2FA in their account settings, Hexclave generates a secret key that is shared with the user's authenticator app (usually via a QR code).
 
 2. **Code Generation**: The authenticator app generates a 6-digit code that changes every 30 seconds, based on the shared secret and the current time.
 
 ## Recommended Authenticator Apps
 
-The following authenticator apps are compatible with Stack Auth 2FA:
+The following authenticator apps are compatible with Hexclave 2FA:
 
 - Google Authenticator (Android, iOS)
 - Microsoft Authenticator (Android, iOS)

--- a/docs-mintlify/guides/apps/authentication/auth-providers/x-twitter.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/x-twitter.mdx
@@ -1,9 +1,9 @@
 ---
 title: "X (Twitter)"
-description: "Set up X (Twitter) as an authentication provider with Stack Auth"
+description: "Set up X (Twitter) as an authentication provider with Hexclave"
 ---
 
-This guide explains how to set up X (formerly Twitter) as an authentication provider with Stack Auth. X OAuth 2.0 allows users to sign in to your application using their X account.
+This guide explains how to set up X (formerly Twitter) as an authentication provider with Hexclave. X OAuth 2.0 allows users to sign in to your application using their X account.
 
 ## Integration Steps
 
@@ -27,8 +27,8 @@ This guide explains how to set up X (formerly Twitter) as an authentication prov
     13. Click **Save** to apply your changes.
   </Step>
 
-  <Step title="Enable X OAuth in Stack Auth">
-    1. On the Stack Auth dashboard, select **Auth Methods** in the left sidebar.
+  <Step title="Enable X OAuth in Hexclave">
+    1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **X (Twitter)** as the provider.
     3. Set the **Client ID** (your API Key) and **Client Secret** you obtained from the X Developer Portal earlier.
   </Step>

--- a/docs-mintlify/guides/apps/authentication/cli-authentication.mdx
+++ b/docs-mintlify/guides/apps/authentication/cli-authentication.mdx
@@ -1,9 +1,9 @@
 ---
 title: CLI Authentication
-description: How to authenticate a command line application using Stack Auth
+description: How to authenticate a command line application using Hexclave
 ---
 
-If you're building a command line application that runs in a terminal, you can use Stack Auth to let your users log in to their accounts.
+If you're building a command line application that runs in a terminal, you can use Hexclave to let your users log in to their accounts.
 
 To do so, we provide a Python template that you can use as a starting point. [Download it here](https://github.com/stack-auth/stack-auth/tree/main/docs/public/stack-auth-cli-template.py) and copy it into your project, for example:
 
@@ -33,7 +33,7 @@ if refresh_token is None:
 
 # you can now use the REST API with the refresh token
 def stack_auth_request(method, endpoint, **kwargs):
-  # ... see Stack Auth's Getting Started section to see how this function should look like
+  # ... see Hexclave's Getting Started section to see how this function should look like
   # https://docs.stack-auth.com/python/getting-started/setup
 
 def get_access_token(refresh_token):

--- a/docs-mintlify/guides/apps/authentication/connected-accounts.mdx
+++ b/docs-mintlify/guides/apps/authentication/connected-accounts.mdx
@@ -3,14 +3,14 @@ title: "Connected Accounts"
 description: "Managing third-party OAuth access tokens"
 ---
 
-Stack has good support for working with OAuth and OIDC providers, such as Google, Facebook, Microsoft, and others.
+Hexclave has good support for working with OAuth and OIDC providers, such as Google, Facebook, Microsoft, and others.
 
-Beyond using OAuth for signing in, Stack can manage your users' access token so you can invoke APIs on their behalf. For example, you can use this to send emails with Gmail, access repositories on GitHub, or access files on OneDrive.
+Beyond using OAuth for signing in, Hexclave can manage your users' access token so you can invoke APIs on their behalf. For example, you can use this to send emails with Gmail, access repositories on GitHub, or access files on OneDrive.
 
 A connected account is simply an external account that is linked to the user in some way. If you are not using shared keys (see note below), any user created with "Sign up with OAuth" is automatically connected to the account they signed up with, but it's also possible to connect a user with a provider that is unavailable for sign in.
 
 <Info>
-  You cannot connect a user's accounts with shared OAuth keys. You need to set up your own OAuth client ID and client secret in Stack's dashboard. For more details, check [Going to Production](/guides/apps/launch-checklist/overview#oauth-providers).
+  You cannot connect a user's accounts with shared OAuth keys. You need to set up your own OAuth client ID and client secret in Hexclave's dashboard. For more details, check [Going to Production](/guides/apps/launch-checklist/overview#oauth-providers).
 </Info>
 
 ## Connecting with OAuth providers
@@ -101,7 +101,7 @@ export const stackServerApp = new StackServerApp({
 
 ## OAuth account merging strategies
 
-When a user attempts to sign in with an OAuth provider that matches an existing account, Stack provides different strategies for handling the authentication flow.
+When a user attempts to sign in with an OAuth provider that matches an existing account, Hexclave provides different strategies for handling the authentication flow.
 
 The available strategies are:
 
@@ -109,9 +109,9 @@ The available strategies are:
 - Link method (new default)
 - Block duplicates (most secure)
 
-The "Link" strategy is the default behavior. If a user attempts to sign in with an OAuth provider that matches an existing account, Stack will link the OAuth identity to the existing account, and the user will be signed into that account.
+The "Link" strategy is the default behavior. If a user attempts to sign in with an OAuth provider that matches an existing account, Hexclave will link the OAuth identity to the existing account, and the user will be signed into that account.
 This requires both of the credentials to be verified, or otherwise the link will be blocked, in the same way as the "Block" strategy.
 
-The "Allow" strategy is the default behavior for old projects. If a user attempts to sign in with an OAuth provider that has an existing account with the same email address, Stack will create a separate account for the user.
+The "Allow" strategy is the default behavior for old projects. If a user attempts to sign in with an OAuth provider that has an existing account with the same email address, Hexclave will create a separate account for the user.
 
 The "Block" strategy will explicitly raise an error if a user attempts to sign in with an OAuth provider that matches an existing account.

--- a/docs-mintlify/guides/apps/authentication/jwts.mdx
+++ b/docs-mintlify/guides/apps/authentication/jwts.mdx
@@ -1,11 +1,11 @@
 ---
 title: "JWT Tokens"
-description: "Understand how Stack Auth uses JSON Web Tokens for authentication"
+description: "Understand how Hexclave uses JSON Web Tokens for authentication"
 ---
 
-JSON Web Tokens (JWT) are a compact, URL-safe means of representing claims to be transferred between two parties. Stack Auth uses JWTs for secure authentication and authorization.
+JSON Web Tokens (JWT) are a compact, URL-safe means of representing claims to be transferred between two parties. Hexclave uses JWTs for secure authentication and authorization.
 
-You don't need to worry about JWTs if you're using Stack Auth. However, if you are an expert user and want the full flexibility to manually verify JWTs for performance or other reasons, this page is for you.
+You don't need to worry about JWTs if you're using Hexclave. However, if you are an expert user and want the full flexibility to manually verify JWTs for performance or other reasons, this page is for you.
 
 ## What is a JWT?
 
@@ -21,9 +21,9 @@ The structure looks like this: `header.payload.signature`
 
 Use the interactive JWT viewer below to decode and inspect JWT tokens. If you're signed in, it will automatically load and display your current session token:
 
-## Stack Auth JWT Structure
+## Hexclave JWT Structure
 
-Stack Auth JWTs contain standardized headers and claims that power authentication throughout the platform.
+Hexclave JWTs contain standardized headers and claims that power authentication throughout the platform.
 
 ### Header
 
@@ -38,9 +38,9 @@ Stack Auth JWTs contain standardized headers and claims that power authenticatio
 * **`exp` (Expiration)**: When the token expires (Unix timestamp)
 * **`iat` (Issued At)**: When the token was issued (Unix timestamp)
 
-### Stack Auth Specific Claims
+### Hexclave Specific Claims
 
-* **`project_id`**: Your Stack Auth project ID
+* **`project_id`**: Your Hexclave project ID
 * **`branch_id`**: The project branch (currently always `main`)
 * **`refresh_token_id`**: ID of the associated refresh token
 * **`role`**: Always set to `authenticated` for valid users
@@ -54,7 +54,7 @@ Stack Auth JWTs contain standardized headers and claims that power authenticatio
 
 ## Example JWT Payload
 
-Here's what a typical Stack Auth JWT payload looks like:
+Here's what a typical Hexclave JWT payload looks like:
 
 ```json
 {
@@ -104,7 +104,7 @@ Users restricted by an administrator (e.g., via [sign-up rules](/guides/apps/aut
 
 ### Client-Side Usage
 
-Stack Auth automatically handles JWT tokens for you. When you use hooks like `useUser()`, the JWT is automatically included in API requests:
+Hexclave automatically handles JWT tokens for you. When you use hooks like `useUser()`, the JWT is automatically included in API requests:
 
 **Next.js:**
 
@@ -140,7 +140,7 @@ export function UserProfile() {
 
 ### Server-Side Usage
 
-On the server side, you can access the JWT and its claims through the Stack Auth API:
+On the server side, you can access the JWT and its claims through the Hexclave API:
 
 ```typescript
 import { stackServerApp } from '@/stack';
@@ -165,12 +165,12 @@ export async function GET() {
 
 ### Manual JWT Verification
 
-If you need to manually verify a JWT (for example, in a different service), fetch the public keys from Stack Auth's JWKS endpoint. Keys are derived per audience so the `kid` in the JWT header always matches one of the published keys.
+If you need to manually verify a JWT (for example, in a different service), fetch the public keys from Hexclave's JWKS endpoint. Keys are derived per audience so the `kid` in the JWT header always matches one of the published keys.
 
 ```typescript
 import * as jose from 'jose';
 
-// Get the public key set from Stack Auth
+// Get the public key set from Hexclave
 const jwks = jose.createRemoteJWKSet(
   new URL('https://api.stack-auth.com/api/v1/projects/YOUR_PROJECT_ID/.well-known/jwks.json')
 );
@@ -238,25 +238,25 @@ const { payload } = await jose.jwtVerify(token, jwks, {
 
 * **Never store JWTs in localStorage** for sensitive applications
 * Use secure, httpOnly cookies when possible
-* Stack Auth handles secure token storage automatically
+* Hexclave handles secure token storage automatically
 
 ### Token Expiration
 
 * JWTs have a limited lifetime (default is 10 minutes via `STACK_ACCESS_TOKEN_EXPIRATION_TIME`)
-* Stack Auth automatically refreshes tokens before they expire
+* Hexclave automatically refreshes tokens before they expire
 * Always check the `exp` claim when manually handling JWTs
 
 ### Signature Verification
 
 * Always verify JWT signatures using the public key
 * Never trust the contents of a JWT without verification
-* Stack Auth SDKs handle verification automatically
+* Hexclave SDKs handle verification automatically
 
 ## Troubleshooting
 
 ### Common Issues
 
-1. **"JWT is expired"**: The token has passed its expiration time. Stack Auth will automatically refresh it.
+1. **"JWT is expired"**: The token has passed its expiration time. Hexclave will automatically refresh it.
 
 2. **"Invalid signature"**: The token was tampered with or signed with a different key.
 
@@ -272,7 +272,7 @@ Use the JWT viewer above to inspect tokens and verify their contents. Pay specia
 
 ## Best Practices
 
-1. **Let Stack Auth handle tokens**: Use the provided SDKs instead of manual JWT handling
+1. **Let Hexclave handle tokens**: Use the provided SDKs instead of manual JWT handling
 2. **Validate on the server**: Always verify JWTs on your backend
 3. **Check expiration**: Ensure tokens haven't expired before using them
 4. **Use HTTPS**: Always transmit JWTs over secure connections

--- a/docs-mintlify/guides/apps/authentication/overview.mdx
+++ b/docs-mintlify/guides/apps/authentication/overview.mdx
@@ -1,6 +1,6 @@
 ---
 title: Authentication
-description: Integrate Stack Auth with AI-powered tools and services
+description: Integrate Hexclave with AI-powered tools and services
 sidebarTitle: Overview
 ---
 

--- a/docs-mintlify/guides/apps/authentication/sign-up-rules.mdx
+++ b/docs-mintlify/guides/apps/authentication/sign-up-rules.mdx
@@ -5,7 +5,7 @@ description: "Control who can sign up for your application with customizable rul
 
 Sign-up rules let you control who can sign up for your application. You can create rules that evaluate sign-up attempts based on conditions like email domain or authentication method, then allow, reject, or restrict users accordingly.
 
-Rules are evaluated during sign-up for all authentication methods (password, magic link, OAuth, passkey). When a user attempts to sign up, Stack evaluates each rule in priority order—the first matching rule determines the outcome. If no rules match, the default action is used.
+Rules are evaluated during sign-up for all authentication methods (password, magic link, OAuth, passkey). When a user attempts to sign up, Hexclave evaluates each rule in priority order—the first matching rule determines the outcome. If no rules match, the default action is used.
 
 ## Creating rules
 

--- a/docs-mintlify/guides/apps/data-vault/overview.mdx
+++ b/docs-mintlify/guides/apps/data-vault/overview.mdx
@@ -4,26 +4,26 @@ description: "An encrypted key-value store for sensitive data, with zero-knowled
 icon: "/images/app-icons/data-vault.svg"
 ---
 
-Data Vault is an encrypted key-value store built into Stack Auth. It lets you securely store sensitive data — API tokens, connection strings, secrets, or any other values — without ever exposing plaintext to Stack Auth's database or operators.
+Data Vault is an encrypted key-value store built into Hexclave. It lets you securely store sensitive data — API tokens, connection strings, secrets, or any other values — without ever exposing plaintext to Hexclave's database or operators.
 
 ## How it works
 
 Data Vault uses a **double encryption** design:
 
-1. **Client-side encryption** — Your SDK encrypts values and hashes keys locally before they leave your server, using a secret that only you know. Stack Auth never sees your plaintext keys or values.
-2. **Server-side encryption** — Stack Auth adds a second layer of envelope encryption using a rotating master key, so even the encrypted data at rest is further protected.
+1. **Client-side encryption** — Your SDK encrypts values and hashes keys locally before they leave your server, using a secret that only you know. Hexclave never sees your plaintext keys or values.
+2. **Server-side encryption** — Hexclave adds a second layer of envelope encryption using a rotating master key, so even the encrypted data at rest is further protected.
 
 Because keys are hashed before storage, **you cannot list or enumerate keys** in a store. You must know the exact key to retrieve a value.
 
 <Warning>
-  If you lose your secret, your data is unrecoverable. Even Stack Auth cannot decrypt your values without it. Keep your secret safe and backed up.
+  If you lose your secret, your data is unrecoverable. Even Hexclave cannot decrypt your values without it. Keep your secret safe and backed up.
 </Warning>
 
 ## Setup
 
 ### 1. Create a store
 
-Go to your project's **Data Vault** page in the [Stack Auth dashboard](https://app.stack-auth.com) and create a new store. Each store has a unique ID that you'll reference in your code.
+Go to your project's **Data Vault** page in the [Hexclave dashboard](https://app.stack-auth.com) and create a new store. Each store has a unique ID that you'll reference in your code.
 
 ### 2. Generate a secret
 
@@ -88,7 +88,7 @@ await store.setValue("some-key", "some-value", {
 
 - **Keys** are hashed with an iterated hash (100,000 iterations) derived from your secret and the logical key. The server only stores the hash.
 - **Values** are encrypted client-side using a derived key from the same secret + key pair, then re-encrypted server-side with KMS envelope encryption.
-- **Your secret** never leaves your server. Stack Auth's API only receives hashed keys and double-encrypted values.
+- **Your secret** never leaves your server. Hexclave's API only receives hashed keys and double-encrypted values.
 - **No enumeration** — since only hashed keys are stored, there is no way to list all keys in a store. This is a deliberate security property.
 
 ## Use cases

--- a/docs-mintlify/guides/apps/emails/overview.mdx
+++ b/docs-mintlify/guides/apps/emails/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "Emails"
-description: "Send custom emails, manage templates, and track delivery - all from Stack Auth."
+description: "Send custom emails, manage templates, and track delivery - all from Hexclave."
 icon: "/images/app-icons/emails.svg"
 ---
 
-Stack Auth includes a full email system for sending transactional and marketing emails to your users. It handles rendering, delivery, scheduling, notification preferences, and tracking out of the box.
+Hexclave includes a full email system for sending transactional and marketing emails to your users. It handles rendering, delivery, scheduling, notification preferences, and tracking out of the box.
 
 ## Email types
 
@@ -184,14 +184,14 @@ EmailTemplate.PreviewVariables = {
 
 Key concepts:
 
-- **`variablesSchema`**  - Define the shape of your template variables using [arktype](https://arktype.io). Stack Auth validates variables against this schema at render time.
+- **`variablesSchema`**  - Define the shape of your template variables using [arktype](https://arktype.io). Hexclave validates variables against this schema at render time.
 - **`<Subject>`**  - Sets the email subject line from inside the template.
 - **`<NotificationCategory>`**  - Declares whether this is a `"Transactional"` or `"Marketing"` email.
 - **`PreviewVariables`**  - Sample data used for the live preview in the dashboard editor.
 
 ### Built-in templates
 
-Stack Auth ships with templates for common auth flows. These are used automatically by the built-in authentication components:
+Hexclave ships with templates for common auth flows. These are used automatically by the built-in authentication components:
 
 | Template | Trigger |
 |---|---|
@@ -207,7 +207,7 @@ You can customize any built-in template from the dashboard under **Emails → Te
 
 ## Themes
 
-Themes wrap your email content in a consistent layout  - header, footer, background, branding. Stack Auth includes three built-in themes:
+Themes wrap your email content in a consistent layout  - header, footer, background, branding. Hexclave includes three built-in themes:
 
 - **Default Light**  - Clean white background with subtle shadow
 - **Default Dark**  - Dark background with light text
@@ -262,7 +262,7 @@ If a user has unsubscribed from Marketing emails, the email will be automaticall
 
 ## React components integration
 
-Emails integrate with Stack Auth UI components automatically (for example verification, password reset, and magic-link flows).  
+Emails integrate with Hexclave UI components automatically (for example verification, password reset, and magic-link flows).  
 For custom flows, trigger `sendEmail` from your server code:
 
 ```typescript
@@ -288,7 +288,7 @@ Configure your email server in the dashboard under **Emails → Email Settings**
 
 ### Shared (development only)
 
-The default for new projects. Emails are sent from `noreply@stackframe.co` using Stack Auth's shared infrastructure. Good for development  - not suitable for production.
+The default for new projects. Emails are sent from `noreply@stackframe.co` using Hexclave's shared infrastructure. Good for development  - not suitable for production.
 
 ### Custom SMTP
 
@@ -301,14 +301,14 @@ Connect any SMTP provider. Configure:
 
 ### Resend
 
-Connect your [Resend](https://resend.com) account by entering your API key. Stack Auth configures the SMTP connection automatically.
+Connect your [Resend](https://resend.com) account by entering your API key. Hexclave configures the SMTP connection automatically.
 
 ### Managed
 
-Let Stack Auth manage your email domain. Stack Auth handles DNS configuration and deliverability for you. Set up requires:
+Let Hexclave manage your email domain. Hexclave handles DNS configuration and deliverability for you. Set up requires:
 
 1. Choose a subdomain (e.g. `mail.yourapp.com`)
-2. Add the DNS records Stack Auth provides
+2. Add the DNS records Hexclave provides
 3. Verify the domain in the dashboard
 
 <Info>
@@ -317,7 +317,7 @@ Let Stack Auth manage your email domain. Stack Auth handles DNS configuration an
 
 ## Delivery stats
 
-Stack Auth tracks delivery metrics across multiple time windows (hour, day, week, month):
+Hexclave tracks delivery metrics across multiple time windows (hour, day, week, month):
 
 - **Sent**  - Successfully delivered
 - **Bounced**  - Rejected by the recipient's mail server

--- a/docs-mintlify/guides/apps/launch-checklist/overview.mdx
+++ b/docs-mintlify/guides/apps/launch-checklist/overview.mdx
@@ -1,20 +1,20 @@
 ---
 title: "Launch Checklist"
-description: "Steps to prepare Stack for production use"
+description: "Steps to prepare Hexclave for production use"
 icon: "/images/app-icons/launch-checklist.svg"
 ---
 
-Stack makes development easy with various default settings, but these settings need to be optimized for security and user experience when moving to production. Here's a checklist of things you need to do before switching to production mode:
+Hexclave makes development easy with various default settings, but these settings need to be optimized for security and user experience when moving to production. Here's a checklist of things you need to do before switching to production mode:
 
 ## Domains
 
-By default, Stack allows all localhost paths as valid callback URLs. This is convenient for development but poses a security risk in production because attackers could use their own domains as callback URLs to intercept sensitive information. Therefore, in production, Stack must know your domain (e.g., `https://your-website.com`) and only allow callbacks from those domains.
+By default, Hexclave allows all localhost paths as valid callback URLs. This is convenient for development but poses a security risk in production because attackers could use their own domains as callback URLs to intercept sensitive information. Therefore, in production, Hexclave must know your domain (e.g., `https://your-website.com`) and only allow callbacks from those domains.
 
 Follow these steps when you're ready to push your application to production:
 
 <Steps>
   <Step title="Add Your Domain">
-    Navigate to the `Domain & Handlers` tab in the Stack dashboard. If you haven't configured your handler, you can leave it as the default. (Learn more about handlers [here](/sdk/objects/stack-app)).
+    Navigate to the `Domain & Handlers` tab in the Hexclave dashboard. If you haven't configured your handler, you can leave it as the default. (Learn more about handlers [here](/sdk/objects/stack-app)).
   </Step>
   <Step title="Disable Localhost Callbacks">
     For enhanced security, disable the `Allow all localhost callbacks for development` option.
@@ -23,13 +23,13 @@ Follow these steps when you're ready to push your application to production:
 
 ## OAuth providers
 
-Stack uses shared OAuth keys for development to simplify setup when using "Sign in with Google/GitHub/etc." However, this isn't secure for production as it displays "Stack Development" on the providers' consent screens, making it unclear to users if the OAuth request is genuinely from your site. Thus, you should configure your own OAuth keys with the providers and connect them to Stack.
+Hexclave uses shared OAuth keys for development to simplify setup when using "Sign in with Google/GitHub/etc." However, this isn't secure for production as it displays "Hexclave Development" on the providers' consent screens, making it unclear to users if the OAuth request is genuinely from your site. Thus, you should configure your own OAuth keys with the providers and connect them to Hexclave.
 
 To use your own OAuth provider setups in production, follow these steps for each provider you use:
 
 <Steps>
   <Step title="Create an OAuth App">
-    On the provider's website, create an OAuth app and set the callback URL to the corresponding Stack callback URL. Copy the client ID and client secret.
+    On the provider's website, create an OAuth app and set the callback URL to the corresponding Hexclave callback URL. Copy the client ID and client secret.
 
     <Tabs>
       <Tab title="Google">
@@ -116,19 +116,19 @@ To use your own OAuth provider setups in production, follow these steps for each
     </Tabs>
   </Step>
   <Step title="Enter OAuth Credentials">
-    Go to the `Auth Methods` section in the Stack dashboard, open the provider's settings, switch from shared keys to custom keys, and enter the client ID and client secret.
+    Go to the `Auth Methods` section in the Hexclave dashboard, open the provider's settings, switch from shared keys to custom keys, and enter the client ID and client secret.
   </Step>
 </Steps>
 
 ## Email server
 
-For development, Stack uses a shared email server, which sends emails from Stack's domain. This is not ideal for production as users may not trust emails from an unfamiliar domain. You should set up an email server connected to your own domain.
+For development, Hexclave uses a shared email server, which sends emails from Hexclave's domain. This is not ideal for production as users may not trust emails from an unfamiliar domain. You should set up an email server connected to your own domain.
 
-Steps to connect your own email server with Stack:
+Steps to connect your own email server with Hexclave:
 
-1. **Setup Email Server**: Configure your own email server and connect it to your domain (this step is beyond Stack's documentation scope).
-2. **Configure Stack's Email Settings**: Navigate to the `Emails` section in the Stack dashboard, click `Edit` in the `Email Server` section, switch from `Shared` to `Custom SMTP server`, enter your SMTP configurations, and save.
+1. **Setup Email Server**: Configure your own email server and connect it to your domain (this step is beyond Hexclave's documentation scope).
+2. **Configure Hexclave's Email Settings**: Navigate to the `Emails` section in the Hexclave dashboard, click `Edit` in the `Email Server` section, switch from `Shared` to `Custom SMTP server`, enter your SMTP configurations, and save.
 
 ## Enabling production mode
 
-After completing the steps above, you can enable production mode on the `Project Settings` tab in the Stack dashboard, ensuring that your website runs securely with Stack in a production environment.
+After completing the steps above, you can enable production mode on the `Project Settings` tab in the Hexclave dashboard, ensuring that your website runs securely with Hexclave in a production environment.

--- a/docs-mintlify/guides/apps/payments/overview.mdx
+++ b/docs-mintlify/guides/apps/payments/overview.mdx
@@ -1,12 +1,12 @@
 ---
 title: "Payments"
-description: "Accept payments and manage billing with Stack Auth's Stripe integration"
+description: "Accept payments and manage billing with Hexclave's Stripe integration"
 icon: "/images/app-icons/payments.svg"
 ---
 
 import { PaymentsConcepts } from "/snippets/payments-concepts.jsx";
 
-Stack Auth includes a Payments app that handles billing, subscriptions, and one-time purchases through Stripe. Instead of building your own billing system, you define products in the dashboard and Stack Auth takes care of checkout, entitlement tracking, subscription lifecycle, and invoicing.
+Hexclave includes a Payments app that handles billing, subscriptions, and one-time purchases through Stripe. Instead of building your own billing system, you define products in the dashboard and Hexclave takes care of checkout, entitlement tracking, subscription lifecycle, and invoicing.
 
 This guide walks through how to set up payments, sell products, manage subscriptions, and work with item-based entitlements like credits or seats.
 
@@ -25,7 +25,7 @@ This guide walks through how to set up payments, sell products, manage subscript
 </Steps>
 
 <Info>
-  Stack Auth Payments is currently only available for US-based businesses. Support for other countries is coming soon.
+  Hexclave Payments is currently only available for US-based businesses. Support for other countries is coming soon.
 </Info>
 
 ## Core concepts
@@ -46,7 +46,7 @@ And the typical flow to make it all work:
 
 1. You define products and items in the dashboard
 2. Your app generates a checkout URL and redirects the user to Stripe
-3. The user pays, Stripe notifies Stack Auth, and the product is granted
+3. The user pays, Stripe notifies Hexclave, and the product is granted
 4. Your app reads the customer's products and item balances to control access
 
 ## Defining products
@@ -379,7 +379,7 @@ If you have a reference to the user object already, you can also call `user.gran
 
 ## Customer types
 
-Stack Auth supports three types of payment customers:
+Hexclave supports three types of payment customers:
 
 - **Users** - Individual user accounts. Users can manage their own purchases, billing, and invoices from the client SDK.
 - **Teams** - Team or organization accounts. Team admins can create checkouts, switch plans, and cancel subscriptions for their team.
@@ -411,7 +411,7 @@ These apply to both one-time purchases and subscription renewals. Customize them
 
 During development, enable test mode in **Payments -> Settings**. All purchases will be free and no real money is charged - products are granted immediately without going through Stripe.
 
-When you're ready to test with real Stripe flows (but still using test credentials), disable Stack's test mode and use Stripe's test card numbers:
+When you're ready to test with real Stripe flows (but still using test credentials), disable Hexclave's test mode and use Stripe's test card numbers:
 
 - **Success**: `4242 4242 4242 4242`
 - **Decline**: `4000 0000 0000 0002`

--- a/docs-mintlify/guides/apps/rbac/overview.mdx
+++ b/docs-mintlify/guides/apps/rbac/overview.mdx
@@ -9,7 +9,7 @@ Permissions are a way to control what each user can do and access within your ap
 
 ## Permission Types
 
-Stack supports two types of permissions:
+Hexclave supports two types of permissions:
 
 1. **Team Permissions**: Control what a user can do within a specific team
 2. **User Permissions**: Control what a user can do globally, across the entire project
@@ -18,17 +18,17 @@ Both permission types can be managed from the dashboard, and both support arbitr
 
 ## Team Permissions
 
-Team permissions control what a user can do within each team. You can create and assign permissions to team members from the Stack dashboard. These permissions could include actions like `create_post` or `read_secret_info`, or roles like `admin` or `moderator`. Within your app, you can verify if a user has a specific permission within a team.
+Team permissions control what a user can do within each team. You can create and assign permissions to team members from the Hexclave dashboard. These permissions could include actions like `create_post` or `read_secret_info`, or roles like `admin` or `moderator`. Within your app, you can verify if a user has a specific permission within a team.
 
 Permissions can be nested to create a hierarchical structure. For example, an `admin` permission can include both `moderator` and `user` permissions. We provide tools to help you verify whether a user has a permission directly or indirectly.
 
 ### Creating a Permission
 
-To create a new permission, navigate to the `Team Permissions` section of the Stack dashboard. You can select the permissions that the new permission will contain. Any permissions included within these selected permissions will also be recursively included.
+To create a new permission, navigate to the `Team Permissions` section of the Hexclave dashboard. You can select the permissions that the new permission will contain. Any permissions included within these selected permissions will also be recursively included.
 
 ### System Permissions
 
-Stack comes with a few predefined team permissions known as system permissions. These permissions start with a dollar sign (`$`). While you can assign these permissions to members or include them within other permissions, you cannot modify them as they are integral to the Stack backend system.
+Hexclave comes with a few predefined team permissions known as system permissions. These permissions start with a dollar sign (`$`). While you can assign these permissions to members or include them within other permissions, you cannot modify them as they are integral to the Hexclave backend system.
 
 ### Checking if a User has a Permission
 
@@ -144,7 +144,7 @@ Project permissions are global permissions that apply to a user across the entir
 
 ### Creating a Project Permission
 
-To create a new project permission, navigate to the `Project Permissions` section of the Stack dashboard. Similar to team permissions, you can select other permissions that the new permission will contain, creating a hierarchical structure.
+To create a new project permission, navigate to the `Project Permissions` section of the Hexclave dashboard. Similar to team permissions, you can select other permissions that the new permission will contain, creating a hierarchical structure.
 
 ### Checking if a User has a Project Permission
 

--- a/docs-mintlify/guides/apps/teams/overview.mdx
+++ b/docs-mintlify/guides/apps/teams/overview.mdx
@@ -83,9 +83,9 @@ You can list all teams a user belongs to using the `listTeams` or `useTeams` fun
 
 ## Creating a team
 
-To create a team, use the `createTeam` function on the `User` object. The user will be added to the team with the default team creator permissions (You can change this on the permissions tab in the Stack dashboard).
+To create a team, use the `createTeam` function on the `User` object. The user will be added to the team with the default team creator permissions (You can change this on the permissions tab in the Hexclave dashboard).
 
-On the client side, this requires enabling the "client side team creation" on the team settings tab in the Stack dashboard.
+On the client side, this requires enabling the "client side team creation" on the team settings tab in the Hexclave dashboard.
 
 ```jsx
 const team = await user.createTeam({

--- a/docs-mintlify/guides/apps/teams/team-selection.mdx
+++ b/docs-mintlify/guides/apps/teams/team-selection.mdx
@@ -19,7 +19,7 @@ While the current team method can be simpler to implement, it has a downside. If
 
 ## Selected Team Switcher
 
-To facilitate team selection, Stack provides a component that looks like this:
+To facilitate team selection, Hexclave provides a component that looks like this:
 
 <Frame>
   <img src="/images/team-switcher.png" alt="TeamSwitcher" />

--- a/docs-mintlify/guides/apps/webhooks/overview.mdx
+++ b/docs-mintlify/guides/apps/webhooks/overview.mdx
@@ -1,16 +1,16 @@
 ---
 title: "Webhooks"
-description: "Receive real-time updates when events occur in your Stack project"
+description: "Receive real-time updates when events occur in your Hexclave project"
 icon: "/images/app-icons/webhooks.svg"
 ---
 
-Webhooks are a powerful way to keep your backend in sync with Stack. They allow you to receive real-time updates when events occur in your Stack project, such as when a user or team is created, updated, or deleted.
+Webhooks are a powerful way to keep your backend in sync with Hexclave. They allow you to receive real-time updates when events occur in your Hexclave project, such as when a user or team is created, updated, or deleted.
 
 For payload schemas and each webhook event, see the [webhook API reference](/api/webhooks/users/usercreated).
 
 ## Setting up webhooks
 
-In the Stack dashboard, you can create a webhook endpoint in the "Webhooks" section. After creating this endpoint with your server URL, you will start receiving POST requests with a JSON payload at that endpoint. The event payload will look something like this:
+In the Hexclave dashboard, you can create a webhook endpoint in the "Webhooks" section. After creating this endpoint with your server URL, you will start receiving POST requests with a JSON payload at that endpoint. The event payload will look something like this:
 
 ```json
 {
@@ -29,9 +29,9 @@ You can use services like [Svix Playground](https://www.svix.com/play/) or [Webh
 
 ## Verifying webhooks
 
-To ensure the webhook is coming from Stack (and not from a malicious actor) and is not prone to replay attacks, you should verify the request.
+To ensure the webhook is coming from Hexclave (and not from a malicious actor) and is not prone to replay attacks, you should verify the request.
 
-Stack signs the webhook payload with a secret key that you can find in the endpoint details on the dashboard. You can verify the signature using the Svix client library. Check out the [Svix documentation](https://docs.svix.com/receiving/verifying-payloads/how) for instructions on how to verify the signature in JavaScript, Python, Ruby, and other languages. Here are example handlers across the supported frameworks:
+Hexclave signs the webhook payload with a secret key that you can find in the endpoint details on the dashboard. You can verify the signature using the Svix client library. Check out the [Svix documentation](https://docs.svix.com/receiving/verifying-payloads/how) for instructions on how to verify the signature in JavaScript, Python, Ruby, and other languages. Here are example handlers across the supported frameworks:
 
 <CodeGroup dropdown>
 ```tsx Next.js

--- a/docs-mintlify/guides/faq.mdx
+++ b/docs-mintlify/guides/faq.mdx
@@ -1,6 +1,6 @@
 ---
 title: FAQ
-description: Frequently asked questions about Stack
+description: Frequently asked questions about Hexclave
 sidebarTitle: FAQ
 ---
 
@@ -10,14 +10,14 @@ sidebarTitle: FAQ
 
 <AccordionGroup>
   <Accordion title="What languages are supported?">
-    For frontends, Stack supports TypeScript and JavaScript. For backends, Stack has a flexible [REST API](/api/overview) that can be used with any language or framework.
+    For frontends, Hexclave supports TypeScript and JavaScript. For backends, Hexclave has a flexible [REST API](/api/overview) that can be used with any language or framework.
   </Accordion>
 
-  <Accordion title="Can I use Stack with other JavaScript frameworks, like Astro or Angular?">
+  <Accordion title="Can I use Hexclave with other JavaScript frameworks, like Astro or Angular?">
     Yes! You can use our vanilla JavaScript SDK, or, if the framework is React-based, our React SDK.
   </Accordion>
 
-  <Accordion title="Can I use Stack with the Next.js pages router?">
+  <Accordion title="Can I use Hexclave with the Next.js pages router?">
     Only the Next.js app router is currently officially supported, although some members of the community have successfully used the React or vanilla JavaScript SDKs with the pages router.
   </Accordion>
 </AccordionGroup>
@@ -32,10 +32,10 @@ sidebarTitle: FAQ
     - Is `<X>` developer-friendly, well-documented, and lets you get started in minutes?
     - Besides authentication, does `<X>` also do authorization and user management (see feature list below)?
 
-    If you answered "no" to any of these questions, then that's how Stack Auth is different from `<X>`.
+    If you answered "no" to any of these questions, then that's how Hexclave is different from `<X>`.
   </Accordion>
 
-  <Accordion title="Can I migrate my existing userbase to Stack Auth?">
+  <Accordion title="Can I migrate my existing userbase to Hexclave?">
     Yes! You can [create users programmatically](/api/server/users/create-user) using our [REST API](/api/overview).
   </Accordion>
 </AccordionGroup>

--- a/docs-mintlify/guides/getting-started/ai-integration.mdx
+++ b/docs-mintlify/guides/getting-started/ai-integration.mdx
@@ -1,13 +1,13 @@
 ---
-title: Using Stack Auth with AI
-description: Integrate Stack Auth with AI-powered tools and services
-sidebarTitle: Using Stack Auth with AI
+title: Using Hexclave with AI
+description: Integrate Hexclave with AI-powered tools and services
+sidebarTitle: Using Hexclave with AI
 ---
 
 <Note>
-  This page is for using Stack Auth's CLI and integrating Stack Auth with your own AI tools.
+  This page is for using Hexclave's CLI and integrating Hexclave with your own AI tools.
 
-  If you would like to use Stack Auth to power your own CLI, see the [CLI Authentication](/guides/apps/authentication/cli-authentication) page.
+  If you would like to use Hexclave to power your own CLI, see the [CLI Authentication](/guides/apps/authentication/cli-authentication) page.
 </Note>
 
 TODO stub

--- a/docs-mintlify/guides/getting-started/setup.mdx
+++ b/docs-mintlify/guides/getting-started/setup.mdx
@@ -1,6 +1,6 @@
 ---
 title: Setup
-description: Install and configure Stack Auth for your project
+description: Install and configure Hexclave for your project
 sidebarTitle: Setup
 ---
 
@@ -10,7 +10,7 @@ sidebarTitle: Setup
 
 Before getting started, make sure you have a project set up for your chosen platform:
 
-- **Next.js**: A [Next.js project](https://nextjs.org/docs/getting-started/installation) using the app router (Stack Auth does not support the pages router on Next.js)
+- **Next.js**: A [Next.js project](https://nextjs.org/docs/getting-started/installation) using the app router (Hexclave does not support the pages router on Next.js)
 - **React**: A [React project](https://react.dev/learn/creating-a-react-app) (we show examples with Vite)
 - **JavaScript**: A Node.js project with Express
 - **Python**: A Python environment with your chosen framework (Django, FastAPI, or Flask)
@@ -27,7 +27,7 @@ We recommend using our **setup wizard** for JavaScript frameworks for a seamless
   The setup wizard is available for JavaScript/TypeScript frameworks. For Python projects, please use the manual installation method.
 </Info>
 
-Run Stack's installation wizard with the following command:
+Run Hexclave's installation wizard with the following command:
 
 ```sh title="Terminal"
 npx @stackframe/stack-cli@latest init
@@ -35,7 +35,7 @@ npx @stackframe/stack-cli@latest init
 
 #### Update API keys
 
-Create an account on [the Stack Auth dashboard](https://app.stack-auth.com/projects), create a new project, and copy its environment variables into the appropriate configuration file. If your project requires publishable client keys, create a project key that includes one and copy that as well.
+Create an account on [the Hexclave dashboard](https://app.stack-auth.com/projects), create a new project, and copy its environment variables into the appropriate configuration file. If your project requires publishable client keys, create a project key that includes one and copy that as well.
 
 <Tabs>
   <Tab title="Next.js">
@@ -72,7 +72,7 @@ That's it! The wizard should have created or updated the following files in your
   <Tab title="Next.js">
     - `app/handler/[...stack]/page.tsx`: Default pages for sign-in, sign-out, account settings, and more
     - `app/layout.tsx`: Updated to wrap the entire body with `StackProvider` and `StackTheme`
-    - `app/loading.tsx`: Suspense boundary for Stack's async hooks
+    - `app/loading.tsx`: Suspense boundary for Hexclave's async hooks
     - `stack/server.ts`: Contains the `stackServerApp` for server-side usage
     - `stack/client.ts`: Contains the `stackClientApp` for client-side usage
   </Tab>
@@ -93,7 +93,7 @@ That's it! The wizard should have created or updated the following files in your
 
 <Steps>
   <Step title="Install package">
-    First, install the appropriate Stack package:
+    First, install the appropriate Hexclave package:
 
     <Tabs>
       <Tab title="Next.js">
@@ -135,7 +135,7 @@ That's it! The wizard should have created or updated the following files in your
   </Step>
 
   <Step title="Create API keys">
-    [Register a new account on Stack](https://app.stack-auth.com/handler/sign-up), create a project in the dashboard, and copy the project ID. If your project requires publishable client keys, also create a project key from the left sidebar and copy the publishable client key. For server-side setups, also copy the secret server key.
+    [Register a new account on Hexclave](https://app.stack-auth.com/handler/sign-up), create a project in the dashboard, and copy the project ID. If your project requires publishable client keys, also create a project key from the left sidebar and copy the publishable client key. For server-side setups, also copy the secret server key.
   </Step>
 
   <Step title="Configure environment variables">
@@ -200,8 +200,8 @@ That's it! The wizard should have created or updated the following files in your
     </Tabs>
   </Step>
 
-  <Step title="Create Stack configuration">
-    Create the Stack app configuration:
+  <Step title="Create Hexclave configuration">
+    Create the Hexclave app configuration:
 
     <Tabs>
       <Tab title="Next.js (server)">
@@ -291,7 +291,7 @@ That's it! The wizard should have created or updated the following files in your
                 **kwargs,
             )
             if res.status_code >= 400:
-                raise Exception(f"Stack Auth API request failed with {res.status_code}: {res.text}")
+                raise Exception(f"Hexclave API request failed with {res.status_code}: {res.text}")
             return res.json()
         ```
       </Tab>
@@ -313,7 +313,7 @@ That's it! The wizard should have created or updated the following files in your
                 **kwargs,
             )
             if res.status_code >= 400:
-                raise Exception(f"Stack Auth API request failed with {res.status_code}: {res.text}")
+                raise Exception(f"Hexclave API request failed with {res.status_code}: {res.text}")
             return res.json()
         ```
       </Tab>
@@ -335,7 +335,7 @@ That's it! The wizard should have created or updated the following files in your
                 **kwargs,
             )
             if res.status_code >= 400:
-                raise Exception(f"Stack Auth API request failed with {res.status_code}: {res.text}")
+                raise Exception(f"Hexclave API request failed with {res.status_code}: {res.text}")
             return res.json()
         ```
       </Tab>
@@ -404,7 +404,7 @@ That's it! The wizard should have created or updated the following files in your
   </Step>
 
   <Step title="Add providers (Next.js and React only)">
-    For Next.js and React, wrap your app with Stack providers:
+    For Next.js and React, wrap your app with Hexclave providers:
 
     <Tabs>
       <Tab title="Next.js">
@@ -472,7 +472,7 @@ That's it! The wizard should have created or updated the following files in your
 
 ## Post-setup
 
-That's it! Stack is now configured in your project.
+That's it! Hexclave is now configured in your project.
 
 ### Testing your setup
 
@@ -515,7 +515,7 @@ That's it! Stack is now configured in your project.
   </Tab>
   <Tab title="Django">
     ```python title="Terminal"
-    # Test the Stack Auth API connection
+    # Test the Hexclave API connection
     print(stack_auth_request('GET', '/api/v1/projects/current'))
 
     # Start your Django server
@@ -524,7 +524,7 @@ That's it! Stack is now configured in your project.
   </Tab>
   <Tab title="FastAPI">
     ```python title="Terminal"
-    # Test the Stack Auth API connection
+    # Test the Hexclave API connection
     print(stack_auth_request('GET', '/api/v1/projects/current'))
 
     # Start your FastAPI server
@@ -533,7 +533,7 @@ That's it! Stack is now configured in your project.
   </Tab>
   <Tab title="Flask">
     ```python title="Terminal"
-    # Test the Stack Auth API connection
+    # Test the Hexclave API connection
     print(stack_auth_request('GET', '/api/v1/projects/current'))
 
     # Start your Flask server
@@ -544,19 +544,19 @@ That's it! Stack is now configured in your project.
 
 ### What you'll see
 
-For JavaScript frameworks with built-in UI components, you'll see the Stack Auth sign-up page:
+For JavaScript frameworks with built-in UI components, you'll see the Hexclave sign-up page:
 
 <Frame>
-  <img src="/images/sign-in.png" alt="Stack sign-in page" />
+  <img src="/images/sign-in.png" alt="Hexclave sign-in page" />
 </Frame>
 
 After signing up/in, you will be redirected back to the home page. You can also check out the account settings page.
 
 <Frame>
-  <img src="/images/account-settings.png" alt="Stack account settings page" />
+  <img src="/images/account-settings.png" alt="Hexclave account settings page" />
 </Frame>
 
-For Python and backend-only JavaScript setups, you'll interact with Stack Auth through the REST API.
+For Python and backend-only JavaScript setups, you'll interact with Hexclave through the REST API.
 
 ## Example usage
 

--- a/docs-mintlify/guides/getting-started/user-fundamentals.mdx
+++ b/docs-mintlify/guides/getting-started/user-fundamentals.mdx
@@ -7,7 +7,7 @@ sidebarTitle: User Fundamentals
 import { UserFieldsTable } from "/snippets/user-fields-table.jsx";
 
 
-You've set up Stack Auth. Now let's understand the most important object in your application: the **User**.
+You've set up Hexclave. Now let's understand the most important object in your application: the **User**.
 
 The user object represents whoever is currently interacting with your app — their identity, profile, and metadata. Almost everything you build will revolve around it: retrieving the current user, protecting pages from unauthorized access, updating profile information, signing out, and more.
 
@@ -107,7 +107,7 @@ Middleware can be used whenever it is easy to tell whether a page should be prot
 
     export const config = {
       // You can add your own route protection logic here
-      // Make sure not to protect the root URL, as it would prevent users from accessing static Next.js files or Stack's /handler path
+      // Make sure not to protect the root URL, as it would prevent users from accessing static Next.js files or Hexclave's /handler path
       matcher: '/protected/:path*',
     };
     ```
@@ -158,7 +158,7 @@ export default function MyClientComponent() {
 
 ### Custom metadata
 
-Beyond built-in fields like `displayName` and `primaryEmail`, you'll often need to store your own data on a user. Stack Auth provides three metadata fields for this:
+Beyond built-in fields like `displayName` and `primaryEmail`, you'll often need to store your own data on a user. Hexclave provides three metadata fields for this:
 
 - **`clientMetadata`** — Readable and writable from both the client and the server. Use this for non-sensitive user preferences like theme, locale, or UI state.
 - **`serverMetadata`** — Readable and writable only from the server. Use this for sensitive or internal data like Stripe customer IDs, internal flags, or anything users shouldn't be able to see or modify.
@@ -233,7 +233,7 @@ You can sign out the user by redirecting them to `/handler/sign-out` or simply b
 
 ## Example: Custom profile page
 
-Stack automatically creates a user profile on sign-up. Let's build a page that displays this information. In `app/profile/page.tsx`:
+Hexclave automatically creates a user profile on sign-up. Let's build a page that displays this information. In `app/profile/page.tsx`:
 
 <Tabs>
   <Tab title="Client Component">
@@ -301,9 +301,9 @@ For more examples on how to use the `User` object, check the [the SDK documentat
 
 ## Anonymous users
 
-Stack Auth supports anonymous users - users who can interact with your app without signing up. This is useful for features like guest checkouts, try-before-you-sign-up flows, or collecting analytics before a user creates an account.
+Hexclave supports anonymous users - users who can interact with your app without signing up. This is useful for features like guest checkouts, try-before-you-sign-up flows, or collecting analytics before a user creates an account.
 
-To get an anonymous user, pass `{ or: "anonymous" }` to `useUser()` or `getUser()`. If the current visitor isn't signed in, Stack will automatically create an anonymous account for them behind the scenes.
+To get an anonymous user, pass `{ or: "anonymous" }` to `useUser()` or `getUser()`. If the current visitor isn't signed in, Hexclave will automatically create an anonymous account for them behind the scenes.
 
 ```tsx title="my-client-component.tsx"
 "use client";

--- a/docs-mintlify/guides/going-further/backend-integration.mdx
+++ b/docs-mintlify/guides/going-further/backend-integration.mdx
@@ -1,14 +1,14 @@
 ---
 title: "Integrating with Backends"
-description: "Integrate Stack Auth with your own server with the REST APIs"
+description: "Integrate Hexclave with your own server with the REST APIs"
 sidebarTitle: "Integrating with Backends"
 ---
 
-To authenticate your endpoints, you need to send the user's access token in the headers of the request to your server, and then make a request to Stack's server API to verify the user's identity.
+To authenticate your endpoints, you need to send the user's access token in the headers of the request to your server, and then make a request to Hexclave's server API to verify the user's identity.
 
 ## Sending requests to your server endpoints
 
-To authenticate your own server endpoints using Stack's server API, you need to protect your endpoints by sending the user's access token in the headers of the request.
+To authenticate your own server endpoints using Hexclave's server API, you need to protect your endpoints by sending the user's access token in the headers of the request.
 
 On the client side, you can retrieve the access token from the `user` object by calling `user.getAuthJson()`. This will return an object containing `accessToken`.
 
@@ -26,10 +26,10 @@ const response = await fetch('/api/users/me', {
 
 ## Authenticating the user on the server endpoints
 
-Stack Auth provides two methods for authenticating users on your server endpoints:
+Hexclave provides two methods for authenticating users on your server endpoints:
 
 1. **JWT Verification**: A fast, lightweight approach that validates the user's token locally without making external requests. While efficient, it provides only essential user information encoded in the JWT.
-2. **REST API Verification**: Makes a request to Stack Auth's servers to validate the token and retrieve comprehensive user information. This method provides access to the complete, up-to-date user profile.
+2. **REST API Verification**: Makes a request to Hexclave's servers to validate the token and retrieve comprehensive user information. This method provides access to the complete, up-to-date user profile.
 
 ### Using JWT
 
@@ -92,8 +92,8 @@ Stack Auth provides two methods for authenticating users on your server endpoint
     const url = 'https://api.stack-auth.com/api/v1/users/me';
     const headers = {
       'x-stack-access-type': 'server',
-      'x-stack-project-id': 'generated on the Stack Auth dashboard',
-      'x-stack-secret-server-key': 'generated on the Stack Auth dashboard',
+      'x-stack-project-id': 'generated on the Hexclave dashboard',
+      'x-stack-secret-server-key': 'generated on the Hexclave dashboard',
       'x-stack-access-token': 'access token from the headers',
     };
 
@@ -112,8 +112,8 @@ Stack Auth provides two methods for authenticating users on your server endpoint
      url = 'https://api.stack-auth.com/api/v1/users/me'
      headers = {
        'x-stack-access-type': 'server',
-       'x-stack-project-id': 'generated on the Stack Auth dashboard',
-       'x-stack-secret-server-key': 'generated on the Stack Auth dashboard',
+       'x-stack-project-id': 'generated on the Hexclave dashboard',
+       'x-stack-secret-server-key': 'generated on the Hexclave dashboard',
        'x-stack-access-token': 'access token from the headers',
      }
 

--- a/docs-mintlify/guides/going-further/local-development.mdx
+++ b/docs-mintlify/guides/going-further/local-development.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Local Development"
-description: "Set up and run Stack Auth locally for development and testing"
+description: "Set up and run Hexclave locally for development and testing"
 ---
 
-This page is under construction. Check back soon for instructions on setting up Stack Auth for local development.
+This page is under construction. Check back soon for instructions on setting up Hexclave for local development.

--- a/docs-mintlify/guides/going-further/stack-app.mdx
+++ b/docs-mintlify/guides/going-further/stack-app.mdx
@@ -1,12 +1,12 @@
 ---
-title: "Stack App"
-description: "The most important object of your Stack project"
+title: "Hexclave App"
+description: "The most important object of your Hexclave project"
 sidebarTitle: "The StackApp Object"
 ---
 
 By now, you may have seen the `useStackApp()` hook and the `stackServerApp` variable. Both return a `StackApp`, of type `StackClientApp` and `StackServerApp` respectively.
 
-Nearly all of Stack's functionality is on your `StackApp` object. Think of this object as the "connection" from your code to Stack's servers. Each app is always associated with one specific project ID (by default the one found in your environment variables).
+Nearly all of Hexclave's functionality is on your `StackApp` object. Think of this object as the "connection" from your code to Hexclave's servers. Each app is always associated with one specific project ID (by default the one found in your environment variables).
 
 There is also a page on [StackApp](/sdk/objects/stack-app) in the SDK reference, which lists all available functions.
 

--- a/docs-mintlify/guides/going-further/user-metadata.mdx
+++ b/docs-mintlify/guides/going-further/user-metadata.mdx
@@ -1,9 +1,9 @@
 ---
 title: "User Metadata"
-description: "How to store custom user metadata in Stack Auth"
+description: "How to store custom user metadata in Hexclave"
 ---
 
-Stack Auth allows storing additional user information through three types of metadata fields:
+Hexclave allows storing additional user information through three types of metadata fields:
 
 1. **clientMetadata**: Readable and writable from a [client](/guides/going-further/stack-app#client-vs-server).
 2. **serverMetadata**: Readable and writable only from a [server](/guides/going-further/stack-app#client-vs-server).

--- a/docs-mintlify/guides/integrations/convex/overview.mdx
+++ b/docs-mintlify/guides/integrations/convex/overview.mdx
@@ -1,9 +1,9 @@
 ---
 title: Convex
-description: Integrate Stack Auth with Convex
+description: Integrate Hexclave with Convex
 ---
 
-This guide shows how to integrate Stack Auth with Convex.
+This guide shows how to integrate Hexclave with Convex.
 
 ### 1) Create a Convex + Next.js app
 
@@ -15,18 +15,18 @@ npm create convex@latest # make sure to choose "Next.js" and "No auth" when aske
 
 Then, run `npx convex dev` to start the Convex backend, and `npm run dev` to start the development server.
 
-### 2) Install Stack Auth
+### 2) Install Hexclave
 
-Next, install Stack Auth using the setup wizard:
+Next, install Hexclave using the setup wizard:
 
 ```bash
 cd my-app/  # replace with your app name
 npx @stackframe/stack-cli@latest init
 ```
 
-### 3) Create a Stack Auth project
+### 3) Create a Hexclave project
 
-[Create a new Stack Auth project](https://app.stack-auth.com). Get the project ID & API key environment variables from the dashboard.
+[Create a new Hexclave project](https://app.stack-auth.com). Get the project ID & API key environment variables from the dashboard.
 
 - Set the `.env.local` file to the environment variables.
 - In Convex, go to the dashboard of your project's deployment, and also set the environment variables there.
@@ -47,22 +47,22 @@ export default {
 }
 ```
 
-Then, update your Convex client to use Stack Auth:
+Then, update your Convex client to use Hexclave:
 
 ```ts
 convexClient.setAuth(stackClientApp.getConvexClientAuth({}));  // browser JS
 convexReactClient.setAuth(stackClientApp.getConvexClientAuth({}));  // React
-convexHttpClient.setAuth(stackClientApp.getConvexHttpClientAuth({ tokenStore: requestObject }));  // HTTP, see Stack Auth docs for more information on tokenStore
+convexHttpClient.setAuth(stackClientApp.getConvexHttpClientAuth({ tokenStore: requestObject }));  // HTTP, see Hexclave docs for more information on tokenStore
 ```
 
 ### 5) Done!
 
-Done! Now, you'll be able to access Stack Auth's functionality from your frontend & backend:
+Done! Now, you'll be able to access Hexclave's functionality from your frontend & backend:
 
 ```ts
 // MyPage.tsx
 export function MyPage() {
-  // see https://docs.stack-auth.com for more information on how to use Stack Auth
+  // see https://docs.stack-auth.com for more information on how to use Hexclave
   const user = useUser();
   return <div>Your email is {user.email}</div>;
 }
@@ -77,4 +77,4 @@ export const myQuery = query({
 });
 ```
 
-You can find the production-ready template with Stack-Auth, Convex & Shadcn pre-configured [here on GitHub](https://github.com/developing-gamer/next-convex-stack-template).
+You can find the production-ready template with Hexclave, Convex & Shadcn pre-configured [here on GitHub](https://github.com/developing-gamer/next-convex-stack-template).

--- a/docs-mintlify/guides/integrations/supabase/overview.mdx
+++ b/docs-mintlify/guides/integrations/supabase/overview.mdx
@@ -1,17 +1,17 @@
 ---
 title: Supabase
-description: Integrate Stack Auth with Supabase RLS
+description: Integrate Hexclave with Supabase RLS
 ---
 
-This guide shows how to integrate Stack Auth with Supabase row level security (RLS).
+This guide shows how to integrate Hexclave with Supabase row level security (RLS).
 
 <Info>
-This guide only focuses on the RLS/JWT integration and does not sync user data between Supabase and Stack. You should use [webhooks](/guides/apps/webhooks/overview) to achieve data sync.
+This guide only focuses on the RLS/JWT integration and does not sync user data between Supabase and Hexclave. You should use [webhooks](/guides/apps/webhooks/overview) to achieve data sync.
 </Info>
 
 ## Setup
 
-Let's create a sample table and some RLS policies to demonstrate how to integrate Stack Auth with Supabase RLS. You can apply the same logic to your own tables and policies.
+Let's create a sample table and some RLS policies to demonstrate how to integrate Hexclave with Supabase RLS. You can apply the same logic to your own tables and policies.
 
 <Steps>
   <Step title="Setup Supabase">
@@ -49,7 +49,7 @@ Let's create a sample table and some RLS policies to demonstrate how to integrat
   </Step>
 
   <Step title="Setup a new Next.js project">
-    Now let's create a new Next.js project and install Stack Auth and Supabase client. (more details on [Next.js setup](https://nextjs.org/docs/getting-started/installation), [Stack Auth setup](/guides/getting-started/setup), and [Supabase setup](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs))
+    Now let's create a new Next.js project and install Hexclave and Supabase client. (more details on [Next.js setup](https://nextjs.org/docs/getting-started/installation), [Hexclave setup](/guides/getting-started/setup), and [Supabase setup](https://supabase.com/docs/guides/getting-started/quickstarts/nextjs))
 
     ```bash title="Terminal"
     npx create-next-app@latest -e with-supabase stack-supabase
@@ -63,7 +63,7 @@ Let's create a sample table and some RLS policies to demonstrate how to integrat
     - `NEXT_PUBLIC_SUPABASE_ANON_KEY`
     - `SUPABASE_JWT_SECRET`
 
-    Copy environment variables from the Stack dashboard to the `.env.local` file.
+    Copy environment variables from the Hexclave dashboard to the `.env.local` file.
 
     - `NEXT_PUBLIC_STACK_PROJECT_ID`
     - `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`
@@ -71,7 +71,7 @@ Let's create a sample table and some RLS policies to demonstrate how to integrat
   </Step>
 
   <Step title="Set up Supabase client">
-    Now let's create a server action that mints a supabase JWT with the Stack Auth user ID if the user is authenticated.
+    Now let's create a server action that mints a supabase JWT with the Hexclave user ID if the user is authenticated.
 
     ```tsx title="/utils/actions.ts"
     'use server';

--- a/docs-mintlify/guides/integrations/vercel/overview.mdx
+++ b/docs-mintlify/guides/integrations/vercel/overview.mdx
@@ -1,13 +1,13 @@
 ---
 title: Vercel
-description: Deploy your Stack Auth project on Vercel with the dashboard integration flow.
+description: Deploy your Hexclave project on Vercel with the dashboard integration flow.
 ---
 
-This guide mirrors the Vercel integration flow in the Stack Auth dashboard app.
+This guide mirrors the Vercel integration flow in the Hexclave dashboard app.
 
 ## What this integration covers
 
-- Generate Stack Auth keys for your project
+- Generate Hexclave keys for your project
 - Add the required environment variables in Vercel
 - Redeploy and verify the auth flow
 
@@ -15,13 +15,13 @@ This guide mirrors the Vercel integration flow in the Stack Auth dashboard app.
 
 <Steps>
   <Step title="Open your Vercel project">
-    In the Vercel dashboard, open the project you want to connect to Stack Auth.
+    In the Vercel dashboard, open the project you want to connect to Hexclave.
 
     [Open Vercel dashboard](https://vercel.com/dashboard)
   </Step>
 
-  <Step title="Generate keys from Stack Auth">
-    In your Stack dashboard, open the **Vercel Integration** app and generate keys for your project.
+  <Step title="Generate keys from Hexclave">
+    In your Hexclave dashboard, open the **Vercel Integration** app and generate keys for your project.
 
     This produces a project ID plus API keys that you can paste into Vercel.
   </Step>
@@ -33,7 +33,7 @@ This guide mirrors the Vercel integration flow in the Stack Auth dashboard app.
     - `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY`
     - `STACK_SECRET_SERVER_KEY`
 
-    Add `NEXT_PUBLIC_STACK_API_URL` only if you are not using the default hosted Stack API.
+    Add `NEXT_PUBLIC_STACK_API_URL` only if you are not using the default hosted Hexclave API.
   </Step>
 
   <Step title="Redeploy">

--- a/docs-mintlify/guides/other/mcp-setup.mdx
+++ b/docs-mintlify/guides/other/mcp-setup.mdx
@@ -1,13 +1,13 @@
 ---
 title: MCP Setup
-description: Set up Stack Auth's Model Context Protocol (MCP) server for intelligent code assistance in your development environment.
+description: Set up Hexclave's Model Context Protocol (MCP) server for intelligent code assistance in your development environment.
 ---
 
-Set up Stack Auth's Model Context Protocol (MCP) server to get intelligent code assistance in your development environment.
+Set up Hexclave's Model Context Protocol (MCP) server to get intelligent code assistance in your development environment.
 
 <Tabs>
   <Tab title="Cursor">
-    Configure Stack Auth MCP in Cursor IDE for enhanced code assistance.
+    Configure Hexclave MCP in Cursor IDE for enhanced code assistance.
 
     ### Manual Installation
 
@@ -25,7 +25,7 @@ Set up Stack Auth's Model Context Protocol (MCP) server to get intelligent code 
   </Tab>
 
   <Tab title="VS Code">
-    Configure Stack Auth MCP in VS Code for enhanced code assistance.
+    Configure Hexclave MCP in VS Code for enhanced code assistance.
 
     ### Manual Installation
 
@@ -208,9 +208,9 @@ If you want to include instructions for all clients in your project's README.md 
 
 ## Features
 
-The Stack Auth MCP server provides:
+The Hexclave MCP server provides:
 
 - **Authentication Flow Assistance**: Get help implementing sign-in, sign-up, and user management
-- **API Documentation**: Access Stack Auth API documentation and examples
+- **API Documentation**: Access Hexclave API documentation and examples
 - **Code Generation**: Generate boilerplate code for common authentication patterns
 - **Best Practices**: Receive guidance on security best practices and implementation patterns

--- a/docs-mintlify/guides/other/self-host.mdx
+++ b/docs-mintlify/guides/other/self-host.mdx
@@ -1,32 +1,32 @@
 ---
 title: Self-host
-description: Deploy Stack Auth on your own infrastructure with full control over your authentication system.
+description: Deploy Hexclave on your own infrastructure with full control over your authentication system.
 ---
 
 <Danger>
-**If you self-host, YOU will be responsible for updating Stack Auth and its dependencies.** Security patches, bug fixes, and new features require manual updates on your infrastructure. If you would like premium support to help with this, [contact us](mailto:team@stack-auth.com).
+**If you self-host, YOU will be responsible for updating Hexclave and its dependencies.** Security patches, bug fixes, and new features require manual updates on your infrastructure. If you would like premium support to help with this, [contact us](mailto:team@stack-auth.com).
 </Danger>
 
-Stack Auth is fully open-source and can be self-hosted on your own infrastructure. This guide will introduce each component of the project and how to set them up.
+Hexclave is fully open-source and can be self-hosted on your own infrastructure. This guide will introduce each component of the project and how to set them up.
 
 <Info>
 If you are unsure whether you should self-host, here are some things to consider:
 
-- **Complexity**: Stack Auth is a complex project with many interdependent services. Self-hosting requires managing these services and ensuring they work together seamlessly.
-- **Updates**: Stack Auth is a rapidly evolving project with frequent feature and fix releases. Self-hosting requires you to manage updates and apply them timely.
+- **Complexity**: Hexclave is a complex project with many interdependent services. Self-hosting requires managing these services and ensuring they work together seamlessly.
+- **Updates**: Hexclave is a rapidly evolving project with frequent feature and fix releases. Self-hosting requires you to manage updates and apply them timely.
 - **Reliability**: Self-hosting requires you to ensure the reliability of your infrastructure. Downtimes and outages can be costly to handle.
 - **Security**: Self-hosting requires ensuring the security of your infrastructure. A compromised service can affect your users.
 
-For most users, we recommend using [Stack Auth's cloud hosted solution](https://app.stack-auth.com). However, if you understand the above challenges and are comfortable managing them, follow the instructions below to self-host!
+For most users, we recommend using [Hexclave's cloud hosted solution](https://app.stack-auth.com). However, if you understand the above challenges and are comfortable managing them, follow the instructions below to self-host!
 </Info>
 
 ## Services
 
-On a high level, Stack Auth is composed of the following services:
+On a high level, Hexclave is composed of the following services:
 
-- **API backend**: The core of Stack Auth, providing the REST API that the dashboard and your app connect to. This is what [api.stack-auth.com](https://api.stack-auth.com) provides.
+- **API backend**: The core of Hexclave, providing the REST API that the dashboard and your app connect to. This is what [api.stack-auth.com](https://api.stack-auth.com) provides.
 - **Dashboard**: The interface for managing users, teams, auth methods, etc. This is available at [app.stack-auth.com](https://app.stack-auth.com).
-- **Client SDK**: An SDK used to connect your app to the Stack Auth API backend, wrapping API calls and providing easy-to-use interfaces. More details [here](/guides/getting-started/setup).
+- **Client SDK**: An SDK used to connect your app to the Hexclave API backend, wrapping API calls and providing easy-to-use interfaces. More details [here](/guides/getting-started/setup).
 - **Postgres database**: Used to store all user data. We use [Prisma](https://prisma.io) as the ORM and manage the database schema migrations.
 - **Svix**: Used to send webhooks. Svix is open-source and can be self-hosted, but also offers a cloud hosted solution. More on Svix [here](https://svix.com)
 - **Email server**: We use [Inbucket](https://inbucket.org) as a local email server for development and a separate SMTP server for production. Any email service supporting SMTP will work.
@@ -34,7 +34,7 @@ On a high level, Stack Auth is composed of the following services:
 
 ## Run with Docker
 
-Stack Auth provides a [pre-configured Docker](https://hub.docker.com/r/stackauth/server) image that bundles the dashboard and API backend into a single container. To complete the setup, you'll need to provide your own PostgreSQL database, and optionally configure an email server and Svix instance for webhooks.
+Hexclave provides a [pre-configured Docker](https://hub.docker.com/r/stackauth/server) image that bundles the dashboard and API backend into a single container. To complete the setup, you'll need to provide your own PostgreSQL database, and optionally configure an email server and Svix instance for webhooks.
 
 1. Use a cloud hosted Postgres or start a example Postgres database. Don't use this setting in production:
 
@@ -42,7 +42,7 @@ Stack Auth provides a [pre-configured Docker](https://hub.docker.com/r/stackauth
 docker run -d --name db -e POSTGRES_USER=postgres -e POSTGRES_PASSWORD=password -e POSTGRES_DB=stackframe -p 5432:5432 postgres:latest
 ```
 
-2. Get the [example environment file](https://github.com/stack-auth/stack-auth/tree/main/docker/server/.env.example) and modify it to your needs (for security, you MUST edit at least the `STACK_SERVER_SECRET` value). You must also supply a `STACK_FREESTYLE_API_KEY` in order to send emails with Stack Auth (can be generated on [freestyle](https://freestyle.sh)). See the [full template here](https://github.com/stack-auth/stack-auth/blob/dev/docker/server/.env).
+2. Get the [example environment file](https://github.com/stack-auth/stack-auth/tree/main/docker/server/.env.example) and modify it to your needs (for security, you MUST edit at least the `STACK_SERVER_SECRET` value). You must also supply a `STACK_FREESTYLE_API_KEY` in order to send emails with Hexclave (can be generated on [freestyle](https://freestyle.sh)). See the [full template here](https://github.com/stack-auth/stack-auth/blob/dev/docker/server/.env).
 
 3. Run the Docker container:
 
@@ -60,7 +60,7 @@ For Linux users, you might need to add `--add-host=host.docker.internal:host-gat
 
 Now you can open the dashboard at [http://localhost:8101](http://localhost:8101) and the API backend on port 8102.
 
-Now, login with your admin account on the dashboard and follow the [normal setup process](/guides/getting-started/setup). Add `NEXT_PUBLIC_STACK_API_URL=https://your-backend-url.com` to your app's environment variables so that it connects to your API backend instead of the default Stack Auth API backend ([https://api.stack-auth.com](https://api.stack-auth.com)).
+Now, login with your admin account on the dashboard and follow the [normal setup process](/guides/getting-started/setup). Add `NEXT_PUBLIC_STACK_API_URL=https://your-backend-url.com` to your app's environment variables so that it connects to your API backend instead of the default Hexclave API backend ([https://api.stack-auth.com](https://api.stack-auth.com)).
 
 ## Local development
 
@@ -163,6 +163,6 @@ Now you can go to the dashboard (e.g., [https://your-dashboard-url.com](https://
 
 To manage your dashboard configs with this account, manually go into the database, find the user you just created, and add `{ managedProjectIds: ["internal"] }` to the `serverMetadata` jsonb column.
 
-Go back to the dashboard, refresh the page, and you should see the "Stack Dashboard" project. We recommend disabling new user sign-ups to your internal project to avoid unauthorized account and project creations.
+Go back to the dashboard, refresh the page, and you should see the "Hexclave Dashboard" project. We recommend disabling new user sign-ups to your internal project to avoid unauthorized account and project creations.
 
-Now, create a new project for your app and follow the [normal setup process](/guides/getting-started/setup). Add `NEXT_PUBLIC_STACK_API_URL=https://your-backend-url.com` to your app's environment variables so that it connects to your API backend instead of the default Stack Auth API backend ([https://api.stack-auth.com](https://api.stack-auth.com)).
+Now, create a new project for your app and follow the [normal setup process](/guides/getting-started/setup). Add `NEXT_PUBLIC_STACK_API_URL=https://your-backend-url.com` to your app's environment variables so that it connects to your API backend instead of the default Hexclave API backend ([https://api.stack-auth.com](https://api.stack-auth.com)).

--- a/docs-mintlify/guides/other/showcase.mdx
+++ b/docs-mintlify/guides/other/showcase.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Showcase"
-description: "See what others have built with Stack Auth"
+description: "See what others have built with Hexclave"
 ---
 
-This page is under construction. Check back soon for a showcase of projects and applications built with Stack Auth.
+This page is under construction. Check back soon for a showcase of projects and applications built with Hexclave.

--- a/docs-mintlify/guides/other/tutorials/build-a-saas-with-stack-auth.mdx
+++ b/docs-mintlify/guides/other/tutorials/build-a-saas-with-stack-auth.mdx
@@ -1,29 +1,29 @@
 ---
-title: Build a SaaS with Stack Auth
-description: Bootstrap auth, resolve the signed-in user, protect your app, and ship-with optional pointers to teams, RBAC, and billing.
+title: Build a SaaS with Hexclave
+description: Bootstrap auth, resolve the signed-in user, protect your app, and ship—with optional pointers to teams, RBAC, and billing.
 ---
 
-This tutorial is a **generic SaaS path** on Stack Auth: install and configure the SDK, wire sign-in, read the current user on the client and server, and gate your product. It does **not** assume teams, workspaces, or a particular permission model-those live in [Build a team-based app](/guides/other/tutorials/build-a-team-based-app) and the linked guides below.
+This tutorial is a **generic SaaS path** on Hexclave: install and configure the SDK, wire sign-in, read the current user on the client and server, and gate your product. It does **not** assume teams, workspaces, or a particular permission model—those live in [Build a team-based app](/guides/other/tutorials/build-a-team-based-app) and the linked guides below.
 
 ## What you will have at the end
 
-- A working sign-in and account flow using Stack Auth's handler routes (Next.js) or your framework’s equivalent.
+- A working sign-in and account flow using Hexclave's handler routes (Next.js) or your framework’s equivalent.
 - A clear pattern for **who** is signed in across server components, client components, server actions, and route handlers.
 - **Protected** areas of your app (for example middleware on `/app/*` or `getUser({ or: "redirect" })` on key routes).
 - A short map for **where** multi-tenant and authorization work fits when you need it, plus a mindset for **production** domains, OAuth, and email.
 
 ## Prerequisites
 
-- A **Next.js** project using the **App Router** (Stack’s first-class path for hosted UI and handlers), or another stack supported in [Setup](/guides/getting-started/setup) (React, Express, or REST from any backend).
-- A Stack Auth account and a **project** in the [dashboard](https://app.stack-auth.com/projects).
+- A **Next.js** project using the **App Router** (Hexclave's first-class path for hosted UI and handlers), or another stack supported in [Setup](/guides/getting-started/setup) (React, Express, or REST from any backend).
+- A Hexclave account and a **project** in the [dashboard](https://app.stack-auth.com/projects).
 
 <Note>
-  Stack does not officially support the Next.js Pages Router. If you are on Pages Router, consider the React or JavaScript SDKs per the [FAQ](/guides/faq).
+  Hexclave does not officially support the Next.js Pages Router. If you are on Pages Router, consider the React or JavaScript SDKs per the [FAQ](/guides/faq).
 </Note>
 
-The examples below focus on **Next.js (App Router)**. The same ideas apply on other stacks-swap in `StackClientApp` / REST calls as in [Setup](/guides/getting-started/setup).
+The examples below focus on **Next.js (App Router)**. The same ideas apply on other stacks—swap in `StackClientApp` / REST calls as in [Setup](/guides/getting-started/setup).
 
-## 1. Install Stack and wire environment variables
+## 1. Install Hexclave and wire environment variables
 
 The fastest path for JavaScript and TypeScript is the **setup wizard**:
 
@@ -45,7 +45,7 @@ After `init`, you should see files similar to:
 
 - `app/handler/[...stack]/page.tsx` - hosted sign-in, sign-up, account settings, and more
 - `app/layout.tsx` - wraps the app with `StackProvider` and `StackTheme`
-- `app/loading.tsx` - Suspense boundary for Stack’s async hooks
+- `app/loading.tsx` - Suspense boundary for Hexclave's async hooks
 - `stack/server.ts` - `stackServerApp` for server components, actions, and route handlers
 - `stack/client.ts` - `stackClientApp` when you need the client app object explicitly
 
@@ -208,7 +208,7 @@ Almost every SaaS screen starts from the **current user**: profile, preferences,
 
 ### Server action that requires a user
 
-`{ or: "throw" }` is useful when a redirect would be wrong (for example, from a form POST). The example below only needs Stack for identity; your own persistence layer stores product data keyed by `user.id`.
+`{ or: "throw" }` is useful when a redirect would be wrong (for example, from a form POST). The example below only needs Hexclave for identity; your own persistence layer stores product data keyed by `user.id`.
 
 ```tsx title="app/actions/onboarding.ts"
 "use server";
@@ -249,7 +249,7 @@ export async function GET() {
 
 ### Middleware for a `/app` (or `/private`) section
 
-Match only the routes that should be gated, and **exclude** `/handler` so Stack’s auth pages keep working:
+Match only the routes that should be gated, and **exclude** `/handler` so Hexclave's auth pages keep working:
 
 ```tsx title="middleware.ts"
 import { NextRequest, NextResponse } from "next/server";
@@ -276,16 +276,16 @@ More detail on protection patterns and sensitive HTML is in [User fundamentals](
 
 ## 3. Tenancy, teams, and permissions (when you need them)
 
-Stack gives you **users** and authentication primitives; **your** SaaS decides how rows and features map to customers.
+Hexclave gives you **users** and authentication primitives; **your** SaaS decides how rows and features map to customers.
 
 - **Single-user or simple B2C** - Often enough to key application data to `user.id` and enforce access in your API with the same user you resolved via `stackServerApp.getUser()`.
-- **Shared accounts, workspaces, or B2B orgs** - Use Stack **teams** as the customer boundary, **team selection** for the active workspace, and **RBAC** for roles and fine-grained actions. Walk through that shape in [Build a team-based app](/guides/other/tutorials/build-a-team-based-app), with reference material in [Teams](/guides/apps/teams/overview), [Team selection](/guides/apps/teams/team-selection), and [RBAC](/guides/apps/rbac/overview).
+- **Shared accounts, workspaces, or B2B orgs** - Use Hexclave **teams** as the customer boundary, **team selection** for the active workspace, and **RBAC** for roles and fine-grained actions. Walk through that shape in [Build a team-based app](/guides/other/tutorials/build-a-team-based-app), with reference material in [Teams](/guides/apps/teams/overview), [Team selection](/guides/apps/teams/team-selection), and [RBAC](/guides/apps/rbac/overview).
 
 Non-JavaScript or custom frontends can use the [REST API](/api/overview) with the same project keys; the identity model you choose (user-only vs teams) stays consistent across clients.
 
 ## 4. Product polish: onboarding, email, and optional billing
 
-Hook flows to the guides-no extra Stack APIs are required at this layer:
+Hook flows to the guides-no extra Hexclave APIs are required at this layer:
 
 - **Onboarding and sign-up rules** - [User onboarding](/guides/apps/authentication/user-onboarding), [Sign-up rules](/guides/apps/authentication/sign-up-rules)
 - **Email** - [Emails](/guides/apps/emails/overview)
@@ -302,7 +302,7 @@ Before going live, tighten **callback domains**, replace shared **OAuth** keys w
 | Topic | Guide |
 |--------|--------|
 | Install and configure | [Setup](/guides/getting-started/setup) |
-| `StackApp` object | [Stack App](/guides/going-further/stack-app) |
+| `StackApp` object | [Hexclave App](/guides/going-further/stack-app) |
 | Current user and page protection | [User fundamentals](/guides/getting-started/user-fundamentals) |
 | Teams, membership, and RBAC (deeper path) | [Build a team-based app](/guides/other/tutorials/build-a-team-based-app) |
 | Teams reference | [Teams](/guides/apps/teams/overview) |
@@ -322,7 +322,7 @@ Before going live, tighten **callback domains**, replace shared **OAuth** keys w
     Use dashboard-defined permissions for **authorization** when you use RBAC; always enforce **business rules** on the server: Server Components, server actions, route handlers, or your backend with the **secret server key** or validated access tokens. Client checks alone are not enough for sensitive operations.
   </Accordion>
 
-  <Accordion title="Can I use Stack only as a backend API?">
+  <Accordion title="Can I use Hexclave only as a backend API?">
     Yes. Non-JS or custom frontends can use the [REST API](/api/overview) with the same project keys; the mental model (users, and optionally teams and permissions) stays the same.
   </Accordion>
 

--- a/docs-mintlify/guides/other/tutorials/build-a-team-based-app.mdx
+++ b/docs-mintlify/guides/other/tutorials/build-a-team-based-app.mdx
@@ -5,7 +5,7 @@ description: Model B2B tenants as teams, wire team selection and deep links, enf
 
 This tutorial walks through a **multi-tenant** product where a **team** is the customer boundary (workspace, organization, account). You get membership-scoped team access, permission checks, team selection UX, and invitations.
 
-If you have not installed Stack yet (handler routes, `StackProvider`, environment variables), start with [Build a SaaS with Stack Auth](/guides/other/tutorials/build-a-saas-with-stack-auth), then continue here.
+If you have not installed Hexclave yet (handler routes, `StackProvider`, environment variables), start with [Build a SaaS with Hexclave](/guides/other/tutorials/build-a-saas-with-stack-auth), then continue here.
 
 ## What you will have at the end
 
@@ -17,7 +17,7 @@ If you have not installed Stack yet (handler routes, `StackProvider`, environmen
 
 ## Prerequisites
 
-- Stack Auth installed as in [Build a SaaS with Stack Auth](/guides/other/tutorials/build-a-saas-with-stack-auth) (Next.js App Router examples below assume `stackServerApp` in `stack/server.ts` and `@stackframe/stack` in the app).
+- Hexclave installed as in [Build a SaaS with Hexclave](/guides/other/tutorials/build-a-saas-with-stack-auth) (Next.js App Router examples below assume `stackServerApp` in `stack/server.ts` and `@stackframe/stack` in the app).
 - A project in the [dashboard](https://app.stack-auth.com/projects) where you can edit **Teams** and **Team permissions**.
 
 <Note>
@@ -26,11 +26,11 @@ If you have not installed Stack yet (handler routes, `StackProvider`, environmen
 
 ## 1. Turn on teams in the dashboard
 
-In your Stack project:
+In your Hexclave project:
 
 1. **Teams** - Enable team features and review defaults (for example whether a personal team is created on sign-up), per [Teams](/guides/apps/teams/overview).
 2. **Client-side team creation** - If the browser will call `user.createTeam`, enable client team creation in team settings (same guide).
-3. **Team permissions** - In **Team permissions**, define the actions your product needs (for example `export_reports`, nested under a role like `admin`). Add Stack **system** permissions where needed; their IDs start with `$` (for example `$invite_members`, `$read_members`, `$update_team`). See [RBAC](/guides/apps/rbac/overview).
+3. **Team permissions** - In **Team permissions**, define the actions your product needs (for example `export_reports`, nested under a role like `admin`). Add Hexclave **system** permissions where needed; their IDs start with `$` (for example `$invite_members`, `$read_members`, `$update_team`). See [RBAC](/guides/apps/rbac/overview).
 
 Keep client-side permission checks as **UX only**; always re-check on the server before changing data.
 
@@ -188,7 +188,7 @@ export async function provisionEmptyTeam(displayName: string) {
 
 ## 4. Team selection and deep links
 
-Stack tracks a **`selectedTeam`** on the user for “current workspace” UX. For B2B apps, **deep links** (`/team/[teamId]`) are usually recommended so shared URLs always refer to the same tenant; see [Team selection](/guides/apps/teams/team-selection).
+Hexclave tracks a **`selectedTeam`** on the user for “current workspace” UX. For B2B apps, **deep links** (`/team/[teamId]`) are usually recommended so shared URLs always refer to the same tenant; see [Team selection](/guides/apps/teams/team-selection).
 
 `SelectedTeamSwitcher` updates `selectedTeam` when `selectedTeam` is passed, optionally navigates via `urlMap`, and can skip updating stored selection with `noUpdateSelectedTeam`:
 
@@ -356,7 +356,7 @@ Teams support `clientMetadata`, `serverMetadata`, and `clientReadOnlyMetadata` o
 
 | Topic | Guide |
 |--------|--------|
-| Auth bootstrap and route protection | [Build a SaaS with Stack Auth](/guides/other/tutorials/build-a-saas-with-stack-auth) |
+| Auth bootstrap and route protection | [Build a SaaS with Hexclave](/guides/other/tutorials/build-a-saas-with-stack-auth) |
 | Teams API reference | [Teams](/guides/apps/teams/overview) |
 | `SelectedTeamSwitcher` and URL strategies | [Team selection](/guides/apps/teams/team-selection) |
 | Permission modeling and nesting | [RBAC](/guides/apps/rbac/overview) |
@@ -367,7 +367,7 @@ Teams support `clientMetadata`, `serverMetadata`, and `clientReadOnlyMetadata` o
 
 <AccordionGroup>
   <Accordion title="When should I use user.getTeam vs stackServerApp.getTeam?">
-    For product pages and APIs acting as the signed-in user, use **`(await stackServerApp.getUser()).getTeam(id)`** so membership is enforced by Stack. Use **`stackServerApp.getTeam`** only when you intentionally need **project-wide** team lookup (for example internal admin tools), then apply your own authorization.
+    For product pages and APIs acting as the signed-in user, use **`(await stackServerApp.getUser()).getTeam(id)`** so membership is enforced by Hexclave. Use **`stackServerApp.getTeam`** only when you intentionally need **project-wide** team lookup (for example internal admin tools), then apply your own authorization.
   </Accordion>
 
   <Accordion title="Why split the client export button into two components?">
@@ -375,6 +375,6 @@ Teams support `clientMetadata`, `serverMetadata`, and `clientReadOnlyMetadata` o
   </Accordion>
 
   <Accordion title="Do permissions replace checks in my database?">
-    Stack permissions answer **whether this Stack user may perform an action in this Stack team**. You should still scope **your** rows by `team.id` (or equivalent) and validate inputs-Stack does not replace your data model.
+    Hexclave permissions answer **whether this Hexclave user may perform an action in this Hexclave team**. You should still scope **your** rows by `team.id` (or equivalent) and validate inputs—Hexclave does not replace your data model.
   </Accordion>
 </AccordionGroup>

--- a/docs-mintlify/guides/other/tutorials/ship-production-ready-auth.mdx
+++ b/docs-mintlify/guides/other/tutorials/ship-production-ready-auth.mdx
@@ -1,11 +1,11 @@
 ---
 title: Ship Production-Ready Auth
-description: Lock down page and API access, handle secrets and environments, then align domains, OAuth, email, webhooks, and dashboard production mode with Stack Auth.
+description: Lock down page and API access, handle secrets and environments, then align domains, OAuth, email, webhooks, and dashboard production mode with Hexclave.
 ---
 
-Going live is not only “turning on production mode.” This guide focuses on **what must be true** so only signed-in users reach protected surfaces, **secrets stay server-only**, and Stack’s dev-friendly defaults are replaced with **your** domains, OAuth apps, and email.
+Going live is not only “turning on production mode.” This guide focuses on **what must be true** so only signed-in users reach protected surfaces, **secrets stay server-only**, and Hexclave's dev-friendly defaults are replaced with **your** domains, OAuth apps, and email.
 
-If you are still wiring Stack into your app, complete [Build a SaaS with Stack Auth](/guides/other/tutorials/build-a-saas-with-stack-auth) first. For team RBAC before launch, see [Build a team-based app](/guides/other/tutorials/build-a-team-based-app).
+If you are still wiring Hexclave into your app, complete [Build a SaaS with Hexclave](/guides/other/tutorials/build-a-saas-with-stack-auth) first. For team RBAC before launch, see [Build a team-based app](/guides/other/tutorials/build-a-team-based-app).
 
 ## What you will have at the end
 
@@ -42,7 +42,7 @@ You typically combine **one or more** of:
     };
     ```
 
-    Match **only** prefixes that should be gated. Do **not** blanket-match `/` or you can block static assets and Stack’s **`/handler`** routes (sign-in, sign-up, callbacks).
+    Match **only** prefixes that should be gated. Do **not** blanket-match `/` or you can block static assets and Hexclave's **`/handler`** routes (sign-in, sign-up, callbacks).
 
     If your project uses **custom handler base paths**, use the sign-in URL from `stackServerApp.urls.signIn` as the redirect target instead of hard-coding `/handler/sign-in` (it may be an absolute URL depending on configuration—`NextResponse.redirect` accepts that).
   </Tab>
@@ -106,7 +106,7 @@ Read the full discussion in [User fundamentals — Protecting a page](/guides/ge
 ## 2. Secrets, keys, and environments
 
 <Warning>
-  **`STACK_SECRET_SERVER_KEY`** (or `ssk_...`) must **only** exist in server-side environments (SSR, route handlers, server actions, your backend). Never prefix it with `NEXT_PUBLIC_`, never import it from code that runs in the browser, and never log it. See [Stack App](/guides/going-further/stack-app) and the [REST API overview](/api/overview).
+  **`STACK_SECRET_SERVER_KEY`** (or `ssk_...`) must **only** exist in server-side environments (SSR, route handlers, server actions, your backend). Never prefix it with `NEXT_PUBLIC_`, never import it from code that runs in the browser, and never log it. See [Hexclave App](/guides/going-further/stack-app) and the [REST API overview](/api/overview).
 </Warning>
 
 Practical split:
@@ -117,18 +117,18 @@ Practical split:
 | `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY` (if used) | Browser + server | Client-safe key where your project uses publishable keys. |
 | `STACK_SECRET_SERVER_KEY` | **Server only** | Elevated server SDK and REST **server** API. |
 
-Use **separate** Stack projects or at least **separate** env values for production vs staging when possible. Rotate keys from the dashboard if a secret is exposed.
+Use **separate** Hexclave projects or at least **separate** env values for production vs staging when possible. Rotate keys from the dashboard if a secret is exposed.
 
 ## 3. Domains, OAuth, email, and production mode
 
-Stack’s dev defaults (localhost callbacks, shared OAuth keys, shared mail) are convenient but **not** what you want for real users.
+Hexclave's dev defaults (localhost callbacks, shared OAuth keys, shared mail) are convenient but **not** what you want for real users.
 
 <Steps>
   <Step title="Domains and callbacks">
     Add your real **`https://…` origin** under **Domain & Handlers** and disable **Allow all localhost callbacks** when you no longer need local redirects against production configuration. Details: [Launch checklist — Domains](/guides/apps/launch-checklist/overview#domains).
   </Step>
   <Step title="OAuth providers">
-    Create **your own** OAuth clients per provider, set the provider callback URLs Stack documents, then paste **your** client ID and secret in the dashboard (leave shared keys for local dev only). Details: [Launch checklist — OAuth providers](/guides/apps/launch-checklist/overview#oauth-providers) and [Auth providers](/guides/apps/authentication/auth-providers).
+    Create **your own** OAuth clients per provider, set the provider callback URLs Hexclave documents, then paste **your** client ID and secret in the dashboard (leave shared keys for local dev only). Details: [Launch checklist — OAuth providers](/guides/apps/launch-checklist/overview#oauth-providers) and [Auth providers](/guides/apps/authentication/auth-providers).
   </Step>
   <Step title="Email">
     Point outbound mail at **your** SMTP/domain so magic links and invitations come from a domain users trust. Details: [Launch checklist — Email server](/guides/apps/launch-checklist/overview#email-server) and [Emails](/guides/apps/emails/overview).
@@ -140,12 +140,12 @@ Stack’s dev defaults (localhost callbacks, shared OAuth keys, shared mail) are
 
 ## 4. Webhooks
 
-If you consume Stack webhooks, **verify every payload** (for example with Svix and `STACK_WEBHOOK_SECRET`) before acting on events—treat unsigned or failed verification as `400`. Implementation patterns: [Webhooks](/guides/apps/webhooks/overview).
+If you consume Hexclave webhooks, **verify every payload** (for example with Svix and `STACK_WEBHOOK_SECRET`) before acting on events—treat unsigned or failed verification as `400`. Implementation patterns: [Webhooks](/guides/apps/webhooks/overview).
 
 ## 5. Before you flip traffic
 
 - **Smoke-test** sign-in, sign-up, password reset, and OAuth **on the production domain** after DNS and env vars are final.
-- **Confirm** redirect URLs in third-party consoles (OAuth, IdP) match the Stack callback URLs you use in prod.
+- **Confirm** redirect URLs in third-party consoles (OAuth, IdP) match the Hexclave callback URLs you use in prod.
 - **Align** session / cookie behavior with your hosting (same-site, HTTPS, reverse proxies) per your platform docs.
 - **Plan rollback**: keep prior env values or a maintenance window note so you can revert dashboard or env changes quickly.
 
@@ -153,10 +153,10 @@ If you consume Stack webhooks, **verify every payload** (for example with Svix a
 
 | Topic | Guide |
 |--------|--------|
-| First integration | [Build a SaaS with Stack Auth](/guides/other/tutorials/build-a-saas-with-stack-auth) |
+| First integration | [Build a SaaS with Hexclave](/guides/other/tutorials/build-a-saas-with-stack-auth) |
 | Page protection details | [User fundamentals](/guides/getting-started/user-fundamentals) |
 | Domains, OAuth, email, prod mode | [Launch checklist](/guides/apps/launch-checklist/overview) |
-| `StackServerApp` and keys | [Stack App](/guides/going-further/stack-app) |
+| `StackServerApp` and keys | [Hexclave App](/guides/going-further/stack-app) |
 | Webhook verification | [Webhooks](/guides/apps/webhooks/overview) |
 | REST from your backend | [API overview](/api/overview) |
 
@@ -167,7 +167,7 @@ If you consume Stack webhooks, **verify every payload** (for example with Svix a
     Middleware runs on **matching routes** and is great for coarse “must be logged in” gates. **Route handlers** and **server actions** should still call `getUser({ or: "throw" })` (or equivalent) and return proper HTTP errors—middleware will not run for every internal call path, and **authorization** (what that user may do) belongs next to your business logic.
   </Accordion>
 
-  <Accordion title="Should production and development share one Stack project?">
+  <Accordion title="Should production and development share one Hexclave project?">
     Prefer **separate projects** (or strictly separated keys and OAuth clients) so you never point production OAuth callbacks at localhost, and so a leaked dev key cannot touch production data.
   </Accordion>
 

--- a/docs-mintlify/index.mdx
+++ b/docs-mintlify/index.mdx
@@ -1,6 +1,6 @@
 ---
 title: "Welcome"
-description: "Stack Auth documentation for setup, components, SDK usage, and REST APIs."
+description: "Hexclave documentation for setup, components, SDK usage, and REST APIs."
 sidebarTitle: "Overview"
 ---
 
@@ -84,7 +84,7 @@ export const ChipLink = ({ href, children }) => (
       <div className="absolute -left-[2.55rem] top-0.5 h-4 w-4 rounded-full border-2 border-[#6b5df7] bg-[#6b5df7]" />
       <SectionLink href="/api/overview">REST API</SectionLink>
       <p className="mt-1 text-sm text-slate-500 dark:text-slate-400">
-        Integrate Stack Auth from any backend or language through HTTP endpoints and webhook flows.
+        Integrate Hexclave from any backend or language through HTTP endpoints and webhook flows.
       </p>
       <div className="mt-3 flex flex-wrap gap-2">
         <ChipLink href="/api/overview">Overview</ChipLink>

--- a/docs-mintlify/sdk/objects/stack-app.mdx
+++ b/docs-mintlify/sdk/objects/stack-app.mdx
@@ -52,12 +52,12 @@ type StackClientApp = {
 
 Creates a new `StackClientApp` instance.
 
-Because each app creates a new connection to Stack Auth's backend, you should re-use existing instances wherever possible.
+Because each app creates a new connection to Hexclave's backend, you should re-use existing instances wherever possible.
 
 <Info>
 This object is not usually constructed directly. More commonly, you would construct a [`StackServerApp`](#stackserverapp) instead, pass it into your app setup (see the [setup guide](/guides/getting-started/setup)), and then use the `useStackApp()` hook to obtain a `StackClientApp`.
 
-The [setup wizard](/guides/getting-started/setup) does these steps for you, so you don't need to worry about it unless you are manually setting up Stack Auth.
+The [setup wizard](/guides/getting-started/setup) does these steps for you, so you don't need to worry about it unless you are manually setting up Hexclave.
 
 If you're building a client-only app and don't have a `SECRET_SERVER_KEY`, you can construct a `StackClientApp` directly.
 
@@ -71,7 +71,7 @@ If you're building a client-only app and don't have a `SECRET_SERVER_KEY`, you c
       </ParamField>
 
       <ParamField body="baseUrl" type="string">
-        Base URL for the Stack Auth API.
+        Base URL for the Hexclave API.
       </ParamField>
 
       <ParamField body="projectId" type="string">
@@ -544,7 +544,7 @@ Creates a new `StackServerApp` instance.
       </ParamField>
 
       <ParamField body="baseUrl" type="string">
-        Base URL for the Stack Auth API.
+        Base URL for the Hexclave API.
       </ParamField>
 
       <ParamField body="projectId" type="string">

--- a/docs-mintlify/sdk/overview.mdx
+++ b/docs-mintlify/sdk/overview.mdx
@@ -1,10 +1,10 @@
 ---
 title: "SDK Overview"
-description: "The SDK reference for Stack Auth's Next.js SDK."
+description: "The SDK reference for Hexclave's Next.js SDK."
 sidebarTitle: "Overview"
 ---
 
-This is the SDK reference for Stack Auth's Next.js SDK.
+This is the SDK reference for Hexclave's Next.js SDK.
 
 <Info>
 For setup instructions and how to use the SDK, see [Setup & Installation](/guides/getting-started/setup). If you are using a framework or programming language other than Next.js, you can use [our REST API](/api/overview).

--- a/docs-mintlify/sdk/types/api-key.mdx
+++ b/docs-mintlify/sdk/types/api-key.mdx
@@ -359,7 +359,7 @@ When creating an API key using [`user.createApiKey()`](/sdk/types/user#currentus
 
 <ParamField body="isPublic" type="boolean">
   Whether the API key is public. Defaults to `false`. **Secret API Keys** are
-  monitored by Stack Auth's secret scanner, which can revoke them if detected in
+  monitored by Hexclave's secret scanner, which can revoke them if detected in
   public code repositories. **Public API Keys** are designed for client-side
   code where exposure is not a concern.
 </ParamField>

--- a/docs-mintlify/sdk/types/customer.mdx
+++ b/docs-mintlify/sdk/types/customer.mdx
@@ -93,7 +93,7 @@ This interface is automatically available on:
 
       <ContentSection title="Parameters">
         <ParamField body="options.productId" type="string" required>
-          The ID of the product to purchase, as configured in your Stack Auth project settings.
+          The ID of the product to purchase, as configured in your Hexclave project settings.
         </ParamField>
 
         <ParamField body="options.returnUrl" type="string">
@@ -769,7 +769,7 @@ Returned by [`listInvoices()`](#customerlistinvoices) / [`useInvoices()`](#custo
     Stripe handles the payment process on their hosted page.
   </Step>
   <Step title="Webhook processing">
-    Stack Auth receives webhook notifications from Stripe.
+    Hexclave receives webhook notifications from Stripe.
   </Step>
   <Step title="Item allocation">
     Purchased items are automatically added to the customer's account.

--- a/docs-mintlify/sdk/types/email.mdx
+++ b/docs-mintlify/sdk/types/email.mdx
@@ -25,7 +25,7 @@ export const EmailSection = (props) => (
   />
 );
 
-This is a detailed reference for email-related types in Stack Auth. If you're looking for a more high-level overview, please refer to our [guide on the email system](/guides/apps/emails/overview).
+This is a detailed reference for email-related types in Hexclave. If you're looking for a more high-level overview, please refer to our [guide on the email system](/guides/apps/emails/overview).
 
 # `SendEmailOptions`
 
@@ -61,7 +61,7 @@ You must provide exactly one of `userIds` or `allUsers`.
 <EmailSection type="sendEmailOptions" property="userIds" defaultOpen={false}>
   <MethodLayout>
     <MethodContent>
-      An array of user IDs that will receive the email. All users must exist in your Stack Auth project. Cannot be used together with `allUsers`.
+      An array of user IDs that will receive the email. All users must exist in your Hexclave project. Cannot be used together with `allUsers`.
     </MethodContent>
     <MethodAside title="Type Definition">
       ```typescript declare const userIds: string[]; ```

--- a/docs-mintlify/sdk/types/item.mdx
+++ b/docs-mintlify/sdk/types/item.mdx
@@ -38,7 +38,7 @@ export const ServerItemSection = (props) => (
   />
 );
 
-Items represent quantifiable resources in your application, such as credits, API calls, storage quotas, or subscription allowances. They can be associated with users, teams, or custom customers and are managed through Stack Auth's payment system.
+Items represent quantifiable resources in your application, such as credits, API calls, storage quotas, or subscription allowances. They can be associated with users, teams, or custom customers and are managed through Hexclave's payment system.
 
 On this page:
 
@@ -74,7 +74,7 @@ Items can be retrieved through:
 <ItemSection type="item" property="displayName" defaultOpen={false}>
   <MethodLayout>
     <MethodContent>
-      The human-readable name of the item as configured in your Stack Auth project settings.
+      The human-readable name of the item as configured in your Hexclave project settings.
     </MethodContent>
     <MethodAside title="Type Definition">
       ```typescript declare const displayName: string; ```

--- a/docs-mintlify/sdk/types/user.mdx
+++ b/docs-mintlify/sdk/types/user.mdx
@@ -641,7 +641,7 @@ Use `useUser()` to get `CurrentUser` (client). Use `stackServerApp.getUser()` to
 <CurrentUserSection type="currentUser" property="toClientJson" defaultOpen={false}>
   <MethodLayout>
     <MethodContent>
-      Converts the user object to the format expected by the Stack Auth API. Useful for serializing user data in API responses or caching.
+      Converts the user object to the format expected by the Hexclave API. Useful for serializing user data in API responses or caching.
 
       <MethodReturns type='CurrentUserCrud["Client"]["Read"]' />
     </MethodContent>

--- a/docs-mintlify/snippets/home-prompt-island.jsx
+++ b/docs-mintlify/snippets/home-prompt-island.jsx
@@ -1,8 +1,8 @@
 export const HomePromptIsland = () => {
   const agentSetupPromptPlaceholder = `You are my coding agent.
 
-Set up Stack Auth in this project.
-- Install and configure Stack Auth
+Set up Hexclave in this project.
+- Install and configure Hexclave
 - Create initial authentication routes
 - Add sign-in and sign-up UI
 - Verify local development setup
@@ -28,7 +28,7 @@ Return the exact files changed and next steps.`;
         Start with a single prompt.
       </h1>
       <p className="mt-3 max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-300">
-        Set up Stack Auth by copying the prompt below into your favorite coding agent.
+        Set up Hexclave by copying the prompt below into your favorite coding agent.
       </p>
 
       <div className="relative mt-6">


### PR DESCRIPTION
Updated docs to reflect new naming convention for Hexclave, preserving code examples, env vars, snippets, etc.

<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Documentation
- Updated product branding throughout the documentation, replacing Stack Auth references with Hexclave across all API guides, authentication methods, integration tutorials, SDK documentation, and getting-started materials.
- All documentation content and functionality remain unchanged; updates focused solely on product and platform name references to reflect the new brand identity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->