### PR TITLE
fix(internal-tool): continue dev startup when spacetime publish fails

### DIFF
--- a/apps/internal-tool/scripts/pre-dev.mjs
+++ b/apps/internal-tool/scripts/pre-dev.mjs
@@ -1,10 +1,8 @@
 #!/usr/bin/env node
 // Runs before `next dev`. Publishes the SpacetimeDB module to the local server
-// if the spacetime CLI is installed and the local server accepts the publish.
-// Otherwise, warns and continues so the dev server still starts (useful in CI,
-// for contributors who haven't installed the CLI yet, and when no local
-// SpacetimeDB server is running — the internal-tool Next.js app itself doesn't
-// need Spacetime to boot).
+// if the spacetime CLI is installed. Otherwise, warns and continues so the
+// dev server still starts (useful in CI and for contributors who haven't
+// installed the CLI yet).
 
 import { spawnSync } from "node:child_process";
 
@@ -22,9 +20,4 @@ const publish = spawnSync("pnpm", ["spacetime:publish:local"], {
   stdio: "inherit",
 });
 
-if (publish.status !== 0) {
-  console.warn("\n[internal-tool] spacetime publish failed (exit code " + (publish.status ?? "unknown") + "). Continuing with dev server startup.");
-  console.warn("[internal-tool] If you need Spacetime locally, make sure a SpacetimeDB server is running on http://127.0.0.1:3000 (see: spacetime start).\n");
-}
-
-process.exit(0);
+process.exit(publish.status ?? 1);

--- a/apps/internal-tool/scripts/pre-dev.mjs
+++ b/apps/internal-tool/scripts/pre-dev.mjs
@@ -1,8 +1,10 @@
 #!/usr/bin/env node
 // Runs before `next dev`. Publishes the SpacetimeDB module to the local server
-// if the spacetime CLI is installed. Otherwise, warns and continues so the
-// dev server still starts (useful in CI and for contributors who haven't
-// installed the CLI yet).
+// if the spacetime CLI is installed and the local server accepts the publish.
+// Otherwise, warns and continues so the dev server still starts (useful in CI,
+// for contributors who haven't installed the CLI yet, and when no local
+// SpacetimeDB server is running — the internal-tool Next.js app itself doesn't
+// need Spacetime to boot).
 
 import { spawnSync } from "node:child_process";
 
@@ -20,4 +22,9 @@ const publish = spawnSync("pnpm", ["spacetime:publish:local"], {
   stdio: "inherit",
 });
 
-process.exit(publish.status ?? 1);
+if (publish.status !== 0) {
+  console.warn("\n[internal-tool] spacetime publish failed (exit code " + (publish.status ?? "unknown") + "). Continuing with dev server startup.");
+  console.warn("[internal-tool] If you need Spacetime locally, make sure a SpacetimeDB server is running on http://127.0.0.1:3000 (see: spacetime start).\n");
+}
+
+process.exit(0);

--- a/apps/internal-tool/scripts/spacetime-publish.mjs
+++ b/apps/internal-tool/scripts/spacetime-publish.mjs
@@ -6,8 +6,27 @@ import { spawnSync } from "node:child_process";
 
 const target = process.argv[2]; // "local" or "prod"
 
+/** HTTP API for 'spacetime publish' (matches docker/dependencies/docker.compose.yaml host port ...39). */
+function localPublishServerUrl() {
+  if (process.env.STACK_SPACETIME_PUBLISH_URL) {
+    return process.env.STACK_SPACETIME_PUBLISH_URL;
+  }
+  const prefix = process.env.NEXT_PUBLIC_STACK_PORT_PREFIX ?? "81";
+  return `http://127.0.0.1:${prefix}39`;
+}
+
 const configs = {
-  local: ["publish", "stack-auth-llm", "--server", "local", "-p", "spacetimedb", "--yes", "--no-config", "--delete-data=on-conflict"],
+  local: [
+    "publish",
+    "stack-auth-llm",
+    "--server",
+    localPublishServerUrl(),
+    "-p",
+    "spacetimedb",
+    "--yes",
+    "--no-config",
+    "--delete-data=on-conflict",
+  ],
   prod: ["publish", "stack-auth-llm", "--server", "maincloud", "-p", "spacetimedb", "--yes", "--no-config"],
 };
 


### PR DESCRIPTION
## Summary
- pre-dev.mjs now warns and exits 0 when the local SpacetimeDB publish fails, instead of aborting `next dev`
- Lets contributors without a running local SpacetimeDB server still start the internal-tool dev server
- Updates the header comment to reflect the new behavior

## Test plan
- [ ] Run `pnpm dev` in `apps/internal-tool` with no SpacetimeDB server running — dev server should still start, with a warning
- [ ] Run with SpacetimeDB server running and `spacetime` CLI installed — publish still runs and dev proceeds
- [ ] Run without `spacetime` CLI installed — existing warn-and-continue path still works

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated local publishing configuration to derive server settings from environment variables for improved flexibility and easier customization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->