### PR TITLE
Add stack doctor

### DIFF
--- a/apps/e2e/tests/general/cli.test.ts
+++ b/apps/e2e/tests/general/cli.test.ts
@@ -565,3 +565,416 @@ describe("Stack CLI — Emulator", () => {
     expect(stdout).toContain("--repo");
   });
 });
+
+// Doctor CLI tests — no backend required. Each test builds a fixture project
+// in a temp dir and runs `stack doctor --output-dir <dir> --json`.
+describe("Stack CLI — Doctor", () => {
+  let doctorTmpRoot: string;
+
+  beforeAll(() => {
+    if (!fs.existsSync(CLI_BIN)) {
+      throw new Error("CLI not built. Run `pnpm --filter @stackframe/stack-cli run build` first.");
+    }
+    doctorTmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), "stack-cli-doctor-test-"));
+  });
+
+  afterAll(() => {
+    if (doctorTmpRoot && fs.existsSync(doctorTmpRoot)) {
+      fs.rmSync(doctorTmpRoot, { recursive: true });
+    }
+  });
+
+  function runDoctor(
+    args: string[],
+    envOverrides?: Record<string, string>,
+  ): Promise<{ stdout: string, stderr: string, exitCode: number | null }> {
+    const env: Record<string, string> = {
+      PATH: process.env.PATH ?? "",
+      HOME: process.env.HOME ?? "",
+      CI: "1",
+      ...envOverrides,
+    };
+    return new Promise((resolve) => {
+      execFile("node", [CLI_BIN, ...args], {
+        env,
+        timeout: 30_000,
+      }, (error, stdout, stderr) => {
+        resolve({
+          stdout: stdout.toString(),
+          stderr: stderr.toString(),
+          exitCode: error ? (error as any).code ?? 1 : 0,
+        });
+      });
+    });
+  }
+
+  function makeProject(subdir: string, files: Record<string, string>): string {
+    const dir = path.join(doctorTmpRoot, `${subdir}-${crypto.randomUUID().slice(0, 8)}`);
+    fs.mkdirSync(dir, { recursive: true });
+    for (const [rel, content] of Object.entries(files)) {
+      const full = path.join(dir, rel);
+      fs.mkdirSync(path.dirname(full), { recursive: true });
+      fs.writeFileSync(full, content);
+    }
+    return dir;
+  }
+
+  function pkg(extra: Record<string, unknown>): string {
+    return JSON.stringify({ name: "fixture", version: "0.0.0", ...extra }, null, 2);
+  }
+
+  // Reusable Next.js all-green fixture
+  function nextHappyFiles(): Record<string, string> {
+    return {
+      "package.json": pkg({
+        dependencies: { next: "14.0.0", "@stackframe/stack": "1.0.0" },
+      }),
+      "stack/client.ts": "export const stackClientApp = {};\n",
+      "stack/server.ts": "export const stackServerApp = {};\n",
+      "app/handler/[...stack]/page.tsx": "export default function Page() { return null; }\n",
+      "app/layout.tsx":
+        `import { StackProvider } from "@stackframe/stack";\n` +
+        `export default function RootLayout({ children }) {\n` +
+        `  return <StackProvider>{children}</StackProvider>;\n` +
+        `}\n`,
+      ".env.local":
+        `NEXT_PUBLIC_STACK_PROJECT_ID=proj_test\n` +
+        `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=pck_test\n` +
+        `STACK_SECRET_SERVER_KEY="ssk_test"\n`,
+    };
+  }
+
+  it("doctor --help shows options", async ({ expect }) => {
+    const { stdout, exitCode } = await runDoctor(["doctor", "--help"]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("--output-dir");
+    expect(stdout).toContain("--framework");
+    expect(stdout).toContain("--json");
+  });
+
+  it("fails when package.json is missing", async ({ expect }) => {
+    const dir = makeProject("no-pkg", {});
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toBe("no package.json");
+    expect(parsed.projectDir).toBe(dir);
+  });
+
+  it("fails when package.json is invalid JSON", async ({ expect }) => {
+    const dir = makeProject("bad-pkg", { "package.json": "not json" });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toBe("invalid package.json");
+    expect(typeof parsed.detail).toBe("string");
+    expect(parsed.detail.length).toBeGreaterThan(0);
+  });
+
+  it("fails when no dependencies declared", async ({ expect }) => {
+    const dir = makeProject("empty-deps", { "package.json": pkg({}) });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("no dependencies");
+  });
+
+  it("rejects Next.js project without app router", async ({ expect }) => {
+    const dir = makeProject("next-pages", {
+      "package.json": pkg({ dependencies: { next: "14.0.0" } }),
+      "pages/index.tsx": "export default function Home() { return null; }\n",
+    });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("pages router");
+  });
+
+  it("rejects unknown --framework value", async ({ expect }) => {
+    const dir = makeProject("bad-fw", { "package.json": pkg({ dependencies: { next: "14.0.0" } }) });
+    const { stdout, exitCode } = await runDoctor([
+      "doctor", "--output-dir", dir, "--framework", "bogus", "--json",
+    ]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.error).toContain("Unknown framework");
+  });
+
+  it("--framework override applies even when deps don't list it", async ({ expect }) => {
+    const dir = makeProject("fw-override", {
+      "package.json": pkg({ dependencies: { something: "1.0.0" } }),
+      "app/marker.txt": "ensures app router exists\n",
+    });
+    const { stdout, exitCode } = await runDoctor([
+      "doctor", "--output-dir", dir, "--framework", "next", "--json",
+    ]);
+    // Will fail many checks (no Stack package, no files), but framework should be next.
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("next");
+  });
+
+  it("Next.js happy path passes all checks", async ({ expect }) => {
+    const dir = makeProject("next-happy", nextHappyFiles());
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("next");
+    expect(parsed.failed).toBe(0);
+    expect(parsed.warned).toBe(0);
+    expect(parsed.checks.every((c: any) => c.status === "pass")).toBe(true);
+  });
+
+  it("Next.js applies src/ prefix when src/app exists", async ({ expect }) => {
+    const dir = makeProject("next-src", {
+      "package.json": pkg({
+        dependencies: { next: "14.0.0", "@stackframe/stack": "1.0.0" },
+      }),
+      "src/stack/client.ts": "export const stackClientApp = {};\n",
+      "src/stack/server.ts": "export const stackServerApp = {};\n",
+      "src/app/handler/[...stack]/page.tsx": "export default function P() { return null; }\n",
+      "src/app/layout.tsx":
+        `import { StackProvider } from "@stackframe/stack";\n` +
+        `export default function L({ children }) { return <StackProvider>{children}</StackProvider>; }\n`,
+      ".env.local":
+        `NEXT_PUBLIC_STACK_PROJECT_ID=p\n` +
+        `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=k\n` +
+        `STACK_SECRET_SERVER_KEY=s\n`,
+    });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const clientCheck = parsed.checks.find((c: any) => c.id === "next.client-app");
+    expect(clientCheck.status).toBe("pass");
+    expect(clientCheck.label).toContain("src/stack/client.ts");
+  });
+
+  it("React happy path passes all checks", async ({ expect }) => {
+    const dir = makeProject("react-happy", {
+      "package.json": pkg({
+        dependencies: { react: "18.0.0", "@stackframe/react": "1.0.0" },
+      }),
+      "stack/client.ts": "export const stackClientApp = {};\n",
+      ".env.local":
+        `VITE_STACK_PROJECT_ID=p\n` +
+        `VITE_STACK_PUBLISHABLE_CLIENT_KEY=k\n`,
+    });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("react");
+    expect(parsed.failed).toBe(0);
+  });
+
+  it("JS catch-all happy path passes all checks", async ({ expect }) => {
+    const dir = makeProject("js-happy", {
+      "package.json": pkg({
+        dependencies: { svelte: "4.0.0", "@stackframe/js": "1.0.0" },
+      }),
+      "stack/server.ts": "export const stackServerApp = {};\n",
+      ".env":
+        `STACK_PROJECT_ID=p\n` +
+        `STACK_PUBLISHABLE_CLIENT_KEY=k\n` +
+        `STACK_SECRET_SERVER_KEY=s\n`,
+    });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("js");
+    expect(parsed.failed).toBe(0);
+  });
+
+  it("JS catch-all accepts PUBLIC_* env aliases", async ({ expect }) => {
+    const dir = makeProject("js-public", {
+      "package.json": pkg({
+        dependencies: { svelte: "4.0.0", "@stackframe/js": "1.0.0" },
+      }),
+      "stack/client.ts": "export const stackClientApp = {};\n",
+      ".env":
+        `PUBLIC_STACK_PROJECT_ID=p\n` +
+        `PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=k\n` +
+        `STACK_SECRET_SERVER_KEY=s\n`,
+    });
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("js");
+    expect(parsed.failed).toBe(0);
+  });
+
+  it("fails when @stackframe/stack is not installed", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["package.json"] = pkg({ dependencies: { next: "14.0.0" } });
+    const dir = makeProject("no-stack-pkg", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.package");
+    expect(check.status).toBe("fail");
+  });
+
+  it("fails when client app file is missing", async ({ expect }) => {
+    const files = nextHappyFiles();
+    delete files["stack/client.ts"];
+    const dir = makeProject("no-client", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.client-app");
+    expect(check.status).toBe("fail");
+  });
+
+  it("fails when handler route is missing", async ({ expect }) => {
+    const files = nextHappyFiles();
+    delete files["app/handler/[...stack]/page.tsx"];
+    const dir = makeProject("no-handler", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.handler-route");
+    expect(check.status).toBe("fail");
+    expect(check.hint).toContain("app/handler/[...stack]/page.tsx");
+  });
+
+  it("warns when layout imports StackProvider but does not render it", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["app/layout.tsx"] =
+      `import { StackProvider } from "@stackframe/stack";\n` +
+      `export default function L({ children }) { return <html><body>{children}</body></html>; }\n`;
+    const dir = makeProject("layout-no-jsx", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    // Warn does not flip exit code.
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.layout-provider");
+    expect(check.status).toBe("warn");
+  });
+
+  it("fails when layout renders <StackProvider> without importing it", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["app/layout.tsx"] =
+      `export default function L({ children }) { return <StackProvider>{children}</StackProvider>; }\n`;
+    const dir = makeProject("layout-no-import", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.layout-provider");
+    expect(check.status).toBe("fail");
+  });
+
+  it("fails when layout file is missing entirely", async ({ expect }) => {
+    const files = nextHappyFiles();
+    delete files["app/layout.tsx"];
+    const dir = makeProject("layout-missing", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "next.layout-provider");
+    expect(check.status).toBe("fail");
+  });
+
+  it("fails when a required env var is missing", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files[".env.local"] =
+      `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=k\n` +
+      `STACK_SECRET_SERVER_KEY=s\n`;
+    const dir = makeProject("env-fail", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "env-vars");
+    expect(check.status).toBe("fail");
+    expect(check.label).toContain("NEXT_PUBLIC_STACK_PROJECT_ID");
+  });
+
+  it("warns (without failing) when only the recommended env var is missing", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files[".env.local"] =
+      `NEXT_PUBLIC_STACK_PROJECT_ID=p\n` +
+      `STACK_SECRET_SERVER_KEY=s\n`;
+    const dir = makeProject("env-warn", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "env-vars");
+    expect(check.status).toBe("warn");
+    expect(check.label).toContain("NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY");
+  });
+
+  it("resolves env vars from .env.local before .env", async ({ expect }) => {
+    const files = nextHappyFiles();
+    // .env is missing the required project ID; .env.local supplies it.
+    files[".env"] = `UNRELATED=1\n`;
+    files[".env.local"] =
+      `NEXT_PUBLIC_STACK_PROJECT_ID=p\n` +
+      `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY=k\n` +
+      `STACK_SECRET_SERVER_KEY=s\n`;
+    const dir = makeProject("env-precedence", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "env-vars");
+    expect(check.status).toBe("pass");
+  });
+
+  it("skips config-file check when stack.config.ts is absent", async ({ expect }) => {
+    const dir = makeProject("no-config", nextHappyFiles());
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "config-file");
+    expect(check).toBeUndefined();
+  });
+
+  it("fails config-file check when config export is an array", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["stack.config.ts"] = "export const config = [];\n";
+    const dir = makeProject("config-array", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "config-file");
+    expect(check.status).toBe("fail");
+    expect(check.label).toContain("not a plain object");
+  });
+
+  it("fails config-file check when there is no config export", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["stack.config.ts"] = "export const other = 1;\n";
+    const dir = makeProject("config-missing", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(1);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "config-file");
+    expect(check.status).toBe("fail");
+    expect(check.label).toContain("missing a `config` export");
+  });
+
+  it("passes config-file check when config is a valid plain object", async ({ expect }) => {
+    const files = nextHappyFiles();
+    files["stack.config.ts"] = "export const config = { apps: { installed: {} } };\n";
+    const dir = makeProject("config-ok", files);
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir, "--json"]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    const check = parsed.checks.find((c: any) => c.id === "config-file");
+    expect(check.status).toBe("pass");
+  });
+
+  it("renders a human report with header and summary when --json is omitted", async ({ expect }) => {
+    const dir = makeProject("human", nextHappyFiles());
+    const { stdout, exitCode } = await runDoctor(["doctor", "--output-dir", dir]);
+    expect(exitCode).toBe(0);
+    expect(stdout).toContain("Stack Auth doctor");
+    expect(stdout).toMatch(/\d+ passed, \d+ failed/);
+  });
+
+  it("honors top-level --json flag (stack --json doctor)", async ({ expect }) => {
+    const dir = makeProject("top-json", nextHappyFiles());
+    const { stdout, exitCode } = await runDoctor(["--json", "doctor", "--output-dir", dir]);
+    expect(exitCode).toBe(0);
+    const parsed = JSON.parse(stdout);
+    expect(parsed.framework).toBe("next");
+    expect(Array.isArray(parsed.checks)).toBe(true);
+  });
+});

--- a/packages/stack-cli/src/commands/doctor.ts
+++ b/packages/stack-cli/src/commands/doctor.ts
@@ -1,0 +1,540 @@
+import { Command } from "commander";
+import * as fs from "fs";
+import * as path from "path";
+
+type Framework = "next" | "react" | "js";
+
+type PackageJson = {
+  dependencies?: Record<string, string>,
+  devDependencies?: Record<string, string>,
+  [key: string]: unknown,
+};
+
+type CheckCtx = {
+  projectDir: string,
+  packageJson: PackageJson,
+  framework: Framework,
+  srcPrefix: "src/" | "",
+};
+
+type CheckStatus = "pass" | "fail" | "warn";
+
+type CheckResult = {
+  id: string,
+  label: string,
+  status: CheckStatus,
+  detail?: string,
+  hint?: string,
+};
+
+type CheckSpec = {
+  id: string,
+  label: string,
+  run: (ctx: CheckCtx) => CheckResult | null | Promise<CheckResult | null>,
+};
+
+type DoctorOptions = {
+  outputDir?: string,
+  framework?: string,
+  json?: boolean,
+};
+
+type Report = {
+  framework: Framework,
+  projectDir: string,
+  checks: CheckResult[],
+  passed: number,
+  failed: number,
+  warned: number,
+};
+
+export function registerDoctorCommand(program: Command) {
+  program
+    .command("doctor")
+    .description("Check that Stack Auth is correctly wired up in your project")
+    .option("--output-dir <dir>", "Project root to inspect (defaults to cwd)")
+    .option("--framework <fw>", "Override framework detection (next | react | js)")
+    .option("--json", "Emit a machine-readable JSON report")
+    .action(async (opts: DoctorOptions) => {
+      const parentJson = Boolean((program.opts() as { json?: boolean }).json);
+      const exitCode = await runDoctor({ ...opts, json: opts.json || parentJson });
+      process.exit(exitCode);
+    });
+}
+
+async function runDoctor(opts: DoctorOptions): Promise<number> {
+  const projectDir = opts.outputDir ? path.resolve(opts.outputDir) : process.cwd();
+
+  const pkgRead = readPackageJson(projectDir);
+  if (pkgRead.kind === "missing") {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: "no package.json", projectDir }));
+    } else {
+      console.error(`No package.json found at ${projectDir}. Doctor needs a Node.js project root.`);
+    }
+    return 1;
+  }
+  if (pkgRead.kind === "invalid") {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: "invalid package.json", projectDir, detail: pkgRead.error }));
+    } else {
+      console.error(`Invalid package.json at ${projectDir}: ${pkgRead.error}`);
+    }
+    return 1;
+  }
+  const packageJson = pkgRead.value;
+
+  const framework = resolveFramework(opts.framework, packageJson, projectDir);
+  if (framework.kind === "unsupported") {
+    if (opts.json) {
+      console.log(JSON.stringify({ error: framework.reason, projectDir }));
+    } else {
+      console.error(framework.reason);
+    }
+    return 1;
+  }
+
+  const srcPrefix = resolveSrcPrefix(framework.value, projectDir);
+  const ctx: CheckCtx = { projectDir, packageJson, framework: framework.value, srcPrefix };
+  const specs = getChecks(framework.value);
+
+  const results: CheckResult[] = [];
+  for (const spec of specs) {
+    const r = await spec.run(ctx);
+    if (r) results.push(r);
+  }
+
+  const passed = results.filter((r) => r.status === "pass").length;
+  const failed = results.filter((r) => r.status === "fail").length;
+  const warned = results.filter((r) => r.status === "warn").length;
+
+  const report: Report = { framework: framework.value, projectDir, checks: results, passed, failed, warned };
+
+  if (opts.json) {
+    console.log(JSON.stringify(report, null, 2));
+  } else {
+    renderHuman(report);
+  }
+
+  return failed > 0 ? 1 : 0;
+}
+
+type PackageJsonRead =
+  | { kind: "ok", value: PackageJson }
+  | { kind: "missing" }
+  | { kind: "invalid", error: string };
+
+function readPackageJson(projectDir: string): PackageJsonRead {
+  const pkgPath = path.join(projectDir, "package.json");
+  if (!fs.existsSync(pkgPath)) return { kind: "missing" };
+  const raw = fs.readFileSync(pkgPath, "utf-8");
+  try {
+    return { kind: "ok", value: JSON.parse(raw) as PackageJson };
+  } catch (error) {
+    if (error instanceof SyntaxError) {
+      return { kind: "invalid", error: error.message };
+    }
+    throw error;
+  }
+}
+
+type FrameworkResolution =
+  | { kind: "ok", value: Framework }
+  | { kind: "unsupported", reason: string };
+
+function resolveSrcPrefix(framework: Framework, projectDir: string): "src/" | "" {
+  if (framework === "next") {
+    return fs.existsSync(path.join(projectDir, "src/app")) ? "src/" : "";
+  }
+  return fs.existsSync(path.join(projectDir, "src")) ? "src/" : "";
+}
+
+function resolveFramework(
+  override: string | undefined,
+  pkg: PackageJson,
+  projectDir: string,
+): FrameworkResolution {
+  if (override) {
+    if (override === "next" || override === "react" || override === "js") {
+      return { kind: "ok", value: override };
+    }
+    return { kind: "unsupported", reason: `Unknown framework: ${override}. Expected one of: next, react, js.` };
+  }
+
+  const allDeps = { ...(pkg.dependencies ?? {}), ...(pkg.devDependencies ?? {}) };
+
+  if (allDeps.next) {
+    const hasAppRouter = fs.existsSync(path.join(projectDir, "app"))
+      || fs.existsSync(path.join(projectDir, "src/app"));
+    if (!hasAppRouter) {
+      return {
+        kind: "unsupported",
+        reason: "Detected Next.js but no app router (app/ or src/app/). The pages router is not yet supported by Stack Auth doctor.",
+      };
+    }
+    return { kind: "ok", value: "next" };
+  }
+
+  if (allDeps.react || allDeps["react-dom"]) {
+    return { kind: "ok", value: "react" };
+  }
+
+  if (Object.keys(allDeps).length > 0) {
+    return { kind: "ok", value: "js" };
+  }
+
+  return { kind: "unsupported", reason: "package.json has no dependencies declared — install one of @stackframe/stack, @stackframe/react, or @stackframe/js to begin." };
+}
+
+function getChecks(framework: Framework): CheckSpec[] {
+  switch (framework) {
+    case "next": {
+      return NEXT_CHECKS;
+    }
+    case "react": {
+      return REACT_CHECKS;
+    }
+    case "js": {
+      return JS_CHECKS;
+    }
+  }
+}
+
+const NEXT_CHECKS: CheckSpec[] = [
+  packageInstalledCheck("next.package", "@stackframe/stack"),
+  fileExistsCheck("next.client-app", "Stack client app instance", [
+    "stack/client.ts", "stack/client.tsx",
+  ]),
+  fileExistsCheck("next.server-app", "Stack server app instance", [
+    "stack/server.ts", "stack/server.tsx",
+  ]),
+  fileExistsCheck("next.handler-route", "Handler route", [
+    "app/handler/[...stack]/page.tsx", "app/handler/[...stack]/page.ts",
+    "app/handler/[...stack]/page.jsx", "app/handler/[...stack]/page.js",
+  ], "Create app/handler/[...stack]/page.tsx that renders <StackHandler fullPage app={stackServerApp} routeProps={props} />."),
+  layoutWrapsStackProviderCheck(),
+  envVarsCheck([
+    { names: ["NEXT_PUBLIC_STACK_PROJECT_ID"], severity: "fail" },
+    { names: ["NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"], severity: "warn" },
+    { names: ["STACK_SECRET_SERVER_KEY"], severity: "fail" },
+  ]),
+  configFileCheck(),
+];
+
+const REACT_CHECKS: CheckSpec[] = [
+  packageInstalledCheck("react.package", "@stackframe/react"),
+  fileExistsCheck("react.client-app", "Stack client app instance", [
+    "stack/client.ts", "stack/client.tsx",
+  ]),
+  envVarsCheck([
+    { names: ["VITE_STACK_PROJECT_ID"], severity: "fail" },
+    { names: ["VITE_STACK_PUBLISHABLE_CLIENT_KEY"], severity: "warn" },
+  ]),
+  configFileCheck(),
+];
+
+const JS_CHECKS: CheckSpec[] = [
+  packageInstalledCheck("js.package", "@stackframe/js"),
+  fileExistsCheck("js.app", "Stack app instance", [
+    "stack/client.ts", "stack/server.ts",
+  ]),
+  envVarsCheck([
+    // PUBLIC_* aliases cover SvelteKit / Astro, which require that prefix
+    // to expose vars to client code.
+    { names: ["STACK_PROJECT_ID", "PUBLIC_STACK_PROJECT_ID"], severity: "fail" },
+    { names: ["STACK_PUBLISHABLE_CLIENT_KEY", "PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY"], severity: "warn" },
+    { names: ["STACK_SECRET_SERVER_KEY"], severity: "fail" },
+  ]),
+  configFileCheck(),
+];
+
+function packageInstalledCheck(id: string, packageName: string): CheckSpec {
+  const label = `${packageName} installed`;
+  return {
+    id,
+    label,
+    run: (ctx) => {
+      const allDeps = {
+        ...(ctx.packageJson.dependencies ?? {}),
+        ...(ctx.packageJson.devDependencies ?? {}),
+      };
+      if (allDeps[packageName]) {
+        return { id, label, status: "pass" };
+      }
+      return {
+        id,
+        label,
+        status: "fail",
+        detail: `${packageName} is not in dependencies or devDependencies.`,
+        hint: `Install it: npm install ${packageName} (or pnpm/yarn/bun equivalent).`,
+      };
+    },
+  };
+}
+
+function fileExistsCheck(id: string, label: string, candidates: string[], extraHint?: string): CheckSpec {
+  return {
+    id,
+    label,
+    run: (ctx) => {
+      const resolved = candidates.map((c) => `${ctx.srcPrefix}${c}`);
+      for (const rel of resolved) {
+        if (fs.existsSync(path.join(ctx.projectDir, rel))) {
+          return {
+            id,
+            label: `${label} found (${rel})`,
+            status: "pass",
+          };
+        }
+      }
+      return {
+        id,
+        label: `${label} missing`,
+        status: "fail",
+        detail: `Expected one of: ${resolved.join(", ")}`,
+        hint: extraHint,
+      };
+    },
+  };
+}
+
+function layoutWrapsStackProviderCheck(): CheckSpec {
+  const id = "next.layout-provider";
+  const label = "Root layout wraps children in <StackProvider>";
+  const baseCandidates = [
+    "app/layout.tsx", "app/layout.jsx", "app/layout.ts", "app/layout.js",
+  ];
+  return {
+    id,
+    label,
+    run: (ctx) => {
+      const candidates = baseCandidates.map((c) => `${ctx.srcPrefix}${c}`);
+      let foundPath: string | null = null;
+      for (const candidate of candidates) {
+        const full = path.join(ctx.projectDir, candidate);
+        if (fs.existsSync(full)) {
+          foundPath = full;
+          break;
+        }
+      }
+      if (!foundPath) {
+        return {
+          id,
+          label: "Root layout missing",
+          status: "fail",
+          detail: `Expected one of: ${candidates.join(", ")}`,
+        };
+      }
+
+      const content = fs.readFileSync(foundPath, "utf-8");
+      const importsStackProvider = /from\s+["']@stackframe\/stack["']/.test(content)
+        && /\bStackProvider\b/.test(content);
+      const wrapsJsx = /<StackProvider\b/.test(content);
+
+      const rel = path.relative(ctx.projectDir, foundPath);
+      if (importsStackProvider && wrapsJsx) {
+        return { id, label, status: "pass" };
+      }
+      if (importsStackProvider && !wrapsJsx) {
+        return {
+          id,
+          label,
+          status: "warn",
+          detail: `${rel} imports StackProvider from @stackframe/stack but does not render it.`,
+          hint: "Wrap {children} with <StackProvider app={stackClientApp}>...</StackProvider>.",
+        };
+      }
+      if (!importsStackProvider && wrapsJsx) {
+        return {
+          id,
+          label,
+          status: "fail",
+          detail: `${rel} renders <StackProvider> but is missing the import from @stackframe/stack.`,
+          hint: `Add: import { StackProvider } from "@stackframe/stack";`,
+        };
+      }
+      return {
+        id,
+        label,
+        status: "fail",
+        detail: `${rel} does not import StackProvider from @stackframe/stack.`,
+        hint: `Add: import { StackProvider } from "@stackframe/stack"; and wrap {children} with <StackProvider app={stackClientApp}>...</StackProvider>.`,
+      };
+    },
+  };
+}
+
+type EnvVarSpec = {
+  names: string[],
+  severity: "fail" | "warn",
+};
+
+function envVarsCheck(specs: EnvVarSpec[]): CheckSpec {
+  return {
+    id: "env-vars",
+    label: `Required env vars (${specs.length})`,
+    run: (ctx) => {
+      const fromFiles = readEnvFiles(ctx.projectDir);
+      const missingHard: string[] = [];
+      const missingSoft: string[] = [];
+      for (const spec of specs) {
+        const present = spec.names.some((n) => {
+          const v = n in fromFiles ? fromFiles[n] : (process.env[n] ?? "");
+          return v.trim().length > 0;
+        });
+        if (!present) {
+          const display = spec.names.length === 1 ? spec.names[0] : spec.names.join(" / ");
+          if (spec.severity === "fail") missingHard.push(display);
+          else missingSoft.push(display);
+        }
+      }
+      if (missingHard.length === 0 && missingSoft.length === 0) {
+        return { id: "env-vars", label: "Env vars present", status: "pass" };
+      }
+      if (missingHard.length === 0) {
+        return {
+          id: "env-vars",
+          label: `Missing recommended env vars: ${missingSoft.join(", ")}`,
+          status: "warn",
+          detail: "Looked in .env.local, .env, and process.env. These may be required depending on dashboard settings (e.g. \"require publishable client keys\").",
+          hint: "Set them in .env.local if your project requires them.",
+        };
+      }
+      const allMissing = [...missingHard, ...missingSoft];
+      return {
+        id: "env-vars",
+        label: `Missing env vars: ${allMissing.join(", ")}`,
+        status: "fail",
+        detail: "Looked in .env.local, .env, and process.env.",
+        hint: "Set the missing variables in .env.local (do not commit secrets).",
+      };
+    },
+  };
+}
+
+function configFileCheck(): CheckSpec {
+  const id = "config-file";
+  const label = "stack.config validity";
+  const candidates = ["stack.config.ts", "stack.config.js"];
+  return {
+    id,
+    label,
+    run: async (ctx) => {
+      let foundPath: string | null = null;
+      let foundRel: string | null = null;
+      for (const c of candidates) {
+        const full = path.join(ctx.projectDir, c);
+        if (fs.existsSync(full)) {
+          foundPath = full;
+          foundRel = c;
+          break;
+        }
+      }
+      if (!foundPath || !foundRel) return null; // skip — config file is optional
+
+      try {
+        const { createJiti } = await import("jiti");
+        const jiti = createJiti(import.meta.url);
+        const mod = await jiti.import<{ config?: unknown }>(foundPath);
+        const config = mod.config;
+        if (config === undefined) {
+          return {
+            id,
+            label: `${foundRel} is missing a \`config\` export`,
+            status: "fail",
+            detail: "The file loaded but has no `config` named export.",
+            hint: "Add: export const config = { /* ... */ };",
+          };
+        }
+        if (config === null || typeof config !== "object" || Array.isArray(config) || !isPlainObject(config)) {
+          return {
+            id,
+            label: `${foundRel} \`config\` export is not a plain object`,
+            status: "fail",
+            detail: `Expected a plain object literal, got ${describeValue(config)}.`,
+            hint: "Use: export const config = { apps: { installed: { ... } } };",
+          };
+        }
+        return { id, label: `${foundRel} loads and exports a valid config`, status: "pass" };
+      } catch (error: unknown) {
+        return {
+          id,
+          label: `${foundRel} failed to load`,
+          status: "fail",
+          detail: error instanceof Error ? error.message : String(error),
+          hint: "Fix the syntax / imports in your config file.",
+        };
+      }
+    },
+  };
+}
+
+function isPlainObject(value: unknown): value is Record<string, unknown> {
+  if (value === null || typeof value !== "object") return false;
+  const proto = Object.getPrototypeOf(value);
+  return proto === Object.prototype || proto === null;
+}
+
+function describeValue(v: unknown): string {
+  if (v === null) return "null";
+  if (Array.isArray(v)) return "array";
+  return typeof v;
+}
+
+function readEnvFiles(projectDir: string): Record<string, string> {
+  const files = [".env.local", ".env"];
+  const result: Record<string, string> = {};
+  for (const f of files) {
+    const full = path.join(projectDir, f);
+    if (!fs.existsSync(full)) continue;
+    const content = fs.readFileSync(full, "utf-8");
+    for (const line of content.split("\n")) {
+      const trimmed = line.trim();
+      if (!trimmed || trimmed.startsWith("#")) continue;
+      const eq = trimmed.indexOf("=");
+      if (eq < 0) continue;
+      const key = trimmed.slice(0, eq).trim();
+      let value = trimmed.slice(eq + 1).trim();
+      if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
+        value = value.slice(1, -1);
+      }
+      if (!(key in result)) result[key] = value;
+    }
+  }
+  return result;
+}
+
+function renderHuman(report: Report) {
+  const useColor = process.stdout.isTTY;
+  const green = useColor ? "\x1b[32m" : "";
+  const red = useColor ? "\x1b[31m" : "";
+  const yellow = useColor ? "\x1b[33m" : "";
+  const dim = useColor ? "\x1b[2m" : "";
+  const reset = useColor ? "\x1b[0m" : "";
+
+  const frameworkName =
+    report.framework === "next" ? "Next.js" :
+      report.framework === "react" ? "React" :
+        "JS / Node";
+
+  console.log(`\nStack Auth doctor — ${frameworkName} project at ${report.projectDir}\n`);
+
+  for (const r of report.checks) {
+    const icon =
+      r.status === "pass" ? `${green}✔${reset}` :
+        r.status === "warn" ? `${yellow}⚠${reset}` :
+      `${red}✘${reset}`;
+    console.log(`${icon} ${r.label}`);
+    if (r.detail) console.log(`  ${dim}${r.detail}${reset}`);
+    if (r.hint) console.log(`  ${dim}Hint: ${r.hint}${reset}`);
+  }
+
+  console.log();
+  const summary = `${report.passed} passed, ${report.failed} failed${report.warned > 0 ? `, ${report.warned} warned` : ""}.`;
+  console.log(summary);
+  if (report.failed > 0) {
+    console.log(`${dim}Tip: run \`stack fix\` and paste the runtime error to apply fixes automatically.${reset}`);
+  }
+}
+
+export type { CheckResult, Report };

--- a/packages/stack-cli/src/commands/doctor.ts
+++ b/packages/stack-cli/src/commands/doctor.ts
@@ -327,8 +327,8 @@ function layoutWrapsStackProviderCheck(): CheckSpec {
       }
 
       const content = fs.readFileSync(foundPath, "utf-8");
-      const importsStackProvider = /from\s+["']@stackframe\/stack["']/.test(content)
-        && /\bStackProvider\b/.test(content);
+      const importsStackProvider =
+        /import\s*\{[^}]*\bStackProvider\b[^}]*\}\s*from\s*["']@stackframe\/stack["']/.test(content);
       const wrapsJsx = /<StackProvider\b/.test(content);
 
       const rel = path.relative(ctx.projectDir, foundPath);
@@ -379,7 +379,7 @@ function envVarsCheck(specs: EnvVarSpec[]): CheckSpec {
       const missingSoft: string[] = [];
       for (const spec of specs) {
         const present = spec.names.some((n) => {
-          const v = n in fromFiles ? fromFiles[n] : (process.env[n] ?? "");
+          const v = fromFiles.has(n) ? fromFiles.get(n)! : (process.env[n] ?? "");
           return v.trim().length > 0;
         });
         if (!present) {
@@ -481,9 +481,9 @@ function describeValue(v: unknown): string {
   return typeof v;
 }
 
-function readEnvFiles(projectDir: string): Record<string, string> {
+function readEnvFiles(projectDir: string): Map<string, string> {
   const files = [".env.local", ".env"];
-  const result: Record<string, string> = {};
+  const result = new Map<string, string>();
   for (const f of files) {
     const full = path.join(projectDir, f);
     if (!fs.existsSync(full)) continue;
@@ -493,12 +493,19 @@ function readEnvFiles(projectDir: string): Record<string, string> {
       if (!trimmed || trimmed.startsWith("#")) continue;
       const eq = trimmed.indexOf("=");
       if (eq < 0) continue;
-      const key = trimmed.slice(0, eq).trim();
-      let value = trimmed.slice(eq + 1).trim();
-      if ((value.startsWith("\"") && value.endsWith("\"")) || (value.startsWith("'") && value.endsWith("'"))) {
-        value = value.slice(1, -1);
+      let key = trimmed.slice(0, eq).trim();
+      if (key.startsWith("export ")) key = key.slice("export ".length).trim();
+      const rawValue = trimmed.slice(eq + 1).trimStart();
+      let value: string;
+      const quote = rawValue.startsWith("\"") ? "\"" : rawValue.startsWith("'") ? "'" : null;
+      if (quote) {
+        const end = rawValue.indexOf(quote, 1);
+        value = end > 0 ? rawValue.slice(1, end) : rawValue.slice(1);
+      } else {
+        const commentIdx = rawValue.search(/\s#/);
+        value = (commentIdx >= 0 ? rawValue.slice(0, commentIdx) : rawValue).trimEnd();
       }
-      if (!(key in result)) result[key] = value;
+      if (!result.has(key)) result.set(key, value);
     }
   }
   return result;

--- a/packages/stack-cli/src/commands/doctor.ts
+++ b/packages/stack-cli/src/commands/doctor.ts
@@ -224,7 +224,7 @@ const NEXT_CHECKS: CheckSpec[] = [
 const REACT_CHECKS: CheckSpec[] = [
   packageInstalledCheck("react.package", "@stackframe/react"),
   fileExistsCheck("react.client-app", "Stack client app instance", [
-    "stack/client.ts", "stack/client.tsx",
+    "stack/client.ts", "stack/client.tsx", "stack/client.js", "stack/client.jsx",
   ]),
   envVarsCheck([
     { names: ["VITE_STACK_PROJECT_ID"], severity: "fail" },
@@ -236,7 +236,8 @@ const REACT_CHECKS: CheckSpec[] = [
 const JS_CHECKS: CheckSpec[] = [
   packageInstalledCheck("js.package", "@stackframe/js"),
   fileExistsCheck("js.app", "Stack app instance", [
-    "stack/client.ts", "stack/server.ts",
+    "stack/client.ts", "stack/client.tsx", "stack/client.js", "stack/client.jsx",
+    "stack/server.ts", "stack/server.tsx", "stack/server.js", "stack/server.jsx",
   ]),
   envVarsCheck([
     // PUBLIC_* aliases cover SvelteKit / Astro, which require that prefix
@@ -400,12 +401,13 @@ function envVarsCheck(specs: EnvVarSpec[]): CheckSpec {
           hint: "Set them in .env.local if your project requires them.",
         };
       }
-      const allMissing = [...missingHard, ...missingSoft];
       return {
         id: "env-vars",
-        label: `Missing env vars: ${allMissing.join(", ")}`,
+        label: `Missing env vars: ${missingHard.join(", ")}`,
         status: "fail",
-        detail: "Looked in .env.local, .env, and process.env.",
+        detail: missingSoft.length > 0
+          ? `Looked in .env.local, .env, and process.env. Also missing (may be required depending on dashboard settings): ${missingSoft.join(", ")}.`
+          : "Looked in .env.local, .env, and process.env.",
         hint: "Set the missing variables in .env.local (do not commit secrets).",
       };
     },

--- a/packages/stack-cli/src/index.ts
+++ b/packages/stack-cli/src/index.ts
@@ -11,6 +11,7 @@ import { registerInitCommand } from "./commands/init.js";
 import { registerProjectCommand } from "./commands/project.js";
 import { registerEmulatorCommand } from "./commands/emulator.js";
 import { registerFixCommand } from "./commands/fix.js";
+import { registerDoctorCommand } from "./commands/doctor.js";
 
 const __filename = fileURLToPath(import.meta.url);
 const __dirname = dirname(__filename);
@@ -33,6 +34,7 @@ registerInitCommand(program);
 registerProjectCommand(program);
 registerEmulatorCommand(program);
 registerFixCommand(program);
+registerDoctorCommand(program);
 
 async function main() {
   try {


### PR DESCRIPTION
## Summary

Adds `stack doctor` — a read-only companion to `stack fix`. No AI, no network, no edits. Detects the framework, runs a fixed list of checks, prints a pass/fail report, and exits 0 if everything's green or 1 if any check fails.

Stacked on top of #1387 (the fix-command PR) so the diff here is just the doctor work.

## Usage

```
stack doctor [--output-dir <dir>] [--framework <next|react|js>] [--json]
```

- `--output-dir`: project root to inspect (defaults to cwd).
- `--framework`: override auto-detection.
- `--json`: machine-readable report instead of the human format.

Exit code is 0 on all-pass-or-warn, 1 on any failure or unsupported project.

## Pre-checks

- `package.json` exists in the target directory. Missing → exit 1.
- `package.json` is valid JSON. Malformed → exit 1 with the parse error.
- `package.json` declares at least one dependency.
- A framework is recognized:
    - `next` in deps **AND** `app/` or `src/app/` exists → Next.js.
    - `next` with only `pages/` → exit 1, "pages router not yet supported".
    - `react` or `react-dom` in deps → React.
    - Anything else with deps → JS catch-all (covers SvelteKit, Astro, Remix, Vue, Node services).

## What gets checked, by framework

### Next.js (7 checks)

1. `@stackframe/stack` is installed (deps or devDeps).
2. Stack client app instance file exists (`stack/client.ts(x)`, prefixed with `src/` if the project uses `src/app/`).
3. Stack server app instance file exists (`stack/server.ts(x)`, same prefix rule).
4. Handler route exists (`app/handler/[...stack]/page.{tsx,ts,jsx,js}`, with the same prefix).
5. Root layout (`app/layout.{tsx,jsx,ts,js}`) imports `StackProvider` from `@stackframe/stack` AND renders `<StackProvider>` in JSX. Distinguishes:
    - Pass: import + JSX usage.
    - Warn: import present, JSX missing.
    - Fail: JSX present, import missing.
    - Fail: layout file missing entirely.
6. Required env vars: `NEXT_PUBLIC_STACK_PROJECT_ID` (fail), `NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY` (warn — only required when the dashboard's "require publishable client keys" toggle is on), `STACK_SECRET_SERVER_KEY` (fail).
7. `stack.config.ts` validity — only runs if the file exists. Loads it via `jiti`, requires a `config` named export that is a plain object (mirroring `stack config push` validation). Skipped silently if no config file is present.

### React (4 checks)

1. `@stackframe/react` is installed.
2. Stack client app instance file exists (`stack/client.ts(x)`, prefixed with `src/` if the project has `src/`).
3. Required env vars: `VITE_STACK_PROJECT_ID` (fail), `VITE_STACK_PUBLISHABLE_CLIENT_KEY` (warn). No server secret check — React-only path is client-only.
4. `stack.config.ts` validity (same as Next).

### JS / Node catch-all (4 checks)

Covers SvelteKit, Astro, Remix, Vue, Nest, plain Node services.

1. `@stackframe/js` is installed.
2. Stack app instance file exists — either `stack/client.ts` or `stack/server.ts` (with `src/` prefix if applicable). Either-or, since backend services often only ship `server.ts` and frontend-only SvelteKit only `client.ts`.
3. Required env vars: `STACK_PROJECT_ID` or `PUBLIC_STACK_PROJECT_ID` (fail), `STACK_PUBLISHABLE_CLIENT_KEY` or `PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY` (warn), `STACK_SECRET_SERVER_KEY` (fail). The `PUBLIC_*` aliases exist because SvelteKit and Astro require that prefix to expose vars to client code.
4. `stack.config.ts` validity (same as Next).

## Env var lookup (shared by all frameworks)

For each required name (or alias group), check in this order:

1. `.env.local` at project root.
2. `.env`.
3. `process.env`.

A var is "present" if the resolved value is non-empty after trimming. Values are **never printed** — only presence/absence — so the secret server key cannot leak through doctor output.

For alias groups (`STACK_PROJECT_ID` / `PUBLIC_STACK_PROJECT_ID`), if any alias is present the logical var is satisfied.

## Severity rules

- `fail` counts toward exit 1.
- `warn` does not count toward exit 1.
- `skip` (returning null from a check) produces no row at all — used by the optional config-file check.

## 