### PR TITLE
fix(email-queue): recover stuck sending without duplicate retry

### DIFF
--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -1,0 +1,104 @@
+import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
+import { globalPrismaClient } from "@/prisma-client";
+import { afterAll, describe, expect, it } from "vitest";
+import { _forTesting } from "./email-queue-step";
+import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
+
+const { recoverEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS } = _forTesting;
+
+// These tests connect to the real dev DB (like payments.test.tsx) and create real EmailOutbox
+// rows against the seeded `internal` tenancy. Each row is tagged with a unique tsxSource so we
+// can find and clean up just our test rows.
+describe.sequential("recoverEmailsStuckInSending", () => {
+  const testRunTag = `stuck-in-sending-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const createdIds: { tenancyId: string, id: string }[] = [];
+
+  const makeRow = async (params: { startedSendingAt: Date | null, finishedSendingAt?: Date | null, isPaused?: boolean }) => {
+    const tenancy = await getSoleTenancyFromProjectBranch("internal", DEFAULT_BRANCH_ID);
+    const created = await globalPrismaClient.emailOutbox.create({
+      data: {
+        tenancyId: tenancy.id,
+        tsxSource: `/* ${testRunTag} */`,
+        themeId: null,
+        isHighPriority: false,
+        to: { type: "custom-emails", emails: ["stuck-test@example.com"] },
+        extraRenderVariables: {},
+        shouldSkipDeliverabilityCheck: true,
+        createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+        scheduledAt: new Date(0),
+        isQueued: true,
+        renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+        startedRenderingAt: new Date(0),
+        finishedRenderingAt: new Date(0),
+        renderedHtml: "<p>stuck</p>",
+        renderedText: "stuck",
+        renderedSubject: "stuck",
+        renderedIsTransactional: false,
+        startedSendingAt: params.startedSendingAt,
+        finishedSendingAt: params.finishedSendingAt ?? null,
+        isPaused: params.isPaused ?? false,
+      },
+    });
+    createdIds.push({ tenancyId: created.tenancyId, id: created.id });
+    return created;
+  };
+
+  afterAll(async () => {
+    for (const { tenancyId, id } of createdIds) {
+      await globalPrismaClient.emailOutbox.deleteMany({ where: { tenancyId, id } });
+    }
+  });
+
+  it("recovers a row whose startedSendingAt is older than the stuck timeout", async () => {
+    const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
+    const row = await makeRow({ startedSendingAt: longAgo });
+
+    await recoverEmailsStuckInSending();
+
+    const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
+      where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
+    });
+    expect(after.finishedSendingAt).not.toBeNull();
+    expect(after.startedSendingAt?.toISOString()).toBe(row.startedSendingAt?.toISOString());
+    expect(after.canHaveDeliveryInfo).toBe(false);
+    expect(after.sendServerErrorExternalMessage).toMatch(/did not complete in time/i);
+    expect(after.sendServerErrorInternalMessage).toMatch(/stuck in sending/i);
+    // Must be a terminal state — no retry scheduled.
+    expect(after.nextSendRetryAt).toBeNull();
+    // sendRetries is not bumped by recovery (we never attempted the send again).
+    expect(after.sendRetries).toBe(row.sendRetries);
+    // Status must be SERVER_ERROR, not SENDING.
+    expect(after.status).toBe("SERVER_ERROR");
+  });
+
+  it("does not touch a row that started sending recently", async () => {
+    const recently = new Date(Date.now() - 1000);
+    const row = await makeRow({ startedSendingAt: recently });
+
+    await recoverEmailsStuckInSending();
+
+    const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
+      where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
+    });
+    expect(after.finishedSendingAt).toBeNull();
+    expect(after.sendServerErrorExternalMessage).toBeNull();
+    expect(after.status).toBe("SENDING");
+  });
+
+  it("does not re-queue recovered rows for another send attempt", async () => {
+    const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
+    const row = await makeRow({ startedSendingAt: longAgo });
+
+    await recoverEmailsStuckInSending();
+    // A second pass should be a no-op for this row: it's already terminal, so it must not
+    // become a candidate for re-sending (which could duplicate an already-accepted delivery).
+    await recoverEmailsStuckInSending();
+
+    const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
+      where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
+    });
+    expect(after.nextSendRetryAt).toBeNull();
+    expect(after.isQueued).toBe(true); // unchanged: we do not unclaim stuck rows
+    expect(after.status).toBe("SERVER_ERROR");
+  });
+});

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -13,6 +13,8 @@ describe.sequential("recoverEmailsStuckInSending", () => {
   const testRunTag = `stuck-in-sending-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const createdIds: { tenancyId: string, id: string }[] = [];
 
+  const recoveryTestFilter = { tsxSource: `/* ${testRunTag} */` };
+
   const makeRow = async (params: {
     startedSendingAt: Date | null,
     finishedSendingAt?: Date | null,
@@ -24,7 +26,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     const created = await globalPrismaClient.emailOutbox.create({
       data: {
         tenancyId: tenancy.id,
-        tsxSource: `/* ${testRunTag} */`,
+        tsxSource: recoveryTestFilter.tsxSource,
         themeId: null,
         isHighPriority: false,
         to: { type: "custom-emails", emails: ["stuck-test@example.com"] },
@@ -65,7 +67,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
       nextSendRetryAt: new Date(Date.now() + 60_000),
     });
 
-    await recoverEmailsStuckInSending();
+    await recoverEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
@@ -73,7 +75,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     expect(after.finishedSendingAt).not.toBeNull();
     expect(after.startedSendingAt?.toISOString()).toBe(row.startedSendingAt?.toISOString());
     expect(after.canHaveDeliveryInfo).toBe(false);
-    expect(after.sendServerErrorExternalMessage).toMatch(/did not complete in time/i);
+    expect(after.sendServerErrorExternalMessage).toMatch(/timed out/i);
     expect(after.sendServerErrorInternalMessage).toMatch(/stuck in sending/i);
     // Must be a terminal state — no retry scheduled.
     expect(after.nextSendRetryAt).toBeNull();
@@ -87,7 +89,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     const recently = new Date(Date.now() - 1000);
     const row = await makeRow({ startedSendingAt: recently });
 
-    await recoverEmailsStuckInSending();
+    await recoverEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
@@ -101,10 +103,10 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
     const row = await makeRow({ startedSendingAt: longAgo });
 
-    await recoverEmailsStuckInSending();
+    await recoverEmailsStuckInSending(recoveryTestFilter);
     // A second pass should be a no-op for this row: it's already terminal, so it must not
     // become a candidate for re-sending (which could duplicate an already-accepted delivery).
-    await recoverEmailsStuckInSending();
+    await recoverEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -13,7 +13,13 @@ describe.sequential("recoverEmailsStuckInSending", () => {
   const testRunTag = `stuck-in-sending-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const createdIds: { tenancyId: string, id: string }[] = [];
 
-  const makeRow = async (params: { startedSendingAt: Date | null, finishedSendingAt?: Date | null, isPaused?: boolean }) => {
+  const makeRow = async (params: {
+    startedSendingAt: Date | null,
+    finishedSendingAt?: Date | null,
+    isPaused?: boolean,
+    sendRetries?: number,
+    nextSendRetryAt?: Date | null,
+  }) => {
     const tenancy = await getSoleTenancyFromProjectBranch("internal", DEFAULT_BRANCH_ID);
     const created = await globalPrismaClient.emailOutbox.create({
       data: {
@@ -36,6 +42,8 @@ describe.sequential("recoverEmailsStuckInSending", () => {
         renderedIsTransactional: false,
         startedSendingAt: params.startedSendingAt,
         finishedSendingAt: params.finishedSendingAt ?? null,
+        sendRetries: params.sendRetries ?? 0,
+        nextSendRetryAt: params.nextSendRetryAt ?? null,
         isPaused: params.isPaused ?? false,
       },
     });
@@ -51,7 +59,11 @@ describe.sequential("recoverEmailsStuckInSending", () => {
 
   it("recovers a row whose startedSendingAt is older than the stuck timeout", async () => {
     const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
-    const row = await makeRow({ startedSendingAt: longAgo });
+    const row = await makeRow({
+      startedSendingAt: longAgo,
+      sendRetries: 1,
+      nextSendRetryAt: new Date(Date.now() + 60_000),
+    });
 
     await recoverEmailsStuckInSending();
 

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -4,12 +4,12 @@ import { afterAll, describe, expect, it } from "vitest";
 import { _forTesting } from "./email-queue-step";
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
 
-const { recoverEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS } = _forTesting;
+const { failEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS } = _forTesting;
 
 // These tests connect to the real dev DB (like payments.test.tsx) and create real EmailOutbox
 // rows against the seeded `internal` tenancy. Each row is tagged with a unique tsxSource so we
 // can find and clean up just our test rows.
-describe.sequential("recoverEmailsStuckInSending", () => {
+describe.sequential("failEmailsStuckInSending", () => {
   const testRunTag = `stuck-in-sending-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const createdIds: { tenancyId: string, id: string }[] = [];
 
@@ -59,7 +59,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     }
   });
 
-  it("recovers a row whose startedSendingAt is older than the stuck timeout", async () => {
+  it("marks a row as failed when startedSendingAt is older than the stuck timeout", async () => {
     const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
     const row = await makeRow({
       startedSendingAt: longAgo,
@@ -67,7 +67,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
       nextSendRetryAt: new Date(Date.now() + 60_000),
     });
 
-    await recoverEmailsStuckInSending(recoveryTestFilter);
+    await failEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
@@ -77,9 +77,10 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     expect(after.canHaveDeliveryInfo).toBe(false);
     expect(after.sendServerErrorExternalMessage).toMatch(/timed out/i);
     expect(after.sendServerErrorInternalMessage).toMatch(/stuck in sending/i);
+    expect(after.sendServerErrorInternalMessage).toMatch(/terminal server error/i);
     // Must be a terminal state — no retry scheduled.
     expect(after.nextSendRetryAt).toBeNull();
-    // sendRetries is not bumped by recovery (we never attempted the send again).
+    // sendRetries is not bumped by this path (we never attempted the send again).
     expect(after.sendRetries).toBe(row.sendRetries);
     // Status must be SERVER_ERROR, not SENDING.
     expect(after.status).toBe("SERVER_ERROR");
@@ -89,7 +90,7 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     const recently = new Date(Date.now() - 1000);
     const row = await makeRow({ startedSendingAt: recently });
 
-    await recoverEmailsStuckInSending(recoveryTestFilter);
+    await failEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },
@@ -99,14 +100,14 @@ describe.sequential("recoverEmailsStuckInSending", () => {
     expect(after.status).toBe("SENDING");
   });
 
-  it("does not re-queue recovered rows for another send attempt", async () => {
+  it("does not re-queue rows already marked failed for another send attempt", async () => {
     const longAgo = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS - 60_000);
     const row = await makeRow({ startedSendingAt: longAgo });
 
-    await recoverEmailsStuckInSending(recoveryTestFilter);
+    await failEmailsStuckInSending(recoveryTestFilter);
     // A second pass should be a no-op for this row: it's already terminal, so it must not
     // become a candidate for re-sending (which could duplicate an already-accepted delivery).
-    await recoverEmailsStuckInSending(recoveryTestFilter);
+    await failEmailsStuckInSending(recoveryTestFilter);
 
     const after = await globalPrismaClient.emailOutbox.findUniqueOrThrow({
       where: { tenancyId_id: { tenancyId: row.tenancyId, id: row.id } },

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -175,6 +175,7 @@ async function recoverEmailsStuckInSending(): Promise<void> {
       sendServerErrorExternalDetails: externalDetails,
       sendServerErrorInternalMessage: `Email was stuck in sending (startedSendingAt <= ${stuckCutoff.toISOString()}) and was recovered by the email queue step. Not retried to avoid duplicate delivery.`,
       sendServerErrorInternalDetails: internalDetails,
+      nextSendRetryAt: null,
       shouldUpdateSequenceId: true,
     },
     select: { id: true, tenancyId: true, startedSendingAt: true, to: true, sendAttemptErrors: true },

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -97,7 +97,7 @@ export const runEmailQueueStep = withTraceSpan("runEmailQueueStep", async () => 
 
   const sendPlan = await withTraceSpan("runEmailQueueStep-prepareSendPlan", prepareSendPlan)(deltaSeconds);
   await withTraceSpan("runEmailQueueStep-processSendPlan", processSendPlan)(sendPlan);
-  await withTraceSpan("runEmailQueueStep-logEmailsStuckInSending", logEmailsStuckInSending)();
+  await withTraceSpan("runEmailQueueStep-recoverEmailsStuckInSending", recoverEmailsStuckInSending)();
   const sendEnd = performance.now();
 
   if (sendPlan.length > 0 || queuedCount > 0 || pendingRender.length > 0) {
@@ -134,24 +134,67 @@ async function retryEmailsStuckInRendering(): Promise<void> {
   }
 }
 
-async function logEmailsStuckInSending(): Promise<void> {
-  const res = await globalPrismaClient.emailOutbox.findMany({
+/**
+ * Recover rows that have been stuck in SENDING for longer than STUCK_EMAIL_TIMEOUT_MS.
+ *
+ * These rows indicate a worker died after setting `startedSendingAt` but before cleaning up
+ * (either marking the send as finished or unclaiming it for retry). We deliberately do NOT
+ * retry automatically: the upstream send may have actually been accepted by the SMTP/provider
+ * before the worker died, and retrying would risk a duplicate delivery. Instead, we mark the
+ * row as a terminal server error with delivery status unknown, and emit a Sentry signal so a
+ * human can investigate if desired.
+ */
+async function recoverEmailsStuckInSending(): Promise<void> {
+  const stuckCutoff = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS);
+  const recoveredAt = new Date();
+  const externalMessage = "Email sending did not complete in time. The email may or may not have been delivered; we are not retrying automatically to avoid sending a duplicate.";
+  const internalDetails: Prisma.InputJsonObject = {
+    errorType: "stuck-in-sending-recovered",
+    stuckTimeoutMs: STUCK_EMAIL_TIMEOUT_MS,
+    recoveredAt: recoveredAt.toISOString(),
+  };
+  const externalDetails: Prisma.InputJsonObject = {
+    errorType: "stuck-in-sending-recovered",
+  };
+
+  const recovered = await globalPrismaClient.emailOutbox.updateManyAndReturn({
     where: {
-      startedSendingAt: {
-        lte: new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS),
-      },
+      startedSendingAt: { lte: stuckCutoff },
       finishedSendingAt: null,
       skippedReason: null,
       isPaused: false,
     },
-    select: { id: true, tenancyId: true, startedSendingAt: true, to: true, sentAt: true, sendAttemptErrors: true },
+    data: {
+      finishedSendingAt: recoveredAt,
+      // canHaveDeliveryInfo must be non-null when finishedSendingAt is set (see schema).
+      // We set it to false because we have no webhook/provider signal we can correlate: delivery
+      // status is effectively unknown, and treating it as "no delivery info available" is the
+      // honest representation.
+      canHaveDeliveryInfo: false,
+      sendServerErrorExternalMessage: externalMessage,
+      sendServerErrorExternalDetails: externalDetails,
+      sendServerErrorInternalMessage: `Email was stuck in sending (startedSendingAt <= ${stuckCutoff.toISOString()}) and was recovered by the email queue step. Not retried to avoid duplicate delivery.`,
+      sendServerErrorInternalDetails: internalDetails,
+      shouldUpdateSequenceId: true,
+    },
+    select: { id: true, tenancyId: true, startedSendingAt: true, to: true, sendAttemptErrors: true },
   });
-  if (res.length > 0) {
-    captureError("email-queue-step-stuck-in-sending", new StackAssertionError(`${res.length} emails stuck in sending! This should never happen. It was NOT correctly marked as an error! Manual intervention is required.`, {
-      emails: res,
-    }));
+
+  if (recovered.length > 0) {
+    captureError(
+      "email-queue-step-stuck-in-sending",
+      new StackAssertionError(
+        `${recovered.length} emails were stuck in sending and have been recovered as terminal server errors (delivery status unknown, not retried to avoid duplicate sends). Manual investigation is recommended.`,
+        { emails: recovered },
+      ),
+    );
   }
 }
+
+export const _forTesting = {
+  recoverEmailsStuckInSending,
+  STUCK_EMAIL_TIMEOUT_MS,
+};
 
 async function updateLastExecutionTime(): Promise<number> {
   const key = "EMAIL_QUEUE_METADATA_KEY";

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -137,17 +137,16 @@ async function retryEmailsStuckInRendering(): Promise<void> {
 /**
  * Recover rows that have been stuck in SENDING for longer than STUCK_EMAIL_TIMEOUT_MS.
  *
- * These rows indicate a worker died after setting `startedSendingAt` but before cleaning up
- * (either marking the send as finished or unclaiming it for retry). We deliberately do NOT
- * retry automatically: the upstream send may have actually been accepted by the SMTP/provider
- * before the worker died, and retrying would risk a duplicate delivery. Instead, we mark the
- * row as a terminal server error with delivery status unknown, and emit a Sentry signal so a
- * human can investigate if desired.
+ * These rows can happen when sending hangs or fails after `startedSendingAt` was set but before
+ * the send attempt was finalized. We deliberately do NOT retry automatically: the upstream send
+ * may have actually been accepted by the SMTP/provider, and retrying would risk a duplicate
+ * delivery. Instead, we mark the row as a terminal server error with delivery status unknown,
+ * and emit a Sentry signal so a human can investigate if desired.
  */
-async function recoverEmailsStuckInSending(): Promise<void> {
+async function recoverEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxWhereInput): Promise<void> {
   const stuckCutoff = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS);
   const recoveredAt = new Date();
-  const externalMessage = "Email sending did not complete in time. The email may or may not have been delivered; we are not retrying automatically to avoid sending a duplicate.";
+  const externalMessage = "Email sending timed out before we could confirm whether it was delivered.";
   const internalDetails: Prisma.InputJsonObject = {
     errorType: "stuck-in-sending-recovered",
     stuckTimeoutMs: STUCK_EMAIL_TIMEOUT_MS,
@@ -157,13 +156,15 @@ async function recoverEmailsStuckInSending(): Promise<void> {
     errorType: "stuck-in-sending-recovered",
   };
 
+  const baseWhere: Prisma.EmailOutboxWhereInput = {
+    startedSendingAt: { lte: stuckCutoff },
+    finishedSendingAt: null,
+    skippedReason: null,
+    isPaused: false,
+  };
+
   const recovered = await globalPrismaClient.emailOutbox.updateManyAndReturn({
-    where: {
-      startedSendingAt: { lte: stuckCutoff },
-      finishedSendingAt: null,
-      skippedReason: null,
-      isPaused: false,
-    },
+    where: additionalWhere == null ? baseWhere : { AND: [baseWhere, additionalWhere] },
     data: {
       finishedSendingAt: recoveredAt,
       // canHaveDeliveryInfo must be non-null when finishedSendingAt is set (see schema).
@@ -176,9 +177,12 @@ async function recoverEmailsStuckInSending(): Promise<void> {
       sendServerErrorInternalMessage: `Email was stuck in sending (startedSendingAt <= ${stuckCutoff.toISOString()}) and was recovered by the email queue step. Not retried to avoid duplicate delivery.`,
       sendServerErrorInternalDetails: internalDetails,
       nextSendRetryAt: null,
+      // Do not append to sendAttemptErrors here: this recovery path did not observe a provider
+      // response or application error for this attempt, and the terminal server-error fields
+      // already record the recovery event without duplicating potentially sensitive details.
       shouldUpdateSequenceId: true,
     },
-    select: { id: true, tenancyId: true, startedSendingAt: true, to: true, sendAttemptErrors: true },
+    select: { id: true, tenancyId: true, startedSendingAt: true },
   });
 
   if (recovered.length > 0) {
@@ -186,7 +190,7 @@ async function recoverEmailsStuckInSending(): Promise<void> {
       "email-queue-step-stuck-in-sending",
       new StackAssertionError(
         `${recovered.length} emails were stuck in sending and have been recovered as terminal server errors (delivery status unknown, not retried to avoid duplicate sends). Manual investigation is recommended.`,
-        { emails: recovered },
+        { emails: recovered.map(({ id, tenancyId, startedSendingAt }) => ({ id, tenancyId, startedSendingAt })) },
       ),
     );
   }

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -97,7 +97,7 @@ export const runEmailQueueStep = withTraceSpan("runEmailQueueStep", async () => 
 
   const sendPlan = await withTraceSpan("runEmailQueueStep-prepareSendPlan", prepareSendPlan)(deltaSeconds);
   await withTraceSpan("runEmailQueueStep-processSendPlan", processSendPlan)(sendPlan);
-  await withTraceSpan("runEmailQueueStep-recoverEmailsStuckInSending", recoverEmailsStuckInSending)();
+  await withTraceSpan("runEmailQueueStep-failEmailsStuckInSending", failEmailsStuckInSending)();
   const sendEnd = performance.now();
 
   if (sendPlan.length > 0 || queuedCount > 0 || pendingRender.length > 0) {
@@ -135,7 +135,7 @@ async function retryEmailsStuckInRendering(): Promise<void> {
 }
 
 /**
- * Recover rows that have been stuck in SENDING for longer than STUCK_EMAIL_TIMEOUT_MS.
+ * Mark rows stuck in SENDING for longer than STUCK_EMAIL_TIMEOUT_MS as failed (terminal server error).
  *
  * These rows can happen when sending hangs or fails after `startedSendingAt` was set but before
  * the send attempt was finalized. We deliberately do NOT retry automatically: the upstream send
@@ -143,17 +143,17 @@ async function retryEmailsStuckInRendering(): Promise<void> {
  * delivery. Instead, we mark the row as a terminal server error with delivery status unknown,
  * and emit a Sentry signal so a human can investigate if desired.
  */
-async function recoverEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxWhereInput): Promise<void> {
+async function failEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxWhereInput): Promise<void> {
   const stuckCutoff = new Date(Date.now() - STUCK_EMAIL_TIMEOUT_MS);
-  const recoveredAt = new Date();
+  const failedAt = new Date();
   const externalMessage = "Email sending timed out before we could confirm whether it was delivered.";
   const internalDetails: Prisma.InputJsonObject = {
-    errorType: "stuck-in-sending-recovered",
+    errorType: "stuck-in-sending-marked-failed",
     stuckTimeoutMs: STUCK_EMAIL_TIMEOUT_MS,
-    recoveredAt: recoveredAt.toISOString(),
+    failedAt: failedAt.toISOString(),
   };
   const externalDetails: Prisma.InputJsonObject = {
-    errorType: "stuck-in-sending-recovered",
+    errorType: "stuck-in-sending-marked-failed",
   };
 
   const baseWhere: Prisma.EmailOutboxWhereInput = {
@@ -163,10 +163,10 @@ async function recoverEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxW
     isPaused: false,
   };
 
-  const recovered = await globalPrismaClient.emailOutbox.updateManyAndReturn({
+  const failed = await globalPrismaClient.emailOutbox.updateManyAndReturn({
     where: additionalWhere == null ? baseWhere : { AND: [baseWhere, additionalWhere] },
     data: {
-      finishedSendingAt: recoveredAt,
+      finishedSendingAt: failedAt,
       // canHaveDeliveryInfo must be non-null when finishedSendingAt is set (see schema).
       // We set it to false because we have no webhook/provider signal we can correlate: delivery
       // status is effectively unknown, and treating it as "no delivery info available" is the
@@ -174,30 +174,30 @@ async function recoverEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxW
       canHaveDeliveryInfo: false,
       sendServerErrorExternalMessage: externalMessage,
       sendServerErrorExternalDetails: externalDetails,
-      sendServerErrorInternalMessage: `Email was stuck in sending (startedSendingAt <= ${stuckCutoff.toISOString()}) and was recovered by the email queue step. Not retried to avoid duplicate delivery.`,
+      sendServerErrorInternalMessage: `Email was stuck in sending (startedSendingAt <= ${stuckCutoff.toISOString()}) and was marked as a terminal server error by the email queue step (delivery status unknown). Not retried to avoid duplicate delivery.`,
       sendServerErrorInternalDetails: internalDetails,
       nextSendRetryAt: null,
-      // Do not append to sendAttemptErrors here: this recovery path did not observe a provider
-      // response or application error for this attempt, and the terminal server-error fields
-      // already record the recovery event without duplicating potentially sensitive details.
+      // Do not append to sendAttemptErrors here: this path did not observe a provider response
+      // or application error for this attempt, and the terminal server-error fields already
+      // record the failure without duplicating potentially sensitive details.
       shouldUpdateSequenceId: true,
     },
     select: { id: true, tenancyId: true, startedSendingAt: true },
   });
 
-  if (recovered.length > 0) {
+  if (failed.length > 0) {
     captureError(
       "email-queue-step-stuck-in-sending",
       new StackAssertionError(
-        `${recovered.length} emails were stuck in sending and have been recovered as terminal server errors (delivery status unknown, not retried to avoid duplicate sends). Manual investigation is recommended.`,
-        { emails: recovered.map(({ id, tenancyId, startedSendingAt }) => ({ id, tenancyId, startedSendingAt })) },
+        `${failed.length} emails were stuck in sending and were marked as failed (terminal server errors; delivery status unknown, not retried to avoid duplicate sends). Manual investigation is recommended.`,
+        { emails: failed.map(({ id, tenancyId, startedSendingAt }) => ({ id, tenancyId, startedSendingAt })) },
       ),
     );
   }
 }
 
 export const _forTesting = {
-  recoverEmailsStuckInSending,
+  failEmailsStuckInSending,
   STUCK_EMAIL_TIMEOUT_MS,
 };
 


### PR DESCRIPTION
## Summary

Email outbox rows can get stuck in `SENDING` if a worker dies after setting `startedSendingAt` but before finishing or unclaiming. This change adds `recoverEmailsStuckInSending`, which runs each email queue step and marks rows past the stuck timeout as **terminal server errors** with delivery status unknown, **without** scheduling an automatic retry (to avoid duplicate sends if the provider already accepted the message).

## Changes

- **`recoverEmailsStuckInSending`**: updates stuck rows with `finishedSendingAt`, `canHaveDeliveryInfo: false`, and server error fields; emits Sentry via `captureError` when any rows are recovered.
- **Tests**: `email-queue-step.test.tsx` covers recovery of old `startedSendingAt`, no-op for recent sends, and idempotency (second pass does not re-queue).

## Test plan

- [ ] `pnpm` / vitest for `apps/backend/src/lib/email-queue-step.test.tsx` (requires dev DB like other integration tests in this package)

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email reliability: messages that remained stuck in sending are now automatically marked as terminal failures, assigned standardized error details, cleared from retry scheduling, prevented from receiving delivery info, and recovery emits an alert only when actual work occurs. Recovery is safe to run repeatedly (idempotent).

* **Tests**
  * Added integration tests validating recovery behavior, proper field updates, and idempotency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->