### PR TITLE
fix(twitch): derive emailVerified from email presence

### DIFF
--- a/apps/backend/src/oauth/providers/twitch.tsx
+++ b/apps/backend/src/oauth/providers/twitch.tsx
@@ -40,7 +40,7 @@ export class TwitchProvider extends OAuthBaseProvider {
       displayName: userInfo.display_name,
       email: userInfo.email,
       profileImageUrl: userInfo.profile_image_url,
-      emailVerified: true,
+      emailVerified: !!userInfo.email,
     });
   }
 


### PR DESCRIPTION
## Summary

The Twitch OAuth provider previously hardcoded `emailVerified: true` unconditionally in `postProcessUserInfo`. This change sets it to `!!userInfo.email` so verified status tracks whether an email was actually returned.

## Background

Twitch's Helix `GET /users` response **does not include** an `email_verified` (or equivalent) field. The documented User object contains only these fields:

`id`, `login`, `display_name`, `type`, `broadcaster_type`, `description`, `profile_image_url`, `offline_image_url`, `view_count`, `email`, `created_at`

However, per the [Twitch API reference](https://dev.twitch.tv/docs/api/reference/#get-users), the `email` field is documented as *"the user's **verified** email address"*. Twitch requires email verification at account creation and only surfaces verified addresses through the API, so **if `email` is present, it is verified**.

## The bug

`email` can legitimately be absent or empty in the response:

- **Token missing `user:read:email` scope** → field is omitted entirely.
- **App access tokens** (no user context) → field is omitted.
- **Batch lookups for users other than the token owner** → field is returned as an empty string `""`.

Stack Auth's Twitch flow requests `user:read:email` and only fetches the token owner, so the common case is safe. But if Twitch ever omits the email (e.g. due to scope stripping, account deactivation edge cases, or future API behavior), the old code would still mark `emailVerified: true` with a null email — a logical inconsistency that downstream code relying on \`emailVerified\` could misinterpret.

## Fix

```diff
-      emailVerified: true,
+      emailVerified: !!userInfo.email,
```

Now `emailVerified` is only `true` when Twitch actually returned a (verified) email, and `false` otherwise.

## References

- [Twitch Helix — Get Users](https://dev.twitch.tv/docs/api/reference/#get-users) — response schema (no `email_verified` field; `email` scoped behind `user:read:email`)
- [Twitch Authentication — Scopes](https://dev.twitch.tv/docs/authentication/scopes/) — `user:read:email` scope definition
- [Twitch OIDC Auth](https://dev.twitch.tv/docs/authentication/getting-tokens-oidc/) — OIDC `email_verified` claim behavior

## Test plan

- [x] `pnpm --filter @stackframe/backend typecheck` passes
- [x] `pnpm --filter @stackframe/backend lint` passes
- [ ] Manual: sign in via Twitch OAuth and confirm `emailVerified` is `true` when the user has an email on file

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Twitch OAuth email verification to accurately reflect whether an email is provided by Twitch, rather than always marking it as verified.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->