### PR TITLE
refactor(dashboard): use getEnabledAppIds on metrics page

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/metrics-page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/metrics-page.tsx
@@ -6,6 +6,7 @@ import { Link } from "@/components/link";
 import { useRouter } from "@/components/router";
 import { cn, Typography } from "@/components/ui";
 import { ALL_APPS_FRONTEND, type AppId, getAppPath } from "@/lib/apps-frontend";
+import { getEnabledAppIds } from "@/lib/apps-utils";
 import {
   type MetricsEmailOverview,
   type MetricsRecentEmail,
@@ -16,7 +17,6 @@ import { CompassIcon, EnvelopeIcon, EnvelopeOpenIcon, GlobeIcon, SquaresFourIcon
 import useResizeObserver from '@react-hook/resize-observer';
 import { useUser } from "@stackframe/stack";
 import { ALL_APPS } from "@stackframe/stack-shared/dist/apps/apps-config";
-import { typedEntries } from "@stackframe/stack-shared/dist/utils/objects";
 import { stringCompare } from "@stackframe/stack-shared/dist/utils/strings";
 import { ErrorBoundary } from "next/dist/client/components/error-boundary";
 import { type ElementType, Suspense, useEffect, useId, useLayoutEffect, useMemo, useRef, useState } from "react";
@@ -997,9 +997,7 @@ function MetricsContent({
   const router = useRouter();
   const data = useMetricsOrThrow(adminApp, includeAnonymous);
   const installedApps = useMemo(
-    () => typedEntries(config.apps.installed)
-      .filter(([_, appConfig]) => appConfig?.enabled === true)
-      .map(([appId]) => appId as AppId),
+    () => getEnabledAppIds(config.apps.installed),
     [config.apps.installed]
   );
   const analyticsEnabled = installedApps.includes("analytics");


### PR DESCRIPTION
## Summary
Uses the shared `getEnabledAppIds` helper from `@/lib/apps-utils` instead of manually filtering installed apps with `typedEntries` on the project metrics page.

## Why
Keeps enabled-app logic consistent with other dashboard code paths and slightly reduces duplication.

## Test plan
- [ ] Smoke: open project metrics / overview and confirm installed app-dependent UI (e.g. analytics) still behaves as before.

Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved code maintainability by consolidating component logic to utilize shared utilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->