### PR TITLE
[codex] Fix Neon malformed Basic auth validation

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
@@ -216,6 +216,7 @@ it("should fail if the neon client details are missing", async ({ expect }) => {
 });
 
 it("should fail if the neon client authorization header is malformed", async ({ expect }) => {
+  // This project ID is arbitrary because malformed Basic auth is rejected before any project lookup runs.
   const projectId = "73782539-cf39-486b-a9f8-9b2893f79ef2";
   const response = await niceBackendFetch(urlString`/api/v1/integrations/neon/projects/transfer?project_id=${projectId}`, {
     method: "GET",

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts
@@ -215,6 +215,38 @@ it("should fail if the neon client details are missing", async ({ expect }) => {
   `);
 });
 
+it("should fail if the neon client authorization header is malformed", async ({ expect }) => {
+  const projectId = "73782539-cf39-486b-a9f8-9b2893f79ef2";
+  const response = await niceBackendFetch(urlString`/api/v1/integrations/neon/projects/transfer?project_id=${projectId}`, {
+    method: "GET",
+    headers: {
+      "Authorization": "Basic",
+    },
+  });
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 400,
+      "body": {
+        "code": "SCHEMA_ERROR",
+        "details": {
+          "message": deindent\`
+            Request validation failed on GET /api/v1/integrations/neon/projects/transfer:
+              - Authorization header must be in the format "Basic <base64>"
+          \`,
+        },
+        "error": deindent\`
+          Request validation failed on GET /api/v1/integrations/neon/projects/transfer:
+            - Authorization header must be in the format "Basic <base64>"
+        \`,
+      },
+      "headers": Headers {
+        "x-stack-known-error": "SCHEMA_ERROR",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+});
+
 it("should fail to transfer project if the user is not signed in", async ({ expect }) => {
   const provisioned = await provisionProject();
   const projectId = provisioned.body.project_id;
@@ -305,4 +337,3 @@ it("should fail the check if project was already transferred", async ({ expect }
     }
   `);
 });
-

--- a/packages/stack-shared/src/schema-fields.ts
+++ b/packages/stack-shared/src/schema-fields.ts
@@ -887,7 +887,7 @@ export const neonAuthorizationHeaderSchema = basicAuthorizationHeaderSchema.test
   return false;
 });
 import.meta.vitest?.test("neonAuthorizationHeaderSchema handles malformed Basic auth as a validation error", async ({ expect }) => {
-  await expect(neonAuthorizationHeaderSchema.validate("Basic")).rejects.toThrow('Authorization header must be in the format "Basic <base64>"');
+  await expect(neonAuthorizationHeaderSchema.validate("Basic", { abortEarly: false })).rejects.toThrow('Authorization header must be in the format "Basic <base64>"');
 });
 
 // Utils

--- a/packages/stack-shared/src/schema-fields.ts
+++ b/packages/stack-shared/src/schema-fields.ts
@@ -3,7 +3,7 @@ import { KnownErrors } from "./known-errors";
 import { isBase64 } from "./utils/bytes";
 import { SUPPORTED_CURRENCIES, type Currency, type MoneyAmount } from "./utils/currency-constants";
 import type { DayInterval, Interval } from "./utils/dates";
-import { StackAssertionError, throwErr } from "./utils/errors";
+import { StackAssertionError } from "./utils/errors";
 import { decodeBasicAuthorizationHeader } from "./utils/http";
 import { allProviders } from "./utils/oauth";
 import { deepPlainClone, omit, typedFromEntries } from "./utils/objects";
@@ -878,11 +878,16 @@ export const basicAuthorizationHeaderSchema = yupString().test('is-basic-authori
 // Neon integration
 export const neonAuthorizationHeaderSchema = basicAuthorizationHeaderSchema.test('is-authorization-header', 'Invalid client_id:client_secret values; did you use the correct values for the integration?', (value) => {
   if (!value) return true;
-  const [clientId, clientSecret] = decodeBasicAuthorizationHeader(value) ?? throwErr(`Authz header invalid? This should've been validated by basicAuthorizationHeaderSchema: ${value}`);
+  const decoded = decodeBasicAuthorizationHeader(value);
+  if (decoded === null) return true;
+  const [clientId, clientSecret] = decoded;
   for (const neonClientConfig of JSON.parse(process.env.STACK_INTEGRATION_CLIENTS_CONFIG || '[]')) {
     if (clientId === neonClientConfig.client_id && clientSecret === neonClientConfig.client_secret) return true;
   }
   return false;
+});
+import.meta.vitest?.test("neonAuthorizationHeaderSchema handles malformed Basic auth as a validation error", async ({ expect }) => {
+  await expect(neonAuthorizationHeaderSchema.validate("Basic")).rejects.toThrow('Authorization header must be in the format "Basic <base64>"');
 });
 
 // Utils


### PR DESCRIPTION
## What changed

This fixes Sentry issue [STACK-BACKEND-1A3](https://stackframe-pw.sentry.io/issues/7436639623/?project=4507442898272256&query=is%3Aunresolved&referrer=issue-stream&seerDrawer=true).

A request with this malformed header:

```http
Authorization: Basic
```

used to crash the Neon auth validator with a `StackAssertionError`, which turned a bad client request into a 500.

The fix makes `neonAuthorizationHeaderSchema` only validate Neon client credentials after the Basic auth header successfully decodes. If decoding fails, the Neon-specific validator returns `true` and lets `basicAuthorizationHeaderSchema` produce the intended 400 schema error: `Authorization header must be in the format "Basic <base64>"`.

## Reviewer walkthrough

There are two checks chained together:

1. `basicAuthorizationHeaderSchema` checks that the header is structurally valid Basic auth.
2. `neonAuthorizationHeaderSchema` checks that the decoded `client_id:client_secret` matches a configured Neon client.

Yup may still run the second check after the first one has failed, because route validation collects errors with `abortEarly: false`. The old code assumed the first check had already passed and called `throwErr(...)` when decoding returned `null`. This PR changes that path to return `true`, because the format error is already owned by the first check.

## Tests

- `pnpm -C packages/stack-shared exec vitest run --maxWorkers=1 --minWorkers=1 src/schema-fields.ts`
- `pnpm -C apps/e2e exec vitest run --maxWorkers=1 --minWorkers=1 tests/backend/endpoints/api/v1/integrations/neon/projects/transfer.test.ts -t "malformed"`
- `pnpm -C packages/stack-shared lint`
- `pnpm -C packages/stack-shared typecheck`
- `pnpm -C apps/e2e lint`
- `pnpm -C apps/e2e typecheck`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authorization header validation so malformed Basic credentials yield the standard, user-facing validation error instead of a provider-specific response.

* **Tests**
  * Added end-to-end and unit tests covering authorization header validation and edge cases to ensure consistent 400/SCHEMA_ERROR responses and expected error details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->