### PR TITLE
Reduce Jaeger memory usage in local dev

### DIFF
--- a/docker/dependencies/docker.compose.yaml
+++ b/docker/dependencies/docker.compose.yaml
@@ -148,9 +148,11 @@ services:
     image: jaegertracing/all-in-one:latest
     environment:
       - COLLECTOR_OTLP_ENABLED=true
+      - MEMORY_MAX_TRACES=50000
     ports:
       - "${NEXT_PUBLIC_STACK_PORT_PREFIX:-81}07:16686"  # Jaeger UI
       - "${NEXT_PUBLIC_STACK_PORT_PREFIX:-81}31:4318"    # OTLP Endpoint
+    mem_limit: 1g
     restart: always
 
   # ================= svix =================


### PR DESCRIPTION
## Summary

Jaeger's `all-in-one` image uses an unbounded in-memory span store by default, so on long-running local dev sessions it quietly grows until the Docker VM is under memory pressure. This caps it in two ways:

- `MEMORY_MAX_TRACES=50000` — tells Jaeger to evict old traces once the in-memory ring buffer hits 50k. Plenty for local debugging without retaining every trace forever.
- `mem_limit: 1g` — hard Docker memory cap as a backstop so a runaway collector can't starve the rest of the compose stack (Postgres, ClickHouse, Svix, etc.).

Only touches `docker/dependencies/docker.compose.yaml` — no app code, no prod config.

## Test plan

- [ ] `docker compose -f docker/dependencies/docker.compose.yaml up jaeger` starts cleanly
- [ ] Jaeger UI reachable at `localhost:8107`
- [ ] OTLP endpoint on `localhost:8131` still ingests spans from the API/dashboard
- [ ] `docker stats` shows the jaeger container capped at ~1GB under load
- [ ] Old traces get evicted once trace count exceeds 50k (verify via UI search)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Configured memory constraints and trace buffering optimization for the tracing service to improve resource management and system stability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->