### PR TITLE
feat(backend): SAML SSO backend (schema, helpers, routes, admin CRUD)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -62,6 +62,8 @@
     "@clickhouse/client": "^1.14.0",
     "@node-oauth/oauth2-server": "^5.1.0",
     "@node-saml/node-saml": "^5.0.0",
+    "@xmldom/xmldom": "^0.8.10",
+    "xpath": "^0.0.34",
     "@openrouter/ai-sdk-provider": "2.2.3",
     "@opentelemetry/api": "^1.9.0",
     "@opentelemetry/api-logs": "^0.53.0",

--- a/apps/backend/prisma/migrations/20260429000000_add_saml_sso_models/migration.sql
+++ b/apps/backend/prisma/migrations/20260429000000_add_saml_sso_models/migration.sql
@@ -7,7 +7,7 @@
 CREATE TABLE "ProjectUserSamlAccount" (
     "id" UUID NOT NULL,
     "tenancyId" UUID NOT NULL,
-    "projectUserId" UUID,
+    "projectUserId" UUID NOT NULL,
     "samlConnectionId" TEXT NOT NULL,
     "nameId" TEXT NOT NULL,
     "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,

--- a/apps/backend/prisma/migrations/20260429000000_add_saml_sso_models/migration.sql
+++ b/apps/backend/prisma/migrations/20260429000000_add_saml_sso_models/migration.sql
@@ -1,0 +1,74 @@
+-- Adds SAML SSO support. Per-connection config (entity ID, IdP cert, ACS URL,
+-- attribute mapping, domain) lives in tenancy.config.auth.saml.connections JSON,
+-- matching how OAuth provider config is stored. The tables below cover only
+-- per-user account records and the in-flight AuthnRequest temp store.
+
+-- CreateTable
+CREATE TABLE "ProjectUserSamlAccount" (
+    "id" UUID NOT NULL,
+    "tenancyId" UUID NOT NULL,
+    "projectUserId" UUID,
+    "samlConnectionId" TEXT NOT NULL,
+    "nameId" TEXT NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+    "email" TEXT,
+    "nameIdFormat" TEXT,
+    "allowSignIn" BOOLEAN NOT NULL DEFAULT true,
+
+    CONSTRAINT "ProjectUserSamlAccount_pkey" PRIMARY KEY ("tenancyId","id")
+);
+
+-- CreateTable
+CREATE TABLE "SamlAuthMethod" (
+    "tenancyId" UUID NOT NULL,
+    "authMethodId" UUID NOT NULL,
+    "samlConnectionId" TEXT NOT NULL,
+    "nameId" TEXT NOT NULL,
+    "projectUserId" UUID NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SamlAuthMethod_pkey" PRIMARY KEY ("tenancyId","authMethodId")
+);
+
+-- CreateTable
+CREATE TABLE "SamlOuterInfo" (
+    "id" TEXT NOT NULL,
+    "info" JSONB NOT NULL,
+    "expiresAt" TIMESTAMP(3) NOT NULL,
+    "createdAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+    "updatedAt" TIMESTAMP(3) NOT NULL,
+
+    CONSTRAINT "SamlOuterInfo_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex
+CREATE INDEX "ProjectUserSamlAccount_tenancyId_projectUserId_idx" ON "ProjectUserSamlAccount"("tenancyId", "projectUserId");
+
+-- CreateIndex
+CREATE INDEX "ProjectUserSamlAccount_tenancyId_samlConnectionId_idx" ON "ProjectUserSamlAccount"("tenancyId", "samlConnectionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectUserSamlAccount_tenancyId_samlConnectionId_nameId_key" ON "ProjectUserSamlAccount"("tenancyId", "samlConnectionId", "nameId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "ProjectUserSamlAccount_tenancyId_samlConnectionId_projectUs_key" ON "ProjectUserSamlAccount"("tenancyId", "samlConnectionId", "projectUserId", "nameId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SamlAuthMethod_tenancyId_projectUserId_samlConnectionId_key" ON "SamlAuthMethod"("tenancyId", "projectUserId", "samlConnectionId");
+
+-- CreateIndex
+CREATE UNIQUE INDEX "SamlAuthMethod_tenancyId_samlConnectionId_projectUserId_nam_key" ON "SamlAuthMethod"("tenancyId", "samlConnectionId", "projectUserId", "nameId");
+
+-- AddForeignKey
+ALTER TABLE "ProjectUserSamlAccount" ADD CONSTRAINT "ProjectUserSamlAccount_tenancyId_projectUserId_fkey" FOREIGN KEY ("tenancyId", "projectUserId") REFERENCES "ProjectUser"("tenancyId", "projectUserId") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SamlAuthMethod" ADD CONSTRAINT "SamlAuthMethod_tenancyId_authMethodId_fkey" FOREIGN KEY ("tenancyId", "authMethodId") REFERENCES "AuthMethod"("tenancyId", "id") ON DELETE CASCADE ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SamlAuthMethod" ADD CONSTRAINT "SamlAuthMethod_tenancyId_samlConnectionId_projectUserId_na_fkey" FOREIGN KEY ("tenancyId", "samlConnectionId", "projectUserId", "nameId") REFERENCES "ProjectUserSamlAccount"("tenancyId", "samlConnectionId", "projectUserId", "nameId") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- AddForeignKey
+ALTER TABLE "SamlAuthMethod" ADD CONSTRAINT "SamlAuthMethod_tenancyId_projectUserId_fkey" FOREIGN KEY ("tenancyId", "projectUserId") REFERENCES "ProjectUser"("tenancyId", "projectUserId") ON DELETE CASCADE ON UPDATE CASCADE;

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -645,9 +645,9 @@ model OAuthOuterInfo {
 // ProjectUserOAuthAccount. samlConnectionId is the string key under
 // tenancy.config.auth.saml.connections.
 model ProjectUserSamlAccount {
-  id               String  @default(uuid()) @db.Uuid
-  tenancyId        String  @db.Uuid
-  projectUserId    String? @db.Uuid
+  id               String @default(uuid()) @db.Uuid
+  tenancyId        String @db.Uuid
+  projectUserId    String @db.Uuid
   samlConnectionId String
   nameId           String
 
@@ -659,10 +659,11 @@ model ProjectUserSamlAccount {
   email        String?
   nameIdFormat String?
 
-  // Before the SAML account is connected to a user (e.g. mid-flight), the
-  // projectUser is null. Once the ACS callback creates/links the user, this
-  // is set.
-  projectUser ProjectUser? @relation(fields: [tenancyId, projectUserId], references: [tenancyId, projectUserId], onDelete: Cascade)
+  // SAML accounts always reference a real user — the ACS handler creates
+  // (or links) the user before persisting the account row, so there is no
+  // intermediate "unlinked" state. This invariant lets findExistingSamlAccount
+  // assume projectUserId is non-null without a runtime fallback.
+  projectUser ProjectUser @relation(fields: [tenancyId, projectUserId], references: [tenancyId, projectUserId], onDelete: Cascade)
 
   // if allowSignIn is true, samlAuthMethod must be set
   samlAuthMethod SamlAuthMethod?

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -308,6 +308,7 @@ model ProjectUser {
   signUpRiskScoreFreeTrialAbuse Int @default(0) @db.SmallInt
 
   projectUserOAuthAccounts ProjectUserOAuthAccount[]
+  projectUserSamlAccounts  ProjectUserSamlAccount[]
   teamMembers              TeamMember[]
   contactChannels          ContactChannel[]
   authMethods              AuthMethod[]
@@ -317,6 +318,7 @@ model ProjectUser {
   passkeyAuthMethod          PasskeyAuthMethod[]
   otpAuthMethod              OtpAuthMethod[]
   oauthAuthMethod            OAuthAuthMethod[]
+  samlAuthMethod             SamlAuthMethod[]
   projectApiKey              ProjectApiKey[]
   directPermissions          ProjectUserDirectPermission[]
   Project                    Project?                      @relation(fields: [projectId], references: [id])
@@ -486,6 +488,7 @@ model AuthMethod {
   passwordAuthMethod PasswordAuthMethod?
   passkeyAuthMethod  PasskeyAuthMethod?
   oauthAuthMethod    OAuthAuthMethod?
+  samlAuthMethod     SamlAuthMethod?
 
   projectUser ProjectUser @relation(fields: [tenancyId, projectUserId], references: [tenancyId, projectUserId], onDelete: Cascade)
 
@@ -625,6 +628,89 @@ model OAuthOuterInfo {
   info       Json
   innerState String   @unique
   expiresAt  DateTime
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+}
+
+// =================== SAML SSO ===================
+//
+// SAML connection *config* (entity ID, IdP cert, ACS URL, attribute mapping,
+// domain, etc.) is stored as JSON in tenancy.config.auth.saml.connections —
+// matching how OAuth provider config (clientId/clientSecret) is stored. The
+// Prisma models below cover only per-user account records and the in-flight
+// AuthnRequest temp store.
+
+// One row per (tenancy, samlConnectionId, NameID). Mirrors
+// ProjectUserOAuthAccount. samlConnectionId is the string key under
+// tenancy.config.auth.saml.connections.
+model ProjectUserSamlAccount {
+  id               String  @default(uuid()) @db.Uuid
+  tenancyId        String  @db.Uuid
+  projectUserId    String? @db.Uuid
+  samlConnectionId String
+  nameId           String
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  // Snapshot from the most recent assertion. Used to distinguish accounts
+  // and to populate primary contact channel on first sign-in.
+  email        String?
+  nameIdFormat String?
+
+  // Before the SAML account is connected to a user (e.g. mid-flight), the
+  // projectUser is null. Once the ACS callback creates/links the user, this
+  // is set.
+  projectUser ProjectUser? @relation(fields: [tenancyId, projectUserId], references: [tenancyId, projectUserId], onDelete: Cascade)
+
+  // if allowSignIn is true, samlAuthMethod must be set
+  samlAuthMethod SamlAuthMethod?
+  allowSignIn    Boolean         @default(true)
+
+  @@id([tenancyId, id])
+  // A NameID is unique per (project, connection). The same NameID from a
+  // different connection is a distinct identity — this is what enforces
+  // multi-tenant connection isolation at the DB level.
+  @@unique([tenancyId, samlConnectionId, nameId])
+  // Composite for FK relation from SamlAuthMethod.samlAccount.
+  @@unique([tenancyId, samlConnectionId, projectUserId, nameId])
+  @@index([tenancyId, projectUserId])
+  @@index([tenancyId, samlConnectionId])
+}
+
+// Connects a project user to a SamlAuthMethod via a SAML account.
+// Mirrors OAuthAuthMethod.
+model SamlAuthMethod {
+  tenancyId        String @db.Uuid
+  authMethodId     String @db.Uuid
+  samlConnectionId String
+  nameId           String
+  projectUserId    String @db.Uuid
+
+  createdAt DateTime @default(now())
+  updatedAt DateTime @updatedAt
+
+  authMethod  AuthMethod             @relation(fields: [tenancyId, authMethodId], references: [tenancyId, id], onDelete: Cascade)
+  samlAccount ProjectUserSamlAccount @relation(fields: [tenancyId, samlConnectionId, projectUserId, nameId], references: [tenancyId, samlConnectionId, projectUserId, nameId])
+  projectUser ProjectUser            @relation(fields: [tenancyId, projectUserId], references: [tenancyId, projectUserId], onDelete: Cascade)
+
+  @@id([tenancyId, authMethodId])
+  // A user has at most one SAML auth method per connection.
+  @@unique([tenancyId, projectUserId, samlConnectionId])
+  @@unique([tenancyId, samlConnectionId, projectUserId, nameId])
+}
+
+// In-flight AuthnRequest state. Mirrors OAuthOuterInfo. Keyed by the
+// AuthnRequest ID so the ACS handler can look up the original context
+// when the IdP POSTs the assertion back via the browser.
+model SamlOuterInfo {
+  // SAML AuthnRequest IDs are XML IDs (xs:ID). They start with a non-numeric
+  // character per spec, so we store as String — not Uuid.
+  id String @id
+
+  info      Json
+  expiresAt DateTime
 
   createdAt DateTime @default(now())
   updatedAt DateTime @updatedAt

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -21,6 +21,7 @@ import { createSamlUserAndAccount, findExistingSamlAccount, handleSamlEmailMerge
 import { Tenancy, getTenancy } from "@/lib/tenancies";
 import { oauthServer } from "@/oauth";
 import { getPrismaClientForTenancy, globalPrismaClient } from "@/prisma-client";
+import { Prisma } from "@/generated/prisma/client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { buildSamlClient, extractInResponseTo, parseAndVerifyAssertion, SamlConnectionConfig } from "@/saml/saml";
 import { InvalidClientError, InvalidScopeError, Request as OAuthRequest, Response as OAuthResponse } from "@node-oauth/oauth2-server";
@@ -28,6 +29,7 @@ import { KnownError, KnownErrors } from "@stackframe/stack-shared";
 import { yupMixed, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StackAssertionError, StatusError, captureError } from "@stackframe/stack-shared/dist/utils/errors";
+import { has } from "@stackframe/stack-shared/dist/utils/objects";
 import { deindent } from "@stackframe/stack-shared/dist/utils/strings";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -101,9 +103,19 @@ export const POST = createSmartRouteHandler({
       throw new StatusError(StatusError.BadRequest, "SAMLResponse has no InResponseTo (IdP-initiated SSO is not supported in V1)");
     }
 
-    const outerInfoDB = await globalPrismaClient.samlOuterInfo.findUnique({ where: { id: inResponseTo } });
-    if (!outerInfoDB) {
-      throw new StatusError(StatusError.BadRequest, "Unknown InResponseTo — SAMLResponse does not match any pending AuthnRequest. Please try signing in again.");
+    // Atomically consume the SamlOuterInfo row up-front so concurrent
+    // duplicate POSTs (browser retry, captured payload, etc.) can't both
+    // pass a findUnique check before either reaches the delete and each
+    // issue an OAuth code. If downstream verification fails, the client
+    // must restart the flow — that's the cost of a one-shot row.
+    let outerInfoDB;
+    try {
+      outerInfoDB = await globalPrismaClient.samlOuterInfo.delete({ where: { id: inResponseTo } });
+    } catch (e) {
+      if (e instanceof Prisma.PrismaClientKnownRequestError && e.code === "P2025") {
+        throw new StatusError(StatusError.BadRequest, "Unknown InResponseTo — SAMLResponse does not match any pending AuthnRequest, or it was already consumed. Please try signing in again.");
+      }
+      throw e;
     }
 
     const outerInfo = outerInfoDB.info as unknown as SamlOuterInfoPayload;
@@ -131,7 +143,7 @@ export const POST = createSmartRouteHandler({
     }
     const prisma = await getPrismaClientForTenancy(tenancy);
 
-    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+    if (!has(tenancy.config.auth.saml.connections, params.connection_id)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }
     const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
@@ -302,11 +314,6 @@ export const POST = createSmartRouteHandler({
         }
         throw error;
       }
-
-      // Replay protection — consume the OuterInfo row so the same assertion
-      // (or a re-issued one from the same AuthnRequest) cannot be replayed.
-      // The next look-up by InResponseTo will 400.
-      await globalPrismaClient.samlOuterInfo.delete({ where: { id: inResponseTo } });
 
       return oauthResponseToSmartResponse(oauthResponse);
     } catch (error) {

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -26,6 +26,7 @@ import { buildSamlClient, extractInResponseTo, parseAndVerifyAssertion, SamlConn
 import { InvalidClientError, InvalidScopeError, Request as OAuthRequest, Response as OAuthResponse } from "@node-oauth/oauth2-server";
 import { KnownError, KnownErrors } from "@stackframe/stack-shared";
 import { yupMixed, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StackAssertionError, StatusError, captureError } from "@stackframe/stack-shared/dist/utils/errors";
 import { deindent } from "@stackframe/stack-shared/dist/utils/strings";
 import { cookies } from "next/headers";
@@ -137,6 +138,13 @@ export const POST = createSmartRouteHandler({
     if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is incompletely configured`);
     }
+    // Defense-in-depth: login already rejects disabled connections, but a
+    // SamlOuterInfo row lives for 10 minutes, so an admin can disable a
+    // connection mid-flow. ACS is the final trust point before issuing an
+    // OAuth code, so re-check here.
+    if (connectionRaw.allowSignIn === false) {
+      throw new StatusError(StatusError.Forbidden, `SAML connection ${params.connection_id} has sign-in disabled`);
+    }
     const connection: SamlConnectionConfig = {
       id: params.connection_id,
       displayName: connectionRaw.displayName,
@@ -153,7 +161,11 @@ export const POST = createSmartRouteHandler({
     }
 
     try {
-      const baseUrl = new URL(outerInfo.redirectUri).origin;
+      // Canonical Stack Auth public API origin — must match login + metadata
+      // so audience/issuer validation lines up with the entity ID the IdP
+      // configured against. The customer's `redirectUri` is for the SDK
+      // post-callback redirect, not the SP origin.
+      const baseUrl = getEnvVariable("NEXT_PUBLIC_STACK_API_URL");
       const client = buildSamlClient(connection, baseUrl);
       const assertion = await parseAndVerifyAssertion(client, connection, samlResponseB64, undefined);
 

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -84,7 +84,12 @@ export const POST = createSmartRouteHandler({
     params: yupObject({
       connection_id: yupString().defined(),
     }).defined(),
-    body: yupMixed().defined(),
+    // ACS is exposed to arbitrary IdP/browser POSTs. Reject malformed
+    // bodies with a clean 400 before they reach base64/XML parsing.
+    body: yupObject({
+      SAMLResponse: yupString().defined(),
+      RelayState: yupString().optional(),
+    }).defined(),
   }),
   response: yupObject({
     statusCode: yupNumber().oneOf([303, 307]).defined(),
@@ -93,12 +98,14 @@ export const POST = createSmartRouteHandler({
     headers: yupMixed().defined(),
   }),
   async handler({ params, body }) {
-    const samlResponseB64 = (body as Record<string, unknown>).SAMLResponse as string | undefined;
-    if (!samlResponseB64) {
-      throw new StatusError(StatusError.BadRequest, "Missing SAMLResponse in form body");
-    }
+    const samlResponseB64 = body.SAMLResponse;
 
-    const inResponseTo = extractInResponseTo(samlResponseB64);
+    let inResponseTo: string | null;
+    try {
+      inResponseTo = extractInResponseTo(samlResponseB64);
+    } catch {
+      throw new StatusError(StatusError.BadRequest, "SAMLResponse is not valid base64-encoded XML");
+    }
     if (!inResponseTo) {
       throw new StatusError(StatusError.BadRequest, "SAMLResponse has no InResponseTo (IdP-initiated SSO is not supported in V1)");
     }
@@ -229,7 +236,7 @@ export const POST = createSmartRouteHandler({
                   );
                   if (existing) {
                     return {
-                      id: existing.projectUserId ?? throwAssertion("SAML account exists but has no associated user"),
+                      id: existing.projectUserId,
                       newUser: false,
                       afterCallbackRedirectUrl: outerInfo.afterCallbackRedirectUrl,
                     };
@@ -327,7 +334,3 @@ export const POST = createSmartRouteHandler({
     }
   },
 });
-
-function throwAssertion(msg: string): never {
-  throw new StackAssertionError(msg);
-}

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -130,9 +130,12 @@ export const POST = createSmartRouteHandler({
     }
     const prisma = await getPrismaClientForTenancy(tenancy);
 
+    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
+    }
     const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
     if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
-      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is not configured`);
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is incompletely configured`);
     }
     const connection: SamlConnectionConfig = {
       id: params.connection_id,

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -1,0 +1,311 @@
+/**
+ * SAML Assertion Consumer Service. Mirrors /auth/oauth/callback/[provider_id]:
+ * receives the IdP's POST, verifies the assertion, runs the SAML user-linking
+ * flow, then hands off to oauthServer.authorize so Stack Auth issues a
+ * customer-facing OAuth code (Stack Auth itself acts as an OAuth2 provider
+ * to the customer's SDK — see comment at top of oauth/callback/[provider_id]
+ * for context).
+ *
+ * Replay protection: the matching SamlOuterInfo row is consumed
+ * (deleted) at the end of a successful flow, and the route looks up by
+ * InResponseTo before calling node-saml's full validation. node-saml then
+ * also enforces signature, audience, NotBefore/NotOnOrAfter, and
+ * InResponseTo equality.
+ */
+import { usersCrudHandlers } from "@/app/api/latest/users/crud";
+import { getBestEffortEndUserRequestContext } from "@/lib/end-users";
+import { reconstructTurnstileAssessment, buildSignUpRuleOptions } from "@/lib/sign-up-context";
+import { checkApiKeySet, throwCheckApiKeySetError } from "@/lib/internal-api-keys";
+import { isAcceptedNativeAppUrl, validateRedirectUrl } from "@/lib/redirect-urls";
+import { createSamlUserAndAccount, findExistingSamlAccount, handleSamlEmailMergeStrategy, linkSamlAccountToUser } from "@/lib/saml-account";
+import { Tenancy, getTenancy } from "@/lib/tenancies";
+import { oauthServer } from "@/oauth";
+import { getPrismaClientForTenancy, globalPrismaClient } from "@/prisma-client";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { buildSamlClient, extractInResponseTo, parseAndVerifyAssertion, SamlConnectionConfig } from "@/saml/saml";
+import { InvalidClientError, InvalidScopeError, Request as OAuthRequest, Response as OAuthResponse } from "@node-oauth/oauth2-server";
+import { KnownError, KnownErrors } from "@stackframe/stack-shared";
+import { yupMixed, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { StackAssertionError, StatusError, captureError } from "@stackframe/stack-shared/dist/utils/errors";
+import { deindent } from "@stackframe/stack-shared/dist/utils/strings";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import { oauthResponseToSmartResponse } from "../../../oauth/oauth-helpers";
+
+type SamlOuterInfoPayload = {
+  tenancyId: string,
+  samlConnectionId: string,
+  publishableClientKey: string,
+  redirectUri: string,
+  state: string,
+  scope: string,
+  grantType: string,
+  codeChallenge: string,
+  codeChallengeMethod: string,
+  responseType: string,
+  errorRedirectUrl?: string,
+  afterCallbackRedirectUrl?: string,
+  responseMode: "json" | "redirect",
+};
+
+const redirectOrThrowError = (error: KnownError, tenancy: Tenancy, options: {
+  callbackRedirectUrl?: string,
+  errorRedirectUrl?: string,
+}) => {
+  const target =
+    options.callbackRedirectUrl && (validateRedirectUrl(options.callbackRedirectUrl, tenancy) || isAcceptedNativeAppUrl(options.callbackRedirectUrl))
+      ? options.callbackRedirectUrl
+      : options.errorRedirectUrl && (validateRedirectUrl(options.errorRedirectUrl, tenancy) || isAcceptedNativeAppUrl(options.errorRedirectUrl))
+        ? options.errorRedirectUrl
+        : null;
+  if (!target) throw error;
+
+  const url = new URL(target);
+  url.searchParams.set("error", "server_error");
+  url.searchParams.set("error_description", error.message);
+  url.searchParams.set("errorCode", error.errorCode);
+  url.searchParams.set("message", error.message);
+  url.searchParams.set("details", error.details ? JSON.stringify(error.details) : JSON.stringify({}));
+  redirect(url.toString());
+};
+
+const shouldRedirectKnownError = (error: KnownError) => (
+  KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse.isInstance(error)
+  || KnownErrors.SignUpNotEnabled.isInstance(error)
+  || KnownErrors.SignUpRejected.isInstance(error)
+);
+
+export const POST = createSmartRouteHandler({
+  metadata: { hidden: true },
+  request: yupObject({
+    params: yupObject({
+      connection_id: yupString().defined(),
+    }).defined(),
+    body: yupMixed().defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([303, 307]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupMixed().defined(),
+    headers: yupMixed().defined(),
+  }),
+  async handler({ params, body }) {
+    const samlResponseB64 = (body as Record<string, unknown>).SAMLResponse as string | undefined;
+    if (!samlResponseB64) {
+      throw new StatusError(StatusError.BadRequest, "Missing SAMLResponse in form body");
+    }
+
+    const inResponseTo = extractInResponseTo(samlResponseB64);
+    if (!inResponseTo) {
+      throw new StatusError(StatusError.BadRequest, "SAMLResponse has no InResponseTo (IdP-initiated SSO is not supported in V1)");
+    }
+
+    const outerInfoDB = await globalPrismaClient.samlOuterInfo.findUnique({ where: { id: inResponseTo } });
+    if (!outerInfoDB) {
+      throw new StatusError(StatusError.BadRequest, "Unknown InResponseTo — SAMLResponse does not match any pending AuthnRequest. Please try signing in again.");
+    }
+
+    const outerInfo = outerInfoDB.info as unknown as SamlOuterInfoPayload;
+
+    if (outerInfo.samlConnectionId !== params.connection_id) {
+      // Cross-connection forgery — assertion was sent to the wrong ACS endpoint.
+      throw new StatusError(StatusError.BadRequest, "SAML connection mismatch (assertion sent to wrong ACS endpoint)");
+    }
+
+    if (outerInfoDB.expiresAt < new Date()) {
+      throw new KnownErrors.OuterOAuthTimeout();
+    }
+
+    if (outerInfo.responseMode !== "json") {
+      const cookieInfo = (await cookies()).get("stack-saml-inner-" + inResponseTo);
+      (await cookies()).delete("stack-saml-inner-" + inResponseTo);
+      if (cookieInfo?.value !== "true") {
+        throw new StatusError(StatusError.BadRequest, "Inner SAML cookie not found. Likely the page was refreshed mid-flow. Please try signing in again.");
+      }
+    }
+
+    const tenancy = await getTenancy(outerInfo.tenancyId);
+    if (!tenancy) {
+      throw new StackAssertionError("Tenancy from SamlOuterInfo not found", { tenancyId: outerInfo.tenancyId });
+    }
+    const prisma = await getPrismaClientForTenancy(tenancy);
+
+    const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
+    if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is not configured`);
+    }
+    const connection: SamlConnectionConfig = {
+      id: params.connection_id,
+      displayName: connectionRaw.displayName,
+      idpEntityId: connectionRaw.idpEntityId,
+      idpSsoUrl: connectionRaw.idpSsoUrl,
+      idpCertificate: connectionRaw.idpCertificate,
+      domain: connectionRaw.domain,
+      attributeMapping: connectionRaw.attributeMapping,
+    };
+
+    const keyCheck = await checkApiKeySet(tenancy.project.id, { publishableClientKey: outerInfo.publishableClientKey });
+    if (keyCheck.status === "error") {
+      throwCheckApiKeySetError(keyCheck.error, tenancy.project.id, new KnownErrors.InvalidPublishableClientKey(tenancy.project.id));
+    }
+
+    try {
+      const baseUrl = new URL(outerInfo.redirectUri).origin;
+      const client = buildSamlClient(connection, baseUrl);
+      const assertion = await parseAndVerifyAssertion(client, connection, samlResponseB64, undefined);
+
+      // Defense-in-depth: node-saml's validation already checks InResponseTo,
+      // but we re-check here against what we stored.
+      if (assertion.inResponseTo !== inResponseTo) {
+        throw new StatusError(StatusError.BadRequest, "Assertion InResponseTo does not match the AuthnRequest ID we stored");
+      }
+      if (!assertion.nameId) {
+        throw new StatusError(StatusError.BadRequest, "Assertion has no NameID");
+      }
+      if (!assertion.email) {
+        throw new StatusError(StatusError.BadRequest, "Assertion has no email attribute or email-format NameID");
+      }
+
+      // Reconstruct the OAuth context originally passed to /auth/saml/login —
+      // oauthServer.authorize needs all of it to issue the customer-facing code.
+      const oauthRequest = new OAuthRequest({
+        headers: {},
+        body: {},
+        method: "GET",
+        query: {
+          client_id: `${tenancy.project.id}#${tenancy.branchId}`,
+          client_secret: outerInfo.publishableClientKey,
+          redirect_uri: outerInfo.redirectUri,
+          state: outerInfo.state,
+          scope: outerInfo.scope,
+          grant_type: outerInfo.grantType,
+          code_challenge: outerInfo.codeChallenge,
+          code_challenge_method: outerInfo.codeChallengeMethod,
+          response_type: outerInfo.responseType,
+        },
+      });
+
+      const oauthResponse = new OAuthResponse();
+      try {
+        await oauthServer.authorize(
+          oauthRequest,
+          oauthResponse,
+          {
+            authenticateHandler: {
+              handle: async () => {
+                try {
+                  const existing = await findExistingSamlAccount(
+                    prisma,
+                    outerInfo.tenancyId,
+                    params.connection_id,
+                    assertion.nameId,
+                  );
+                  if (existing) {
+                    return {
+                      id: existing.projectUserId ?? throwAssertion("SAML account exists but has no associated user"),
+                      newUser: false,
+                      afterCallbackRedirectUrl: outerInfo.afterCallbackRedirectUrl,
+                    };
+                  }
+
+                  // No existing SAML account → try to merge with an existing
+                  // user by email, otherwise create a new user.
+                  const { linkedUserId, primaryEmailAuthEnabled } = await handleSamlEmailMergeStrategy(
+                    prisma,
+                    tenancy,
+                    { email: assertion.email!, emailVerified: true },
+                  );
+
+                  if (linkedUserId) {
+                    await linkSamlAccountToUser(prisma, {
+                      tenancyId: outerInfo.tenancyId,
+                      samlConnectionId: params.connection_id,
+                      nameId: assertion.nameId,
+                      nameIdFormat: assertion.nameIdFormat,
+                      email: assertion.email,
+                      projectUserId: linkedUserId,
+                    });
+                    return {
+                      id: linkedUserId,
+                      newUser: false,
+                      afterCallbackRedirectUrl: outerInfo.afterCallbackRedirectUrl,
+                    };
+                  }
+
+                  const requestContext = await getBestEffortEndUserRequestContext();
+                  const { projectUserId: newUserId } = await createSamlUserAndAccount(
+                    prisma,
+                    tenancy,
+                    {
+                      samlConnectionId: params.connection_id,
+                      nameId: assertion.nameId,
+                      nameIdFormat: assertion.nameIdFormat,
+                      email: assertion.email,
+                      emailVerified: true, // SAML assertions are signed by the IdP — treat email as verified
+                      primaryEmailAuthEnabled,
+                      currentUser: null,
+                      displayName: assertion.displayName,
+                      profileImageUrl: null,
+                      signUpRuleOptions: buildSignUpRuleOptions({
+                        authMethod: "oauth", // closest existing tag; future: add 'saml'
+                        oauthProvider: `saml:${params.connection_id}`,
+                        requestContext,
+                        turnstileAssessment: reconstructTurnstileAssessment("invalid", undefined),
+                      }),
+                    },
+                  );
+
+                  return {
+                    id: newUserId,
+                    newUser: true,
+                    afterCallbackRedirectUrl: outerInfo.afterCallbackRedirectUrl,
+                  };
+                } catch (error) {
+                  if (KnownError.isKnownError(error) && shouldRedirectKnownError(error)) {
+                    redirectOrThrowError(error, tenancy, {
+                      callbackRedirectUrl: outerInfo.redirectUri,
+                      errorRedirectUrl: outerInfo.errorRedirectUrl,
+                    });
+                  }
+                  throw error;
+                }
+              },
+            },
+          },
+        );
+      } catch (error) {
+        if (error instanceof InvalidClientError) {
+          if (error.message.includes("redirect_uri") || error.message.includes("redirectUri")) {
+            throw new KnownErrors.RedirectUrlNotWhitelisted();
+          }
+        } else if (error instanceof InvalidScopeError) {
+          captureError("saml-acs-invalid-scope", new StackAssertionError(deindent`
+            Client requested an invalid scope during SAML ACS.
+              Scopes requested: ${oauthRequest.query?.scope}
+          `, { outerInfo, cause: error, scopes: oauthRequest.query?.scope }));
+          throw new StatusError(StatusError.BadRequest, "Invalid scope requested");
+        }
+        throw error;
+      }
+
+      // Replay protection — consume the OuterInfo row so the same assertion
+      // (or a re-issued one from the same AuthnRequest) cannot be replayed.
+      // The next look-up by InResponseTo will 400.
+      await globalPrismaClient.samlOuterInfo.delete({ where: { id: inResponseTo } });
+
+      return oauthResponseToSmartResponse(oauthResponse);
+    } catch (error) {
+      if (KnownError.isKnownError(error)) {
+        redirectOrThrowError(error, tenancy, {
+          callbackRedirectUrl: outerInfo.redirectUri,
+          errorRedirectUrl: outerInfo.errorRedirectUrl,
+        });
+      }
+      throw error;
+    }
+  },
+});
+
+function throwAssertion(msg: string): never {
+  throw new StackAssertionError(msg);
+}

--- a/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
@@ -42,8 +42,13 @@ export const GET = createSmartRouteHandler({
     }
     // Inject `id` into each connection so it satisfies SamlConnectionConfig —
     // the config schema stores id as the record key, not a value field.
+    // Skip connections with sign-in disabled — discover is the entry point
+    // for the signInWithSso flow, so returning a disabled connection would
+    // direct the user through `/auth/saml/login`, where it 403s. Treat
+    // disabled connections as if they didn't exist for discovery purposes.
     const connections: Record<string, SamlConnectionConfig> = {};
     for (const [id, conn] of typedEntries(tenancy.config.auth.saml.connections)) {
+      if (conn.allowSignIn === false) continue;
       if (!conn.idpEntityId || !conn.idpSsoUrl || !conn.idpCertificate) continue;
       connections[id] = {
         id,

--- a/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
@@ -1,0 +1,57 @@
+import { discoverConnectionByEmail } from "@/saml/discovery";
+import type { SamlConnectionConfig } from "@/saml/saml";
+import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { emailSchema, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+
+/**
+ * Email-domain → SAML connection lookup for the client SDK's
+ * signInWithSso({ email }) flow. Returns the matching connection's id +
+ * displayName so the customer's UI can show e.g. "Sign in with Acme SSO"
+ * before redirecting.
+ *
+ * Returns 404 (rather than 200 with null) when no connection matches —
+ * the SDK relies on the status to fall back to other sign-in methods.
+ */
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Discover SAML connection by email",
+    description: "Returns the SAML connection matching the email's domain, if any.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    query: yupObject({
+      email: emailSchema.defined(),
+      project_id: yupString().defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      connection_id: yupString().defined(),
+      display_name: yupString().defined(),
+    }).defined(),
+  }),
+  async handler({ query }) {
+    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
+    if (!tenancy) {
+      throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
+    }
+    const samlConfig = (tenancy.config.auth as { saml?: { connections?: Record<string, SamlConnectionConfig> } }).saml;
+    const connections = samlConfig?.connections ?? {};
+    const matched = discoverConnectionByEmail(connections, query.email);
+    if (!matched) {
+      throw new StatusError(StatusError.NotFound, "No SAML connection matches this email's domain");
+    }
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        connection_id: matched.id,
+        display_name: matched.displayName,
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
@@ -1,6 +1,7 @@
 import { discoverConnectionByEmail } from "@/saml/discovery";
 import type { SamlConnectionConfig } from "@/saml/saml";
 import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
+import { typedEntries } from "@stackframe/stack-shared/dist/utils/objects";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { emailSchema, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
@@ -39,8 +40,21 @@ export const GET = createSmartRouteHandler({
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }
-    const samlConfig = (tenancy.config.auth as { saml?: { connections?: Record<string, SamlConnectionConfig> } }).saml;
-    const connections = samlConfig?.connections ?? {};
+    // Inject `id` into each connection so it satisfies SamlConnectionConfig —
+    // the config schema stores id as the record key, not a value field.
+    const connections: Record<string, SamlConnectionConfig> = {};
+    for (const [id, conn] of typedEntries(tenancy.config.auth.saml.connections)) {
+      if (!conn.idpEntityId || !conn.idpSsoUrl || !conn.idpCertificate) continue;
+      connections[id] = {
+        id,
+        displayName: conn.displayName,
+        idpEntityId: conn.idpEntityId,
+        idpSsoUrl: conn.idpSsoUrl,
+        idpCertificate: conn.idpCertificate,
+        domain: conn.domain,
+        attributeMapping: conn.attributeMapping,
+      };
+    }
     const matched = discoverConnectionByEmail(connections, query.email);
     if (!matched) {
       throw new StatusError(StatusError.NotFound, "No SAML connection matches this email's domain");

--- a/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
@@ -25,6 +25,12 @@ export const GET = createSmartRouteHandler({
     query: yupObject({
       email: emailSchema.defined(),
       project_id: yupString().defined(),
+      // Optional — connections live under a tenancy/branch, and login
+      // resolves the branch from `client_id` (`projectId#branchId`). If the
+      // SDK is targeting a non-default branch, it must pass the same
+      // branch_id here so discovery returns the connection that login will
+      // actually use.
+      branch_id: yupString().optional(),
     }).defined(),
   }),
   response: yupObject({
@@ -36,7 +42,7 @@ export const GET = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ query }) {
-    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
+    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, query.branch_id ?? DEFAULT_BRANCH_ID, true);
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -171,12 +171,22 @@ export const GET = createSmartRouteHandler({
 
     // Browser-redirect mode: set a CSRF cookie keyed to the AuthnRequest ID.
     // The ACS route checks this cookie before honoring the assertion.
+    //
+    // SAML's normal flow has the IdP browser-POSTing the assertion back to
+    // ACS cross-site, so this cookie must be SameSite=None (with Secure).
+    // Default Lax would silently drop on the cross-site POST, leaving ACS
+    // to consume the one-shot SamlOuterInfo row before failing the cookie
+    // check. In dev we don't have HTTPS, and `Secure` is required for
+    // SameSite=None, so we fall back to Lax — the mock IdP runs on the
+    // same registrable domain (localhost) where Lax is sent on POST.
+    const isDev = getNodeEnvironment() === "development";
     (await cookies()).set(
       "stack-saml-inner-" + requestId,
       "true",
       {
         httpOnly: true,
-        secure: getNodeEnvironment() !== "development",
+        secure: !isDev,
+        sameSite: isDev ? "lax" : "none",
         maxAge: 60 * SAML_OUTER_TTL_MINUTES,
       },
     );

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -18,7 +18,7 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { buildAuthnRequestUrl, buildSamlClient, SamlConnectionConfig } from "@/saml/saml";
 import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { urlSchema, yupArray, yupNumber, yupObject, yupString, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
-import { getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
+import { getEnvVariable, getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
@@ -129,7 +129,10 @@ export const GET = createSmartRouteHandler({
       attributeMapping: connectionRaw.attributeMapping,
     };
 
-    const baseUrl = new URL(query.redirect_uri).origin;
+    // Canonical Stack Auth public API origin — must match the metadata route
+    // and ACS validation, since this origin is embedded in the SP entityId
+    // and audience the IdP signs assertions against.
+    const baseUrl = getEnvVariable("NEXT_PUBLIC_STACK_API_URL");
     const client = buildSamlClient(connection, baseUrl);
     const { url: samlUrl, requestId } = await buildAuthnRequestUrl(client, query.state);
 

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -100,12 +100,15 @@ export const GET = createSmartRouteHandler({
       throwCheckApiKeySetError(keyCheck.error, tenancy.project.id, new KnownErrors.InvalidPublishableClientKey(tenancy.project.id));
     }
 
-    const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
-    if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
-      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is not configured`);
+    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }
+    const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
     if (connectionRaw.allowSignIn === false) {
       throw new StatusError(StatusError.Forbidden, `SAML connection ${params.connection_id} has sign-in disabled`);
+    }
+    if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is incompletely configured`);
     }
 
     if (

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -20,6 +20,7 @@ import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { urlSchema, yupArray, yupNumber, yupObject, yupString, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
 import { getEnvVariable, getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { has } from "@stackframe/stack-shared/dist/utils/objects";
 import { cookies } from "next/headers";
 import { redirect } from "next/navigation";
 import type { Schema } from "yup";
@@ -100,7 +101,7 @@ export const GET = createSmartRouteHandler({
       throwCheckApiKeySetError(keyCheck.error, tenancy.project.id, new KnownErrors.InvalidPublishableClientKey(tenancy.project.id));
     }
 
-    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+    if (!has(tenancy.config.auth.saml.connections, params.connection_id)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }
     const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -1,0 +1,179 @@
+/**
+ * SAML SP-initiated login. Mirrors /auth/oauth/authorize/[provider_id]:
+ * receives the same OAuth client params (so Stack Auth itself can later
+ * issue an OAuth code via oauthServer.authorize), stashes them in
+ * SamlOuterInfo keyed by AuthnRequest ID, and redirects to the IdP.
+ *
+ * V1 scope: SP-initiated only, no signed AuthnRequests, no link/upgrade
+ * flow (just plain sign-in). Turnstile is also skipped here — SAML
+ * sign-in originates from a corporate IdP, not a public form.
+ */
+import { checkApiKeySet, throwCheckApiKeySetError } from "@/lib/internal-api-keys";
+import { isAcceptedNativeAppUrl, validateRedirectUrl } from "@/lib/redirect-urls";
+import { getSoleTenancyFromProjectBranch } from "@/lib/tenancies";
+import { getProjectBranchFromClientId } from "@/oauth";
+import { globalPrismaClient } from "@/prisma-client";
+import type { SmartResponse } from "@/route-handlers/smart-response";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { buildAuthnRequestUrl, buildSamlClient, SamlConnectionConfig } from "@/saml/saml";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
+import { urlSchema, yupArray, yupNumber, yupObject, yupString, yupUnion } from "@stackframe/stack-shared/dist/schema-fields";
+import { getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+import type { Schema } from "yup";
+
+const SAML_OUTER_TTL_MINUTES = 10;
+
+// Stored in SamlOuterInfo.info — narrower than OAuth's outer info because
+// SAML doesn't have PKCE / response_type / scope handling at this layer.
+type SamlOuterInfoPayload = {
+  tenancyId: string,
+  samlConnectionId: string,
+  publishableClientKey: string,
+  redirectUri: string,
+  state: string,
+  scope: string,
+  grantType: string,
+  codeChallenge: string,
+  codeChallengeMethod: string,
+  responseType: string,
+  errorRedirectUrl?: string,
+  afterCallbackRedirectUrl?: string,
+  responseMode: "json" | "redirect",
+};
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "SAML SP-initiated login",
+    description: "Build a SAML AuthnRequest, persist outer state, and redirect the browser to the IdP.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    params: yupObject({
+      connection_id: yupString().defined(),
+    }).defined(),
+    query: yupObject({
+      // Stack Auth OAuth client params — same as /auth/oauth/authorize.
+      client_id: yupString().defined(),
+      client_secret: yupString().defined(),
+      redirect_uri: urlSchema.defined(),
+      scope: yupString().defined(),
+      state: yupString().defined(),
+      grant_type: yupString().oneOf(["authorization_code"]).defined(),
+      code_challenge: yupString().defined(),
+      code_challenge_method: yupString().defined(),
+      response_type: yupString().defined(),
+      // Optional after-callback redirect (where to send the user post-sign-in).
+      after_callback_redirect_url: urlSchema.optional(),
+      error_redirect_uri: urlSchema.optional(),
+      // SDK uses stack_response_mode=json so it can intercept before navigating.
+      stack_response_mode: yupString().oneOf(["json", "redirect"]).default("redirect"),
+    }).noUnknown(false).defined(),
+  }),
+  response: yupUnion(
+    yupObject({
+      statusCode: yupNumber().oneOf([200]).defined(),
+      bodyType: yupString().oneOf(["json"]).defined(),
+      body: yupObject({
+        location: yupString().defined(),
+      }).defined(),
+    }).defined(),
+    yupObject({
+      statusCode: yupNumber().oneOf([307]).defined(),
+      headers: yupObject({
+        location: yupArray(yupString().defined()).defined(),
+      }).defined(),
+      bodyType: yupString().oneOf(["text"]).defined(),
+      body: yupString().defined(),
+    }).defined(),
+  ) as unknown as Schema<SmartResponse>,
+  async handler({ params, query }) {
+    const tenancy = await getSoleTenancyFromProjectBranch(...getProjectBranchFromClientId(query.client_id), true);
+    if (!tenancy) {
+      throw new KnownErrors.InvalidOAuthClientIdOrSecret(query.client_id);
+    }
+
+    const keyCheck = await checkApiKeySet(tenancy.project.id, { publishableClientKey: query.client_secret });
+    if (keyCheck.status === "error") {
+      throwCheckApiKeySetError(keyCheck.error, tenancy.project.id, new KnownErrors.InvalidPublishableClientKey(tenancy.project.id));
+    }
+
+    const connectionRaw = tenancy.config.auth.saml.connections[params.connection_id];
+    if (!connectionRaw.idpEntityId || !connectionRaw.idpSsoUrl || !connectionRaw.idpCertificate) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is not configured`);
+    }
+    if (connectionRaw.allowSignIn === false) {
+      throw new StatusError(StatusError.Forbidden, `SAML connection ${params.connection_id} has sign-in disabled`);
+    }
+
+    if (
+      query.after_callback_redirect_url
+      && !validateRedirectUrl(query.after_callback_redirect_url, tenancy)
+      && !isAcceptedNativeAppUrl(query.after_callback_redirect_url)
+    ) {
+      throw new KnownErrors.RedirectUrlNotWhitelisted();
+    }
+
+    const connection: SamlConnectionConfig = {
+      id: params.connection_id,
+      displayName: connectionRaw.displayName,
+      idpEntityId: connectionRaw.idpEntityId,
+      idpSsoUrl: connectionRaw.idpSsoUrl,
+      idpCertificate: connectionRaw.idpCertificate,
+      domain: connectionRaw.domain,
+      attributeMapping: connectionRaw.attributeMapping,
+    };
+
+    const baseUrl = new URL(query.redirect_uri).origin;
+    const client = buildSamlClient(connection, baseUrl);
+    const { url: samlUrl, requestId } = await buildAuthnRequestUrl(client, query.state);
+
+    const payload: SamlOuterInfoPayload = {
+      tenancyId: tenancy.id,
+      samlConnectionId: params.connection_id,
+      publishableClientKey: query.client_secret,
+      redirectUri: query.redirect_uri.split("#")[0],
+      state: query.state,
+      scope: query.scope,
+      grantType: query.grant_type,
+      codeChallenge: query.code_challenge,
+      codeChallengeMethod: query.code_challenge_method,
+      responseType: query.response_type,
+      errorRedirectUrl: query.error_redirect_uri,
+      afterCallbackRedirectUrl: query.after_callback_redirect_url,
+      responseMode: query.stack_response_mode,
+    };
+
+    await globalPrismaClient.samlOuterInfo.create({
+      data: {
+        id: requestId,
+        info: payload as unknown as object,
+        expiresAt: new Date(Date.now() + 1000 * 60 * SAML_OUTER_TTL_MINUTES),
+      },
+    });
+
+    if (query.stack_response_mode === "json") {
+      return {
+        statusCode: 200,
+        bodyType: "json",
+        body: { location: samlUrl },
+      };
+    }
+
+    // Browser-redirect mode: set a CSRF cookie keyed to the AuthnRequest ID.
+    // The ACS route checks this cookie before honoring the assertion.
+    (await cookies()).set(
+      "stack-saml-inner-" + requestId,
+      "true",
+      {
+        httpOnly: true,
+        secure: getNodeEnvironment() !== "development",
+        maxAge: 60 * SAML_OUTER_TTL_MINUTES,
+      },
+    );
+
+    redirect(samlUrl);
+  },
+});

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -37,9 +37,12 @@ export const GET = createSmartRouteHandler({
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }
+    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found in project ${query.project_id}`);
+    }
     const connection = tenancy.config.auth.saml.connections[params.connection_id];
     if (!connection.idpEntityId || !connection.idpSsoUrl || !connection.idpCertificate) {
-      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found or incompletely configured in project ${query.project_id}`);
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is incompletely configured (missing IdP entity ID, SSO URL, or certificate)`);
     }
 
     // Derive the public-facing base URL from the request origin so SP

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -4,6 +4,7 @@ import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { has } from "@stackframe/stack-shared/dist/utils/objects";
 
 /**
  * Public-fetchable SP metadata XML for a single SAML connection. The IdP
@@ -44,7 +45,7 @@ export const GET = createSmartRouteHandler({
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }
-    if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
+    if (!has(tenancy.config.auth.saml.connections, params.connection_id)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found in project ${query.project_id}`);
     }
     const connection = tenancy.config.auth.saml.connections[params.connection_id];

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -2,6 +2,7 @@ import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenanc
 import { getSpMetadataXml } from "@/saml/saml";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 
 /**
@@ -25,6 +26,12 @@ export const GET = createSmartRouteHandler({
     }).defined(),
     query: yupObject({
       project_id: yupString().defined(),
+      // Optional — SAML connections live under a tenancy/branch. If a
+      // connection was created on a non-default branch, the IdP admin must
+      // pass the same branch_id when fetching metadata so the SP entityId
+      // matches what login (resolved from `client_id` = `projectId#branchId`)
+      // will use.
+      branch_id: yupString().optional(),
     }).defined(),
   }),
   response: yupObject({
@@ -32,8 +39,8 @@ export const GET = createSmartRouteHandler({
     bodyType: yupString().oneOf(["text"]).defined(),
     body: yupString().defined(),
   }),
-  async handler({ params, query }, fullReq) {
-    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
+  async handler({ params, query }) {
+    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, query.branch_id ?? DEFAULT_BRANCH_ID, true);
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }
@@ -45,10 +52,10 @@ export const GET = createSmartRouteHandler({
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} is incompletely configured (missing IdP entity ID, SSO URL, or certificate)`);
     }
 
-    // Derive the public-facing base URL from the request origin so SP
-    // metadata reflects the host the IdP is calling.
-    const reqUrl = new URL(fullReq.url);
-    const baseUrl = `${reqUrl.protocol}//${reqUrl.host}`;
+    // Canonical Stack Auth public API origin — must match login + ACS so the
+    // SP entityId/audience the IdP signs against is consistent across the
+    // whole flow.
+    const baseUrl = getEnvVariable("NEXT_PUBLIC_STACK_API_URL");
     const xml = getSpMetadataXml({
       id: params.connection_id,
       displayName: connection.displayName,

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -1,0 +1,58 @@
+import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
+import { getSpMetadataXml, SamlConnectionConfig } from "@/saml/saml";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+
+/**
+ * Public-fetchable SP metadata XML for a single SAML connection. The IdP
+ * admin pastes this URL into their IdP UI to configure the SP side.
+ *
+ * V1 design: includes `?project_id=` because the connection ID alone
+ * doesn't identify a tenancy (connection config lives in JSON, not a
+ * Prisma table — we'd otherwise have to scan all tenancies). A reverse
+ * index can be added later if this UX matters more.
+ */
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "SAML SP metadata",
+    description: "Returns the Service Provider metadata XML for a SAML connection — paste into the IdP admin UI to configure the SP side.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    params: yupObject({
+      connection_id: yupString().defined(),
+    }).defined(),
+    query: yupObject({
+      project_id: yupString().defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["text"]).defined(),
+    body: yupString().defined(),
+  }),
+  async handler({ params, query }, fullReq) {
+    const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
+    if (!tenancy) {
+      throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
+    }
+    const samlConfig = (tenancy.config.auth as { saml?: { connections?: Record<string, SamlConnectionConfig> } }).saml;
+    const connection = samlConfig?.connections?.[params.connection_id];
+    if (!connection) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found in project ${query.project_id}`);
+    }
+
+    // Derive the public-facing base URL from the request origin so SP
+    // metadata reflects the host the IdP is calling.
+    const reqUrl = new URL(fullReq.url);
+    const baseUrl = `${reqUrl.protocol}//${reqUrl.host}`;
+    const xml = getSpMetadataXml({ ...connection, id: params.connection_id }, baseUrl);
+
+    return {
+      statusCode: 200,
+      bodyType: "text",
+      body: xml,
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -1,5 +1,5 @@
 import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
-import { getSpMetadataXml, SamlConnectionConfig } from "@/saml/saml";
+import { getSpMetadataXml } from "@/saml/saml";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
@@ -37,17 +37,24 @@ export const GET = createSmartRouteHandler({
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
     }
-    const samlConfig = (tenancy.config.auth as { saml?: { connections?: Record<string, SamlConnectionConfig> } }).saml;
-    const connection = samlConfig?.connections?.[params.connection_id];
-    if (!connection) {
-      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found in project ${query.project_id}`);
+    const connection = tenancy.config.auth.saml.connections[params.connection_id];
+    if (!connection.idpEntityId || !connection.idpSsoUrl || !connection.idpCertificate) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found or incompletely configured in project ${query.project_id}`);
     }
 
     // Derive the public-facing base URL from the request origin so SP
     // metadata reflects the host the IdP is calling.
     const reqUrl = new URL(fullReq.url);
     const baseUrl = `${reqUrl.protocol}//${reqUrl.host}`;
-    const xml = getSpMetadataXml({ ...connection, id: params.connection_id }, baseUrl);
+    const xml = getSpMetadataXml({
+      id: params.connection_id,
+      displayName: connection.displayName,
+      idpEntityId: connection.idpEntityId,
+      idpSsoUrl: connection.idpSsoUrl,
+      idpCertificate: connection.idpCertificate,
+      domain: connection.domain,
+      attributeMapping: connection.attributeMapping,
+    }, baseUrl);
 
     return {
       statusCode: 200,

--- a/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
@@ -1,0 +1,64 @@
+/**
+ * Admin GET for a single SAML connection — returns the full config
+ * including idp_certificate. Use this for the dashboard's detail page;
+ * the list endpoint omits the cert.
+ */
+import { adaptSchema, adminAuthTypeSchema, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "Get a SAML connection",
+    description: "Admin: full connection config including the IdP certificate.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema,
+    }).defined(),
+    params: yupObject({
+      connection_id: yupString().defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      id: yupString().defined(),
+      display_name: yupString().defined(),
+      allow_sign_in: yupBoolean().defined(),
+      domain: yupString().nullable().defined(),
+      idp_entity_id: yupString().nullable().defined(),
+      idp_sso_url: yupString().nullable().defined(),
+      idp_certificate: yupString().nullable().defined(),
+      attribute_mapping: yupObject({
+        email: yupString().optional(),
+        display_name: yupString().optional(),
+      }).nullable().defined(),
+    }).defined(),
+  }),
+  async handler({ auth, params }) {
+    if (!(params.connection_id in auth.tenancy.config.auth.saml.connections)) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
+    }
+    const conn = auth.tenancy.config.auth.saml.connections[params.connection_id];
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        id: params.connection_id,
+        display_name: conn.displayName,
+        allow_sign_in: conn.allowSignIn,
+        domain: conn.domain ?? null,
+        idp_entity_id: conn.idpEntityId ?? null,
+        idp_sso_url: conn.idpSsoUrl ?? null,
+        idp_certificate: conn.idpCertificate ?? null,
+        attribute_mapping: conn.attributeMapping
+          ? { email: conn.attributeMapping.email, display_name: conn.attributeMapping.displayName }
+          : null,
+      },
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
@@ -6,6 +6,7 @@
 import { adaptSchema, adminAuthTypeSchema, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { has } from "@stackframe/stack-shared/dist/utils/objects";
 
 export const GET = createSmartRouteHandler({
   metadata: {
@@ -40,7 +41,7 @@ export const GET = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ auth, params }) {
-    if (!(params.connection_id in auth.tenancy.config.auth.saml.connections)) {
+    if (!has(auth.tenancy.config.auth.saml.connections, params.connection_id)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }
     const conn = auth.tenancy.config.auth.saml.connections[params.connection_id];

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -100,6 +100,20 @@ export const POST = createSmartRouteHandler({
   }),
   async handler({ auth, body }) {
     const exists = has(auth.tenancy.config.auth.saml.connections, body.id);
+
+    // Discovery picks the first connection whose domain matches the email's
+    // domain, so allowing two connections to claim the same domain would
+    // make /auth/saml/discover non-deterministic. Reject collisions up front.
+    if (body.domain) {
+      const newDomain = body.domain.toLowerCase();
+      type Conn = (typeof auth.tenancy.config.auth.saml.connections)[string];
+      const entries = Object.entries(auth.tenancy.config.auth.saml.connections) as Array<[string, Conn]>;
+      const conflict = entries.find(([id, c]) => id !== body.id && c.domain && c.domain.toLowerCase() === newDomain);
+      if (conflict) {
+        throw new StatusError(StatusError.BadRequest, `Another SAML connection (${conflict[0]}) already claims domain "${body.domain}". Domains must be unique per project.`);
+      }
+    }
+
     const prefix = `auth.saml.connections.${body.id}`;
     const overlay: Record<string, unknown> = {};
     if (!exists) {

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -14,6 +14,7 @@ import { overrideEnvironmentConfigOverride, resetEnvironmentConfigOverrideKeys }
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { adaptSchema, adminAuthTypeSchema, yupArray, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { has } from "@stackframe/stack-shared/dist/utils/objects";
 
 const samlConnectionResponseShape = yupObject({
   id: yupString().defined(),
@@ -98,7 +99,7 @@ export const POST = createSmartRouteHandler({
     body: samlConnectionResponseShape,
   }),
   async handler({ auth, body }) {
-    const exists = body.id in auth.tenancy.config.auth.saml.connections;
+    const exists = has(auth.tenancy.config.auth.saml.connections, body.id);
     const prefix = `auth.saml.connections.${body.id}`;
     const overlay: Record<string, unknown> = {};
     if (!exists) {
@@ -183,7 +184,7 @@ export const DELETE = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ auth, body }) {
-    if (!(body.id in auth.tenancy.config.auth.saml.connections)) {
+    if (!has(auth.tenancy.config.auth.saml.connections, body.id)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${body.id} not found`);
     }
     await resetEnvironmentConfigOverrideKeys({

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -1,0 +1,177 @@
+/**
+ * Admin endpoints for managing SAML connections on a project.
+ *
+ * Connection config lives in tenancy.config.auth.saml.connections (JSON).
+ * These endpoints are thin REST wrappers around the same config-override
+ * mechanism the dashboard would otherwise call directly — they exist so
+ * the dashboard's SSO list/detail pages don't have to compose key paths
+ * manually.
+ *
+ * Admin access only. Per-project; the project is identified by the admin
+ * auth context (no project_id in the URL).
+ */
+import { overrideEnvironmentConfigOverride, resetEnvironmentConfigOverrideKeys } from "@/lib/config";
+import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { adaptSchema, adminAuthTypeSchema, yupArray, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+
+const samlConnectionResponseShape = yupObject({
+  id: yupString().defined(),
+  display_name: yupString().defined(),
+  allow_sign_in: yupBoolean().defined(),
+  domain: yupString().nullable().defined(),
+  idp_entity_id: yupString().nullable().defined(),
+  idp_sso_url: yupString().nullable().defined(),
+  // idp_certificate intentionally truncated in list responses (it's long
+  // and rarely needed); full cert is returned only by GET /[id].
+  has_idp_certificate: yupBoolean().defined(),
+});
+
+export const GET = createSmartRouteHandler({
+  metadata: {
+    summary: "List SAML connections",
+    description: "Admin: list every SAML connection configured on the project.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema,
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      items: yupArray(samlConnectionResponseShape).defined(),
+    }).defined(),
+  }),
+  async handler({ auth }) {
+    const connections = auth.tenancy.config.auth.saml.connections;
+    type Conn = (typeof auth.tenancy.config.auth.saml.connections)[string];
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        items: (Object.entries(connections) as Array<[string, Conn]>).map(([id, c]) => ({
+          id,
+          display_name: c.displayName,
+          allow_sign_in: c.allowSignIn,
+          domain: c.domain ?? null,
+          idp_entity_id: c.idpEntityId ?? null,
+          idp_sso_url: c.idpSsoUrl ?? null,
+          has_idp_certificate: !!c.idpCertificate,
+        })),
+      },
+    };
+  },
+});
+
+export const POST = createSmartRouteHandler({
+  metadata: {
+    summary: "Create or update a SAML connection",
+    description: "Admin: idempotent upsert by connection_id.",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema,
+    }).defined(),
+    body: yupObject({
+      id: yupString().matches(/^[a-z0-9_-]+$/i).defined(),
+      display_name: yupString().defined(),
+      allow_sign_in: yupBoolean().defined(),
+      domain: yupString().nullable().optional(),
+      idp_entity_id: yupString().defined(),
+      idp_sso_url: yupString().defined(),
+      idp_certificate: yupString().defined(),
+      attribute_mapping: yupObject({
+        email: yupString().optional(),
+        display_name: yupString().optional(),
+      }).optional(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: samlConnectionResponseShape,
+  }),
+  async handler({ auth, body }) {
+    const overlay: Record<string, unknown> = {
+      [`auth.saml.connections.${body.id}.displayName`]: body.display_name,
+      [`auth.saml.connections.${body.id}.allowSignIn`]: body.allow_sign_in,
+      [`auth.saml.connections.${body.id}.idpEntityId`]: body.idp_entity_id,
+      [`auth.saml.connections.${body.id}.idpSsoUrl`]: body.idp_sso_url,
+      [`auth.saml.connections.${body.id}.idpCertificate`]: body.idp_certificate,
+    };
+    if (body.domain !== undefined) {
+      overlay[`auth.saml.connections.${body.id}.domain`] = body.domain;
+    }
+    if (body.attribute_mapping) {
+      overlay[`auth.saml.connections.${body.id}.attributeMapping`] = {
+        email: body.attribute_mapping.email,
+        displayName: body.attribute_mapping.display_name,
+      };
+    }
+
+    await overrideEnvironmentConfigOverride({
+      projectId: auth.tenancy.project.id,
+      branchId: auth.tenancy.branchId,
+      environmentConfigOverrideOverride: overlay as Parameters<typeof overrideEnvironmentConfigOverride>[0]["environmentConfigOverrideOverride"],
+    });
+
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: {
+        id: body.id,
+        display_name: body.display_name,
+        allow_sign_in: body.allow_sign_in,
+        domain: body.domain ?? null,
+        idp_entity_id: body.idp_entity_id,
+        idp_sso_url: body.idp_sso_url,
+        has_idp_certificate: true,
+      },
+    };
+  },
+});
+
+export const DELETE = createSmartRouteHandler({
+  metadata: {
+    summary: "Delete a SAML connection",
+    description: "Admin: remove the connection. Existing user accounts linked via this connection remain in the database (they just become unable to sign in until a connection with the same id is recreated).",
+    tags: ["Saml"],
+  },
+  request: yupObject({
+    auth: yupObject({
+      type: adminAuthTypeSchema,
+      tenancy: adaptSchema,
+    }).defined(),
+    body: yupObject({
+      id: yupString().defined(),
+    }).defined(),
+  }),
+  response: yupObject({
+    statusCode: yupNumber().oneOf([200]).defined(),
+    bodyType: yupString().oneOf(["json"]).defined(),
+    body: yupObject({
+      success: yupBoolean().defined(),
+    }).defined(),
+  }),
+  async handler({ auth, body }) {
+    if (!(body.id in auth.tenancy.config.auth.saml.connections)) {
+      throw new StatusError(StatusError.NotFound, `SAML connection ${body.id} not found`);
+    }
+    await resetEnvironmentConfigOverrideKeys({
+      projectId: auth.tenancy.project.id,
+      branchId: auth.tenancy.branchId,
+      keysToReset: [`auth.saml.connections.${body.id}`],
+    });
+    return {
+      statusCode: 200,
+      bodyType: "json",
+      body: { success: true },
+    };
+  },
+});

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -98,21 +98,44 @@ export const POST = createSmartRouteHandler({
     body: samlConnectionResponseShape,
   }),
   async handler({ auth, body }) {
-    const overlay: Record<string, unknown> = {
-      [`auth.saml.connections.${body.id}.displayName`]: body.display_name,
-      [`auth.saml.connections.${body.id}.allowSignIn`]: body.allow_sign_in,
-      [`auth.saml.connections.${body.id}.idpEntityId`]: body.idp_entity_id,
-      [`auth.saml.connections.${body.id}.idpSsoUrl`]: body.idp_sso_url,
-      [`auth.saml.connections.${body.id}.idpCertificate`]: body.idp_certificate,
-    };
-    if (body.domain !== undefined) {
-      overlay[`auth.saml.connections.${body.id}.domain`] = body.domain;
-    }
-    if (body.attribute_mapping) {
-      overlay[`auth.saml.connections.${body.id}.attributeMapping`] = {
-        email: body.attribute_mapping.email,
-        displayName: body.attribute_mapping.display_name,
+    const exists = body.id in auth.tenancy.config.auth.saml.connections;
+    const prefix = `auth.saml.connections.${body.id}`;
+    const overlay: Record<string, unknown> = {};
+    if (!exists) {
+      // First-time create: write the whole record entry as a nested object.
+      // Dotting into a missing parent record entry is silently dropped by
+      // the config layer (see lib/config validateConfigOverrideSchema), so
+      // child-only updates would 200 with no effect on a brand-new connection.
+      const data: Record<string, unknown> = {
+        displayName: body.display_name,
+        allowSignIn: body.allow_sign_in,
+        idpEntityId: body.idp_entity_id,
+        idpSsoUrl: body.idp_sso_url,
+        idpCertificate: body.idp_certificate,
       };
+      if (body.domain !== undefined) data.domain = body.domain;
+      if (body.attribute_mapping) {
+        data.attributeMapping = {
+          email: body.attribute_mapping.email,
+          displayName: body.attribute_mapping.display_name,
+        };
+      }
+      overlay[prefix] = data;
+    } else {
+      overlay[`${prefix}.displayName`] = body.display_name;
+      overlay[`${prefix}.allowSignIn`] = body.allow_sign_in;
+      overlay[`${prefix}.idpEntityId`] = body.idp_entity_id;
+      overlay[`${prefix}.idpSsoUrl`] = body.idp_sso_url;
+      overlay[`${prefix}.idpCertificate`] = body.idp_certificate;
+      if (body.domain !== undefined) {
+        overlay[`${prefix}.domain`] = body.domain;
+      }
+      if (body.attribute_mapping) {
+        overlay[`${prefix}.attributeMapping`] = {
+          email: body.attribute_mapping.email,
+          displayName: body.attribute_mapping.display_name,
+        };
+      }
     }
 
     await overrideEnvironmentConfigOverride({

--- a/apps/backend/src/lib/external-auth.tsx
+++ b/apps/backend/src/lib/external-auth.tsx
@@ -1,0 +1,74 @@
+import { getAuthContactChannelWithEmailNormalization } from "@/lib/contact-channel";
+import { Tenancy } from "@/lib/tenancies";
+import { PrismaClientTransaction } from "@/prisma-client";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
+import { captureError, StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
+
+/**
+ * Email-based account merging shared between OAuth and SAML sign-in.
+ *
+ * When a new external sign-in arrives with an email that's already used
+ * for auth by an existing user, this returns whether to link to that user
+ * (link_method), reject (raise_error), or create a duplicate
+ * (allow_duplicates).
+ *
+ * Lifted from oauth.tsx so the SAML ACS handler can reuse the same logic
+ * without duplicating the merge-strategy switch and contact-channel
+ * lookup.
+ *
+ * @returns linkedUserId - User ID to link to, or null if creating new user
+ * @returns primaryEmailAuthEnabled - Whether the email should be used for auth
+ */
+export async function handleExternalEmailMergeStrategy(
+  prisma: PrismaClientTransaction,
+  tenancy: Tenancy,
+  params: {
+    email: string,
+    emailVerified: boolean,
+    accountMergeStrategy: "link_method" | "raise_error" | "allow_duplicates",
+  },
+): Promise<{ linkedUserId: string | null, primaryEmailAuthEnabled: boolean }> {
+  let primaryEmailAuthEnabled = true;
+  let linkedUserId: string | null = null;
+
+  const existingContactChannel = await getAuthContactChannelWithEmailNormalization(
+    prisma,
+    {
+      tenancyId: tenancy.id,
+      type: "EMAIL",
+      value: params.email,
+    },
+  );
+
+  if (existingContactChannel && existingContactChannel.usedForAuth) {
+    switch (params.accountMergeStrategy) {
+      case "link_method": {
+        if (!existingContactChannel.isVerified) {
+          throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", params.email, true);
+        }
+        if (!params.emailVerified) {
+          // Edge case: existing user is verified, but the new external assertion claims an
+          // unverified email. Linking would let an attacker hijack an account by claiming
+          // the victim's email at an unverified IdP. We refuse for safety.
+          const err = new StackAssertionError(
+            "Account merge strategy is link_method, but the new external email is not verified.",
+            { existingContactChannel, email: params.email, emailVerified: params.emailVerified },
+          );
+          captureError("external-auth-link-method-email-not-verified", err);
+          throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", params.email);
+        }
+        linkedUserId = existingContactChannel.projectUserId;
+        break;
+      }
+      case "raise_error": {
+        throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", params.email);
+      }
+      case "allow_duplicates": {
+        primaryEmailAuthEnabled = false;
+        break;
+      }
+    }
+  }
+
+  return { linkedUserId, primaryEmailAuthEnabled };
+}

--- a/apps/backend/src/lib/oauth.tsx
+++ b/apps/backend/src/lib/oauth.tsx
@@ -1,10 +1,10 @@
-import { getAuthContactChannelWithEmailNormalization } from "@/lib/contact-channel";
+import { handleExternalEmailMergeStrategy } from "@/lib/external-auth";
 import { Tenancy } from "@/lib/tenancies";
 import { createOrUpgradeAnonymousUserWithRules, SignUpRuleOptions } from "@/lib/users";
 import { PrismaClientTransaction } from "@/prisma-client";
 import { UsersCrud } from "@stackframe/stack-shared/dist/interface/crud/users";
 import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
-import { captureError, StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+import { StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
 
 /**
  * Find an existing OAuth account for sign-in.
@@ -53,8 +53,8 @@ export function getProjectUserIdFromOAuthAccount(
 /**
  * Handle the OAuth email merge strategy.
  *
- * This determines whether a new OAuth sign-up should be linked to an existing user
- * based on email address, according to the project's merge strategy setting.
+ * Thin wrapper around handleExternalEmailMergeStrategy that pulls the
+ * project's OAuth-specific account merge strategy from tenancy config.
  *
  * @returns linkedUserId - The user ID to link to, or null if creating a new user
  * @returns primaryEmailAuthEnabled - Whether the email should be used for auth
@@ -65,52 +65,11 @@ export async function handleOAuthEmailMergeStrategy(
   email: string,
   emailVerified: boolean,
 ): Promise<{ linkedUserId: string | null, primaryEmailAuthEnabled: boolean }> {
-  let primaryEmailAuthEnabled = true;
-  let linkedUserId: string | null = null;
-
-  const existingContactChannel = await getAuthContactChannelWithEmailNormalization(
-    prisma,
-    {
-      tenancyId: tenancy.id,
-      type: "EMAIL",
-      value: email,
-    }
-  );
-
-  // Check if we should link this OAuth account to an existing user based on email
-  if (existingContactChannel && existingContactChannel.usedForAuth) {
-    const accountMergeStrategy = tenancy.config.auth.oauth.accountMergeStrategy;
-    switch (accountMergeStrategy) {
-      case "link_method": {
-        if (!existingContactChannel.isVerified) {
-          throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", email, true);
-        }
-
-        if (!emailVerified) {
-          // TODO: Handle this case
-          const err = new StackAssertionError(
-            "OAuth account merge strategy is set to link_method, but the NEW email is not verified. This is an edge case that we don't handle right now",
-            { existingContactChannel, email, emailVerified }
-          );
-          captureError("oauth-link-method-email-not-verified", err);
-          throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", email);
-        }
-
-        // Link to existing user
-        linkedUserId = existingContactChannel.projectUserId;
-        break;
-      }
-      case "raise_error": {
-        throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", email);
-      }
-      case "allow_duplicates": {
-        primaryEmailAuthEnabled = false;
-        break;
-      }
-    }
-  }
-
-  return { linkedUserId, primaryEmailAuthEnabled };
+  return await handleExternalEmailMergeStrategy(prisma, tenancy, {
+    email,
+    emailVerified,
+    accountMergeStrategy: tenancy.config.auth.oauth.accountMergeStrategy,
+  });
 }
 
 /**

--- a/apps/backend/src/lib/saml-account.tsx
+++ b/apps/backend/src/lib/saml-account.tsx
@@ -60,8 +60,7 @@ export async function handleSamlEmailMergeStrategy(
   // Read SAML-specific strategy from config; fall back to OAuth's strategy if
   // not set, so existing projects keep consistent behavior across protocols
   // until they explicitly opt into a different SAML policy.
-  const samlConfig = (tenancy.config.auth as { saml?: { accountMergeStrategy?: "link_method" | "raise_error" | "allow_duplicates" } }).saml;
-  const accountMergeStrategy = samlConfig?.accountMergeStrategy ?? tenancy.config.auth.oauth.accountMergeStrategy;
+  const accountMergeStrategy = tenancy.config.auth.saml.accountMergeStrategy ?? tenancy.config.auth.oauth.accountMergeStrategy;
   return await handleExternalEmailMergeStrategy(prisma, tenancy, {
     email: params.email,
     emailVerified: params.emailVerified,

--- a/apps/backend/src/lib/saml-account.tsx
+++ b/apps/backend/src/lib/saml-account.tsx
@@ -121,10 +121,12 @@ export async function linkSamlAccountToUser(
 /**
  * Create a new user from a verified SAML identity. JIT provisioning — runs
  * when no existing account or matching email is found. Mirrors
- * createOAuthUserAndAccount.
+ * createOAuthUserAndAccount. The AuthMethod and ProjectUserSamlAccount writes
+ * are wrapped in a transaction so a failure on the second write can't leave
+ * an orphaned bare AuthMethod tied to the new user.
  */
 export async function createSamlUserAndAccount(
-  prisma: PrismaClientTransaction,
+  prisma: Omit<PrismaClient, "$on">,
   tenancy: Tenancy,
   params: {
     samlConnectionId: string,
@@ -157,29 +159,31 @@ export async function createSamlUserAndAccount(
     params.signUpRuleOptions,
   );
 
-  const authMethod = await prisma.authMethod.create({
-    data: {
-      tenancyId: tenancy.id,
-      projectUserId: newUser.id,
-    },
-  });
-
-  const samlAccount = await prisma.projectUserSamlAccount.create({
-    data: {
-      tenancyId: tenancy.id,
-      samlConnectionId: params.samlConnectionId,
-      nameId: params.nameId,
-      nameIdFormat: params.nameIdFormat,
-      email: params.email,
-      projectUserId: newUser.id,
-      samlAuthMethod: {
-        create: {
-          authMethodId: authMethod.id,
-        },
+  return await retryTransaction(prisma, async (tx) => {
+    const authMethod = await tx.authMethod.create({
+      data: {
+        tenancyId: tenancy.id,
+        projectUserId: newUser.id,
       },
-      allowSignIn: true,
-    },
-  });
+    });
 
-  return { projectUserId: newUser.id, samlAccountId: samlAccount.id };
+    const samlAccount = await tx.projectUserSamlAccount.create({
+      data: {
+        tenancyId: tenancy.id,
+        samlConnectionId: params.samlConnectionId,
+        nameId: params.nameId,
+        nameIdFormat: params.nameIdFormat,
+        email: params.email,
+        projectUserId: newUser.id,
+        samlAuthMethod: {
+          create: {
+            authMethodId: authMethod.id,
+          },
+        },
+        allowSignIn: true,
+      },
+    });
+
+    return { projectUserId: newUser.id, samlAccountId: samlAccount.id };
+  });
 }

--- a/apps/backend/src/lib/saml-account.tsx
+++ b/apps/backend/src/lib/saml-account.tsx
@@ -1,7 +1,8 @@
 import { handleExternalEmailMergeStrategy } from "@/lib/external-auth";
 import { Tenancy } from "@/lib/tenancies";
 import { createOrUpgradeAnonymousUserWithRules, SignUpRuleOptions } from "@/lib/users";
-import { PrismaClientTransaction } from "@/prisma-client";
+import { PrismaClientTransaction, retryTransaction } from "@/prisma-client";
+import type { PrismaClient } from "@/generated/prisma/client";
 import { UsersCrud } from "@stackframe/stack-shared/dist/interface/crud/users";
 import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
@@ -71,10 +72,13 @@ export async function handleSamlEmailMergeStrategy(
 /**
  * Link a verified SAML identity to an already-existing user (matched by email).
  * Mirrors linkOAuthAccountToUser. Creates one ProjectUserSamlAccount and one
- * AuthMethod with a nested SamlAuthMethod.
+ * AuthMethod with a nested SamlAuthMethod — atomically, so a partial failure
+ * can't leave a sign-in-enabled SAML account row without the matching
+ * auth-method state (which findExistingSamlAccount would still treat as a
+ * valid identity).
  */
 export async function linkSamlAccountToUser(
-  prisma: PrismaClientTransaction,
+  prisma: Omit<PrismaClient, "$on">,
   params: {
     tenancyId: string,
     samlConnectionId: string,
@@ -84,32 +88,34 @@ export async function linkSamlAccountToUser(
     projectUserId: string,
   },
 ): Promise<{ samlAccountId: string }> {
-  const samlAccount = await prisma.projectUserSamlAccount.create({
-    data: {
-      tenancyId: params.tenancyId,
-      samlConnectionId: params.samlConnectionId,
-      nameId: params.nameId,
-      nameIdFormat: params.nameIdFormat,
-      email: params.email,
-      projectUserId: params.projectUserId,
-    },
-  });
+  return await retryTransaction(prisma, async (tx) => {
+    const samlAccount = await tx.projectUserSamlAccount.create({
+      data: {
+        tenancyId: params.tenancyId,
+        samlConnectionId: params.samlConnectionId,
+        nameId: params.nameId,
+        nameIdFormat: params.nameIdFormat,
+        email: params.email,
+        projectUserId: params.projectUserId,
+      },
+    });
 
-  await prisma.authMethod.create({
-    data: {
-      tenancyId: params.tenancyId,
-      projectUserId: params.projectUserId,
-      samlAuthMethod: {
-        create: {
-          projectUserId: params.projectUserId,
-          samlConnectionId: params.samlConnectionId,
-          nameId: params.nameId,
+    await tx.authMethod.create({
+      data: {
+        tenancyId: params.tenancyId,
+        projectUserId: params.projectUserId,
+        samlAuthMethod: {
+          create: {
+            projectUserId: params.projectUserId,
+            samlConnectionId: params.samlConnectionId,
+            nameId: params.nameId,
+          },
         },
       },
-    },
-  });
+    });
 
-  return { samlAccountId: samlAccount.id };
+    return { samlAccountId: samlAccount.id };
+  });
 }
 
 /**

--- a/apps/backend/src/lib/saml-account.tsx
+++ b/apps/backend/src/lib/saml-account.tsx
@@ -5,7 +5,6 @@ import { PrismaClientTransaction, retryTransaction } from "@/prisma-client";
 import type { PrismaClient } from "@/generated/prisma/client";
 import { UsersCrud } from "@stackframe/stack-shared/dist/interface/crud/users";
 import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
-import { StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
 
 /**
  * Find an existing SAML account by NameID within a connection. Used when the
@@ -37,15 +36,6 @@ export async function findExistingSamlAccount(
     return null;
   }
   return account;
-}
-
-export function getProjectUserIdFromSamlAccount(
-  account: Awaited<ReturnType<typeof findExistingSamlAccount>>,
-): string {
-  if (!account) {
-    throw new StackAssertionError("SAML account is null");
-  }
-  return account.projectUserId ?? throwErr("SAML account exists but has no associated user");
 }
 
 /**

--- a/apps/backend/src/lib/saml-account.tsx
+++ b/apps/backend/src/lib/saml-account.tsx
@@ -1,0 +1,180 @@
+import { handleExternalEmailMergeStrategy } from "@/lib/external-auth";
+import { Tenancy } from "@/lib/tenancies";
+import { createOrUpgradeAnonymousUserWithRules, SignUpRuleOptions } from "@/lib/users";
+import { PrismaClientTransaction } from "@/prisma-client";
+import { UsersCrud } from "@stackframe/stack-shared/dist/interface/crud/users";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
+import { StackAssertionError, throwErr } from "@stackframe/stack-shared/dist/utils/errors";
+
+/**
+ * Find an existing SAML account by NameID within a connection. Used when the
+ * ACS handler receives a verified assertion and needs to look up the user.
+ *
+ * Connection isolation invariant: the unique key includes samlConnectionId,
+ * so the same NameID arriving from a different connection is treated as a
+ * separate identity. Tests covered: "two connections, two distinct user
+ * pools" + "cross-connection assertion forgery" (see plan §multi-tenancy).
+ */
+export async function findExistingSamlAccount(
+  prisma: PrismaClientTransaction,
+  tenancyId: string,
+  samlConnectionId: string,
+  nameId: string,
+) {
+  const account = await prisma.projectUserSamlAccount.findUnique({
+    where: {
+      tenancyId_samlConnectionId_nameId: {
+        tenancyId,
+        samlConnectionId,
+        nameId,
+      },
+    },
+  });
+  // allowSignIn=false means the user (or admin) has disabled SAML sign-in for
+  // this account — treat as if not found so the caller errors out cleanly.
+  if (account && !account.allowSignIn) {
+    return null;
+  }
+  return account;
+}
+
+export function getProjectUserIdFromSamlAccount(
+  account: Awaited<ReturnType<typeof findExistingSamlAccount>>,
+): string {
+  if (!account) {
+    throw new StackAssertionError("SAML account is null");
+  }
+  return account.projectUserId ?? throwErr("SAML account exists but has no associated user");
+}
+
+/**
+ * Wraps the shared email-merge logic with the SAML-specific config path.
+ * Defaults to "link_method" if the project hasn't configured a strategy
+ * (the same default as OAuth).
+ */
+export async function handleSamlEmailMergeStrategy(
+  prisma: PrismaClientTransaction,
+  tenancy: Tenancy,
+  params: { email: string, emailVerified: boolean },
+): Promise<{ linkedUserId: string | null, primaryEmailAuthEnabled: boolean }> {
+  // Read SAML-specific strategy from config; fall back to OAuth's strategy if
+  // not set, so existing projects keep consistent behavior across protocols
+  // until they explicitly opt into a different SAML policy.
+  const samlConfig = (tenancy.config.auth as { saml?: { accountMergeStrategy?: "link_method" | "raise_error" | "allow_duplicates" } }).saml;
+  const accountMergeStrategy = samlConfig?.accountMergeStrategy ?? tenancy.config.auth.oauth.accountMergeStrategy;
+  return await handleExternalEmailMergeStrategy(prisma, tenancy, {
+    email: params.email,
+    emailVerified: params.emailVerified,
+    accountMergeStrategy,
+  });
+}
+
+/**
+ * Link a verified SAML identity to an already-existing user (matched by email).
+ * Mirrors linkOAuthAccountToUser. Creates one ProjectUserSamlAccount and one
+ * AuthMethod with a nested SamlAuthMethod.
+ */
+export async function linkSamlAccountToUser(
+  prisma: PrismaClientTransaction,
+  params: {
+    tenancyId: string,
+    samlConnectionId: string,
+    nameId: string,
+    nameIdFormat: string | null,
+    email: string | null,
+    projectUserId: string,
+  },
+): Promise<{ samlAccountId: string }> {
+  const samlAccount = await prisma.projectUserSamlAccount.create({
+    data: {
+      tenancyId: params.tenancyId,
+      samlConnectionId: params.samlConnectionId,
+      nameId: params.nameId,
+      nameIdFormat: params.nameIdFormat,
+      email: params.email,
+      projectUserId: params.projectUserId,
+    },
+  });
+
+  await prisma.authMethod.create({
+    data: {
+      tenancyId: params.tenancyId,
+      projectUserId: params.projectUserId,
+      samlAuthMethod: {
+        create: {
+          projectUserId: params.projectUserId,
+          samlConnectionId: params.samlConnectionId,
+          nameId: params.nameId,
+        },
+      },
+    },
+  });
+
+  return { samlAccountId: samlAccount.id };
+}
+
+/**
+ * Create a new user from a verified SAML identity. JIT provisioning — runs
+ * when no existing account or matching email is found. Mirrors
+ * createOAuthUserAndAccount.
+ */
+export async function createSamlUserAndAccount(
+  prisma: PrismaClientTransaction,
+  tenancy: Tenancy,
+  params: {
+    samlConnectionId: string,
+    nameId: string,
+    nameIdFormat: string | null,
+    email: string | null,
+    emailVerified: boolean,
+    primaryEmailAuthEnabled: boolean,
+    currentUser: UsersCrud["Admin"]["Read"] | null,
+    displayName: string | null,
+    profileImageUrl: string | null,
+    signUpRuleOptions: SignUpRuleOptions,
+  },
+): Promise<{ projectUserId: string, samlAccountId: string }> {
+  if (!tenancy.config.auth.allowSignUp) {
+    throw new KnownErrors.SignUpNotEnabled();
+  }
+
+  const newUser = await createOrUpgradeAnonymousUserWithRules(
+    tenancy,
+    params.currentUser,
+    {
+      display_name: params.displayName,
+      profile_image_url: params.profileImageUrl,
+      primary_email: params.email,
+      primary_email_verified: params.emailVerified,
+      primary_email_auth_enabled: params.primaryEmailAuthEnabled,
+    },
+    [],
+    params.signUpRuleOptions,
+  );
+
+  const authMethod = await prisma.authMethod.create({
+    data: {
+      tenancyId: tenancy.id,
+      projectUserId: newUser.id,
+    },
+  });
+
+  const samlAccount = await prisma.projectUserSamlAccount.create({
+    data: {
+      tenancyId: tenancy.id,
+      samlConnectionId: params.samlConnectionId,
+      nameId: params.nameId,
+      nameIdFormat: params.nameIdFormat,
+      email: params.email,
+      projectUserId: newUser.id,
+      samlAuthMethod: {
+        create: {
+          authMethodId: authMethod.id,
+        },
+      },
+      allowSignIn: true,
+    },
+  });
+
+  return { projectUserId: newUser.id, samlAccountId: samlAccount.id };
+}

--- a/apps/backend/src/lib/seed-dummy-data.ts
+++ b/apps/backend/src/lib/seed-dummy-data.ts
@@ -1940,6 +1940,74 @@ async function seedBulkSignupsAndActivity(options: {
 }
 
 /**
+ * Pre-creates two SAML connections (acme + globex) on the dummy project that
+ * point at the local mock SAML IdP. Gated on STACK_SEED_ENABLE_SAML='true'.
+ * Fetches the mock IdP's metadata at seed time so the seeded cert matches
+ * the cert the mock generated at startup — the mock currently regenerates
+ * keys per restart, so re-seed if you restart the mock.
+ */
+async function seedSamlConnections(projectId: string): Promise<void> {
+  // Default URL is derived from NEXT_PUBLIC_STACK_PORT_PREFIX so a non-default
+  // prefix (e.g. running multiple dev environments side by side) doesn't make
+  // the seed reach into a stale service from a different stack.
+  const portPrefix = getEnvVariable("NEXT_PUBLIC_STACK_PORT_PREFIX", "81");
+  const mockUrl = getEnvVariable("STACK_MOCK_SAML_URL", `http://localhost:${portPrefix}42`);
+  const tenants: Array<{ slug: string, displayName: string, domain: string }> = [
+    { slug: "acme", displayName: "Acme Corp SSO", domain: "acme.test" },
+    { slug: "globex", displayName: "Globex SAML", domain: "globex.test" },
+  ];
+
+  const fetched = await Promise.all(
+    tenants.map(async (t) => {
+      const metadataUrl = new URL(`/idp/${encodeURIComponent(t.slug)}/metadata`, mockUrl);
+      const res = await fetch(metadataUrl, { signal: AbortSignal.timeout(10_000) });
+      if (!res.ok) {
+        throw new Error(`Mock SAML IdP at ${metadataUrl.toString()} returned ${res.status} — is the mock running?`);
+      }
+      const xml = await res.text();
+      // Inline minimal metadata parse to avoid a circular import. Format is
+      // exactly what the mock emits, so a regex is enough; the production
+      // parser at apps/backend/src/saml/metadata-parser.tsx is the
+      // robust one used by the dashboard "paste metadata" form.
+      const entityIdMatch = xml.match(/entityID="([^"]+)"/);
+      const ssoUrlMatch = xml.match(/Binding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-Redirect"[^>]*Location="([^"]+)"/);
+      const certMatch = xml.match(/<X509Certificate>([\s\S]+?)<\/X509Certificate>/);
+      if (!entityIdMatch || !ssoUrlMatch || !certMatch) {
+        throw new Error(`Could not parse mock IdP metadata for tenant ${t.slug}`);
+      }
+      return {
+        ...t,
+        idpEntityId: entityIdMatch[1],
+        idpSsoUrl: ssoUrlMatch[1],
+        idpCertificate: certMatch[1].replace(/\s+/g, ""),
+      };
+    }),
+  );
+
+  // Set the entire connection entry as a single value, not as deep
+  // dot-keys — config normalization with onDotIntoNonObject="ignore"
+  // drops dot-keys that try to navigate into a record entry that
+  // doesn't yet exist (same convention as auth.oauth.providers).
+  const overlay: Parameters<typeof overrideEnvironmentConfigOverride>[0]["environmentConfigOverrideOverride"] = {};
+  for (const f of fetched) {
+    overlay[`auth.saml.connections.${f.slug}`] = {
+      displayName: f.displayName,
+      allowSignIn: true,
+      domain: f.domain,
+      idpEntityId: f.idpEntityId,
+      idpSsoUrl: f.idpSsoUrl,
+      idpCertificate: f.idpCertificate,
+    };
+  }
+
+  await overrideEnvironmentConfigOverride({
+    projectId,
+    branchId: DEFAULT_BRANCH_ID,
+    environmentConfigOverrideOverride: overlay,
+  });
+}
+
+/**
  * Creates a new project and fills it with dummy data (users, teams, payments, emails, analytics events).
  * Used by both the seed script and the preview project creation endpoint.
  */
@@ -2089,6 +2157,16 @@ export async function seedDummyProject(options: SeedDummyProjectOptions): Promis
       },
     }),
   ]);
+
+  // Run sequentially after the parallel block. Both this and the
+  // `payments.testMode` write above target the same environment config,
+  // and `overrideEnvironmentConfigOverride` is read-modify-write — running
+  // them in parallel races and one write clobbers the other (TODO at
+  // config.ts:491 already documents this). Sequencing avoids the race
+  // until the underlying override is wrapped in a serializable txn.
+  if (getEnvVariable("STACK_SEED_ENABLE_SAML", "false") === "true") {
+    await seedSamlConnections(projectId);
+  }
 
   await seedDummyTransactions({
     prisma: dummyPrisma,

--- a/apps/backend/src/saml/discovery.tsx
+++ b/apps/backend/src/saml/discovery.tsx
@@ -1,0 +1,29 @@
+import type { SamlConnectionConfig } from "@/saml/saml";
+
+/**
+ * Email-domain-based connection discovery for /auth/saml/discover and the
+ * client SDK's signInWithSso({ email }) flow.
+ *
+ * Iterates the project's configured SAML connections and returns the first
+ * whose `domain` exactly matches the email's domain (case-insensitive).
+ *
+ * The schema enforces uniqueness on (tenancyId, samlConnectionId, domain) so
+ * "exactly one match per domain per project" is a DB-level invariant; this
+ * function picks deterministically when scanning.
+ */
+export function discoverConnectionByEmail(
+  connections: Record<string, SamlConnectionConfig>,
+  email: string,
+): SamlConnectionConfig | null {
+  const at = email.lastIndexOf("@");
+  if (at < 0) return null;
+  const domain = email.slice(at + 1).toLowerCase();
+  if (!domain) return null;
+
+  for (const conn of Object.values(connections)) {
+    if (conn.domain && conn.domain.toLowerCase() === domain) {
+      return conn;
+    }
+  }
+  return null;
+}

--- a/apps/backend/src/saml/discovery.tsx
+++ b/apps/backend/src/saml/discovery.tsx
@@ -7,9 +7,11 @@ import type { SamlConnectionConfig } from "@/saml/saml";
  * Iterates the project's configured SAML connections and returns the first
  * whose `domain` exactly matches the email's domain (case-insensitive).
  *
- * The schema enforces uniqueness on (tenancyId, samlConnectionId, domain) so
- * "exactly one match per domain per project" is a DB-level invariant; this
- * function picks deterministically when scanning.
+ * Connections live as JSON under tenancy.config — there is no DB-level
+ * unique index on `domain`. The admin POST /saml-connections handler
+ * rejects duplicate-domain inserts so this scan is effectively
+ * deterministic per project; if a misconfiguration ever bypasses that
+ * guard, "first match wins" in Object.values() iteration order.
  */
 export function discoverConnectionByEmail(
   connections: Record<string, SamlConnectionConfig>,

--- a/apps/backend/src/saml/metadata-parser.tsx
+++ b/apps/backend/src/saml/metadata-parser.tsx
@@ -1,0 +1,70 @@
+/**
+ * Parse pasted IdP metadata XML into the fields we need to construct a
+ * SamlConnectionConfig. The dashboard "Add SAML connection" form lets a
+ * customer paste this XML so they don't have to copy each field manually.
+ */
+import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
+import { DOMParser } from "@xmldom/xmldom";
+import * as xpath from "xpath";
+
+export type ParsedIdpMetadata = {
+  entityId: string,
+  ssoUrl: string,
+  /** Bare base64 cert (no PEM headers). Caller wraps in headers if needed. */
+  signingCertificate: string,
+};
+
+const SELECT = xpath.useNamespaces({
+  md: "urn:oasis:names:tc:SAML:2.0:metadata",
+  ds: "http://www.w3.org/2000/09/xmldsig#",
+});
+
+export function parseIdpMetadataXml(xml: string): ParsedIdpMetadata {
+  let doc: Document;
+  try {
+    doc = new DOMParser().parseFromString(xml, "text/xml") as unknown as Document;
+  } catch (err: unknown) {
+    throw new StatusError(StatusError.BadRequest, `Could not parse IdP metadata XML: ${(err as Error).message}`);
+  }
+
+  const entityId = (SELECT("string(/md:EntityDescriptor/@entityID)", doc) as string).trim();
+  if (!entityId) {
+    throw new StatusError(StatusError.BadRequest, "IdP metadata has no /md:EntityDescriptor/@entityID");
+  }
+
+  // Prefer HTTP-Redirect binding (what we send AuthnRequests over), fall back
+  // to HTTP-POST. Most IdPs publish both.
+  const ssoUrl =
+    (SELECT(
+      "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']/@Location)",
+      doc,
+    ) as string).trim()
+    || (SELECT(
+      "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']/@Location)",
+      doc,
+    ) as string).trim();
+  if (!ssoUrl) {
+    throw new StatusError(StatusError.BadRequest, "IdP metadata has no SingleSignOnService with HTTP-Redirect or HTTP-POST binding");
+  }
+
+  // Prefer the signing-only KeyDescriptor; fall back to one without `use=`
+  // (which means it's valid for both signing and encryption per spec).
+  const signingCert =
+    (SELECT(
+      "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:KeyDescriptor[@use='signing']/ds:KeyInfo/ds:X509Data/ds:X509Certificate)",
+      doc,
+    ) as string).trim()
+    || (SELECT(
+      "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:KeyDescriptor[not(@use)]/ds:KeyInfo/ds:X509Data/ds:X509Certificate)",
+      doc,
+    ) as string).trim();
+  if (!signingCert) {
+    throw new StatusError(StatusError.BadRequest, "IdP metadata has no signing X509Certificate");
+  }
+
+  return {
+    entityId,
+    ssoUrl,
+    signingCertificate: signingCert.replace(/\s+/g, ""),
+  };
+}

--- a/apps/backend/src/saml/metadata-parser.tsx
+++ b/apps/backend/src/saml/metadata-parser.tsx
@@ -32,19 +32,24 @@ export function parseIdpMetadataXml(xml: string): ParsedIdpMetadata {
     throw new StatusError(StatusError.BadRequest, "IdP metadata has no /md:EntityDescriptor/@entityID");
   }
 
-  // Prefer HTTP-Redirect binding (what we send AuthnRequests over), fall back
-  // to HTTP-POST. Most IdPs publish both.
-  const ssoUrl =
-    (SELECT(
-      "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']/@Location)",
-      doc,
-    ) as string).trim()
-    || (SELECT(
+  // V1: we only emit AuthnRequests over HTTP-Redirect (node-saml's
+  // getAuthorizeUrlAsync produces a Redirect-style GET). Accepting POST-only
+  // metadata would store a POST endpoint that we'd later send a Redirect
+  // request to — likely rejected by the IdP. Reject up-front with a clear
+  // error; POST-binding emission can be added later if needed.
+  const ssoUrl = (SELECT(
+    "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-Redirect']/@Location)",
+    doc,
+  ) as string).trim();
+  if (!ssoUrl) {
+    const postUrl = (SELECT(
       "string(/md:EntityDescriptor/md:IDPSSODescriptor/md:SingleSignOnService[@Binding='urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST']/@Location)",
       doc,
     ) as string).trim();
-  if (!ssoUrl) {
-    throw new StatusError(StatusError.BadRequest, "IdP metadata has no SingleSignOnService with HTTP-Redirect or HTTP-POST binding");
+    if (postUrl) {
+      throw new StatusError(StatusError.BadRequest, "IdP metadata only advertises an HTTP-POST SingleSignOnService binding. Stack Auth's SAML SP currently requires HTTP-Redirect.");
+    }
+    throw new StatusError(StatusError.BadRequest, "IdP metadata has no SingleSignOnService with HTTP-Redirect binding");
   }
 
   // Prefer the signing-only KeyDescriptor; fall back to one without `use=`

--- a/apps/backend/src/saml/saml.tsx
+++ b/apps/backend/src/saml/saml.tsx
@@ -58,6 +58,11 @@ export function buildSamlClient(connection: SamlConnectionConfig, baseUrl: strin
     callbackUrl: spAcsUrl(baseUrl, connection.id),
     idpCert: pemToBareCert(connection.idpCertificate),
     audience: spEntityId(baseUrl, connection.id),
+    // Bind the assertion to the configured IdP entity so a Response signed
+    // by the same cert but issued under a different entity (e.g. another
+    // SSO app from the same vendor reusing a signing key) is rejected.
+    // node-saml compares this against the Response/Assertion <Issuer>.
+    idpIssuer: connection.idpEntityId,
     // V1: SP doesn't sign AuthnRequests and assertions aren't encrypted.
     // Per-connection toggles for both will land with signed/encrypted assertion support.
     //

--- a/apps/backend/src/saml/saml.tsx
+++ b/apps/backend/src/saml/saml.tsx
@@ -71,6 +71,22 @@ export function buildSamlClient(connection: SamlConnectionConfig, baseUrl: strin
 }
 
 /**
+ * Extract the InResponseTo attribute from a SAMLResponse without verifying
+ * the signature. Used by the ACS handler to look up the matching
+ * SamlOuterInfo (and thus recover the tenancy) BEFORE calling node-saml's
+ * full validation.
+ *
+ * Returns null if the attribute isn't present (which would be the case for
+ * IdP-initiated SSO — out of scope for V1, so the caller treats null as
+ * an error).
+ */
+export function extractInResponseTo(samlResponseB64: string): string | null {
+  const xml = Buffer.from(samlResponseB64, "base64").toString("utf-8");
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  return doc.documentElement.getAttribute("InResponseTo");
+}
+
+/**
  * Build the redirect URL the browser should follow to begin SAML SSO. Returns
  * both the URL and the AuthnRequest ID — the ID is stored in SamlOuterInfo
  * so the ACS handler can verify InResponseTo matches.

--- a/apps/backend/src/saml/saml.tsx
+++ b/apps/backend/src/saml/saml.tsx
@@ -170,13 +170,19 @@ export async function parseAndVerifyAssertion(
   const emailAttr = connection.attributeMapping?.email ?? "email";
   const displayNameAttr = connection.attributeMapping?.displayName ?? "displayName";
 
+  // Only fall back to NameID for email when its Format explicitly says it's
+  // an email address — many IdPs use persistent/opaque identifiers as NameID
+  // (e.g. `00u123...`), and ACS treats `assertion.email` as a verified email.
+  // Promoting an opaque subject identifier to verified email identity would
+  // let an IdP-side identifier collide with or override real user emails.
+  const nameIdIsEmail = profile.nameIDFormat === "urn:oasis:names:tc:SAML:1.1:nameid-format:emailAddress";
   return {
     nameId: profile.nameID,
     nameIdFormat: profile.nameIDFormat,
     // node-saml types inResponseTo as a loose object; coerce to string defensively.
     inResponseTo: profile.inResponseTo ? String(profile.inResponseTo) : null,
     attributes,
-    email: pickFirst(attributes[emailAttr]) ?? profile.nameID,
+    email: pickFirst(attributes[emailAttr]) ?? (nameIdIsEmail ? profile.nameID : null),
     displayName: pickFirst(attributes[displayNameAttr]) ?? null,
   };
 }

--- a/apps/backend/src/saml/saml.tsx
+++ b/apps/backend/src/saml/saml.tsx
@@ -60,8 +60,15 @@ export function buildSamlClient(connection: SamlConnectionConfig, baseUrl: strin
     audience: spEntityId(baseUrl, connection.id),
     // V1: SP doesn't sign AuthnRequests and assertions aren't encrypted.
     // Per-connection toggles for both will land with signed/encrypted assertion support.
-    wantAssertionsSigned: true,
-    wantAuthnResponseSigned: false,
+    //
+    // Per SAML 2.0 §4.1.4.2 we accept either a signed Response OR a signed
+    // Assertion (most IdPs sign one or the other). node-saml verifies
+    // whichever signatures are present; setting both wants to false would
+    // skip verification entirely. We require AT LEAST the Response to be
+    // signed because that's what the most common IdPs (Okta, Azure AD,
+    // samlify defaults) emit.
+    wantAssertionsSigned: false,
+    wantAuthnResponseSigned: true,
     signatureAlgorithm: "sha256",
     digestAlgorithm: "sha256",
     // Tolerate small clock skew between SP and IdP. SAML test #16 verifies

--- a/apps/backend/src/saml/saml.tsx
+++ b/apps/backend/src/saml/saml.tsx
@@ -1,0 +1,186 @@
+/**
+ * Backend SAML 2.0 protocol wrapper around @node-saml/node-saml.
+ *
+ * Tests must NOT import from this file — drive the mock IdP via HTTP and
+ * verify the backend's externally-observable behavior. Importing here would
+ * make the backend its own oracle (the tests would just confirm it agrees
+ * with itself), defeating the purpose of running an independent SAML
+ * implementation in apps/mock-saml-idp.
+ */
+import { SAML } from "@node-saml/node-saml";
+import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
+import { DOMParser } from "@xmldom/xmldom";
+
+/**
+ * SAML connection config — the JSON shape stored under
+ * tenancy.config.auth.saml.connections.[connectionId]. Defined here (rather
+ * than imported from stack-shared) so the protocol wrapper can be built and
+ * tested independently of the project-config schema.
+ */
+export type SamlConnectionConfig = {
+  id: string,
+  displayName: string,
+  idpEntityId: string,
+  idpSsoUrl: string,
+  /** PEM-encoded X.509 cert used to verify assertion signatures. */
+  idpCertificate: string,
+  /** Optional email domain for /auth/saml/discover lookups. */
+  domain?: string,
+  /** Optional attribute name mapping. Defaults: email → "email", displayName → "displayName". */
+  attributeMapping?: {
+    email?: string,
+    displayName?: string,
+  },
+};
+
+/** SAML SP URLs derived from baseUrl + connectionId. Stable per deployment. */
+export function spEntityId(baseUrl: string, connectionId: string): string {
+  return `${baseUrl}/api/v1/auth/saml/metadata/${connectionId}`;
+}
+
+export function spAcsUrl(baseUrl: string, connectionId: string): string {
+  return `${baseUrl}/api/v1/auth/saml/acs/${connectionId}`;
+}
+
+/** Strip PEM headers/whitespace — node-saml's idpCert wants the bare base64. */
+function pemToBareCert(pemOrBare: string): string {
+  return pemOrBare
+    .replace(/-----BEGIN CERTIFICATE-----/g, "")
+    .replace(/-----END CERTIFICATE-----/g, "")
+    .replace(/\s+/g, "");
+}
+
+/** Construct a node-saml client for a given connection. Cheap to call per-request. */
+export function buildSamlClient(connection: SamlConnectionConfig, baseUrl: string): SAML {
+  return new SAML({
+    entryPoint: connection.idpSsoUrl,
+    issuer: spEntityId(baseUrl, connection.id),
+    callbackUrl: spAcsUrl(baseUrl, connection.id),
+    idpCert: pemToBareCert(connection.idpCertificate),
+    audience: spEntityId(baseUrl, connection.id),
+    // V1: SP doesn't sign AuthnRequests and assertions aren't encrypted.
+    // Per-connection toggles for both will land with signed/encrypted assertion support.
+    wantAssertionsSigned: true,
+    wantAuthnResponseSigned: false,
+    signatureAlgorithm: "sha256",
+    digestAlgorithm: "sha256",
+    // Tolerate small clock skew between SP and IdP. SAML test #16 verifies
+    // this tolerance is honored.
+    acceptedClockSkewMs: 60 * 1000,
+  });
+}
+
+/**
+ * Build the redirect URL the browser should follow to begin SAML SSO. Returns
+ * both the URL and the AuthnRequest ID — the ID is stored in SamlOuterInfo
+ * so the ACS handler can verify InResponseTo matches.
+ */
+export async function buildAuthnRequestUrl(
+  client: SAML,
+  relayState: string,
+): Promise<{ url: string, requestId: string }> {
+  const url = await client.getAuthorizeUrlAsync(relayState, undefined, {});
+  const requestId = extractAuthnRequestId(url);
+  return { url, requestId };
+}
+
+/**
+ * Pull the AuthnRequest ID out of a built redirect URL by decoding the
+ * SAMLRequest query param (base64 + DEFLATE) and reading the ID attribute.
+ *
+ * node-saml doesn't expose the generated ID directly, so we parse it back
+ * out. This is a tiny, well-defined operation — uses xmldom rather than
+ * regex so it copes with attribute order variations.
+ */
+function extractAuthnRequestId(redirectUrl: string): string {
+  const params = new URL(redirectUrl).searchParams;
+  const samlRequestB64 = params.get("SAMLRequest");
+  if (!samlRequestB64) {
+    throw new StackAssertionError("buildAuthnRequestUrl: redirect URL is missing SAMLRequest", { redirectUrl });
+  }
+  const compressed = Buffer.from(samlRequestB64, "base64");
+  // Lazy import zlib — only loaded on the auth path, not at module load.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const xml = require("zlib").inflateRawSync(compressed).toString("utf-8") as string;
+  const doc = new DOMParser().parseFromString(xml, "text/xml");
+  const id = doc.documentElement.getAttribute("ID");
+  if (!id) {
+    throw new StackAssertionError("buildAuthnRequestUrl: AuthnRequest is missing ID attribute", { xml });
+  }
+  return id;
+}
+
+export type ParsedAssertion = {
+  nameId: string,
+  nameIdFormat: string | null,
+  inResponseTo: string | null,
+  attributes: Record<string, string | string[]>,
+  email: string | null,
+  displayName: string | null,
+};
+
+/**
+ * Verify the signature, audience, and timestamps on an incoming SAMLResponse,
+ * then extract the NameID and mapped attributes.
+ *
+ * node-saml validates the signature against connection.idpCertificate,
+ * checks audience matches our SP entity ID, validates NotBefore/NotOnOrAfter
+ * with our 60s clock skew, and ensures InResponseTo matches the SAMLRequest
+ * we issued (caller must verify the InResponseTo against SamlOuterInfo).
+ */
+export async function parseAndVerifyAssertion(
+  client: SAML,
+  connection: SamlConnectionConfig,
+  samlResponseB64: string,
+  relayState: string | undefined,
+): Promise<ParsedAssertion> {
+  const result = await client.validatePostResponseAsync({
+    SAMLResponse: samlResponseB64,
+    RelayState: relayState ?? "",
+  });
+  const profile = result.profile;
+  if (!profile) {
+    throw new StackAssertionError("validatePostResponseAsync returned no profile (was the user logged out?)");
+  }
+
+  const attributes = normalizeAttributes((profile.attributes ?? {}) as Record<string, unknown>);
+  const emailAttr = connection.attributeMapping?.email ?? "email";
+  const displayNameAttr = connection.attributeMapping?.displayName ?? "displayName";
+
+  return {
+    nameId: profile.nameID,
+    nameIdFormat: profile.nameIDFormat,
+    // node-saml types inResponseTo as a loose object; coerce to string defensively.
+    inResponseTo: profile.inResponseTo ? String(profile.inResponseTo) : null,
+    attributes,
+    email: pickFirst(attributes[emailAttr]) ?? profile.nameID,
+    displayName: pickFirst(attributes[displayNameAttr]) ?? null,
+  };
+}
+
+function normalizeAttributes(raw: Record<string, unknown>): Record<string, string | string[]> {
+  const out: Record<string, string | string[]> = {};
+  for (const [k, v] of Object.entries(raw)) {
+    if (Array.isArray(v)) {
+      out[k] = v.map(String);
+    } else if (v != null) {
+      out[k] = String(v);
+    }
+  }
+  return out;
+}
+
+function pickFirst(v: string | string[] | undefined): string | null {
+  if (Array.isArray(v)) return v[0] ?? null;
+  return v ?? null;
+}
+
+/**
+ * Generate the SP metadata XML that the customer's IdP admin will paste into
+ * their IdP. Includes our entity ID + ACS URL + (when SP signing is added
+ * later) the SP signing cert.
+ */
+export function getSpMetadataXml(connection: SamlConnectionConfig, baseUrl: string): string {
+  const client = buildSamlClient(connection, baseUrl);
+  return client.generateServiceProviderMetadata(null, null);
+}

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/config.test.ts
@@ -85,6 +85,7 @@ describe("basic config operations", () => {
           "otp": { "allowSignIn": false },
           "passkey": { "allowSignIn": false },
           "password": { "allowSignIn": true },
+          "saml": { "connections": {} },
           "signUpRules": {},
           "signUpRulesDefaultAction": "allow",
         },

--- a/apps/e2e/tests/js/config.test.ts
+++ b/apps/e2e/tests/js/config.test.ts
@@ -130,6 +130,7 @@ describe("getConfig", () => {
           "otp": { "allowSignIn": false },
           "passkey": { "allowSignIn": false },
           "password": { "allowSignIn": true },
+          "saml": { "connections": {} },
           "signUpRules": {},
           "signUpRulesDefaultAction": "allow",
         },
@@ -159,6 +160,7 @@ describe("updateConfig", () => {
         "otp": { "allowSignIn": false },
         "passkey": { "allowSignIn": false },
         "password": { "allowSignIn": true },
+        "saml": { "connections": {} },
         "signUpRules": {},
         "signUpRulesDefaultAction": "allow",
       }
@@ -179,6 +181,7 @@ describe("updateConfig", () => {
         "otp": { "allowSignIn": false },
         "passkey": { "allowSignIn": false },
         "password": { "allowSignIn": true },
+        "saml": { "connections": {} },
         "signUpRules": {},
         "signUpRulesDefaultAction": "allow",
       }

--- a/packages/stack-shared/src/config/schema-fuzzer.test.ts
+++ b/packages/stack-shared/src/config/schema-fuzzer.test.ts
@@ -51,6 +51,16 @@ const branchSchemaFuzzerConfig = [{
         }],
       }],
     }],
+    saml: [{
+      accountMergeStrategy: ["link_method", "raise_error", "allow_duplicates"],
+      connections: [{
+        "some-saml-connection-id": [{
+          displayName: ["Acme Corp SSO", "Globex SAML"],
+          allowSignIn: [true, false],
+          domain: ["acme.test", "globex.test"],
+        }],
+      }],
+    }],
     signUpRules: [{
       "some-rule-id": [{
         enabled: [true, false],
@@ -216,6 +226,16 @@ const environmentSchemaFuzzerConfig = [{
         facebookConfigId: ["some-facebook-config-id"],
         microsoftTenantId: ["some-microsoft-tenant-id"],
         appleBundles: [{ "some-bundle-id": [{ bundleId: ["com.example.app"] }] }],
+      }]]))] as const,
+    }],
+    saml: [{
+      ...branchSchemaFuzzerConfig[0].auth[0].saml[0],
+      connections: [typedFromEntries(typedEntries(branchSchemaFuzzerConfig[0].auth[0].saml[0].connections[0]).map(([key, value]) => [key, [{
+        ...value[0],
+        idpEntityId: ["https://idp.example.com/saml/metadata"],
+        idpSsoUrl: ["https://idp.example.com/saml/sso"],
+        idpCertificate: ["MIICertificatePlaceholderBase64="],
+        attributeMapping: [{ email: ["email"], displayName: ["displayName"] }],
       }]]))] as const,
     }],
   }],

--- a/packages/stack-shared/src/config/schema.ts
+++ b/packages/stack-shared/src/config/schema.ts
@@ -133,6 +133,24 @@ const branchAuthSchema = yupObject({
       }),
     ),
   }),
+  saml: yupObject({
+    // Mirrors auth.oauth.accountMergeStrategy. Falls back to the OAuth strategy
+    // when unset (see saml-account.tsx#handleSamlEmailMergeStrategy), so existing
+    // projects keep consistent merge behavior across protocols.
+    accountMergeStrategy: yupString().oneOf(['link_method', 'raise_error', 'allow_duplicates']).optional(),
+    // Connections — non-sensitive fields here, IdP cert + URLs added at the
+    // environment-config level below, mirroring how oauth.providers splits.
+    connections: yupRecord(
+      userSpecifiedIdSchema("samlConnectionId"),
+      yupObject({
+        displayName: yupString(),
+        allowSignIn: yupBoolean(),
+        // Email domain used by /auth/saml/discover for the signInWithSso flow.
+        // Optional — connections without a domain are addressable by ID only.
+        domain: yupString().optional(),
+      }),
+    ),
+  }),
   signUpRules: yupRecord(
     userSpecifiedIdSchema("signUpRuleId"),
     yupObject({
@@ -307,6 +325,27 @@ export const environmentConfigSchema = branchConfigSchema.concat(yupObject({
           ).optional(),
           allowSignIn: yupBoolean().optional(),
           allowConnectedAccounts: yupBoolean().optional(),
+        }),
+      ),
+    })),
+    saml: branchConfigSchema.getNested("auth").getNested("saml").concat(yupObject({
+      connections: yupRecord(
+        userSpecifiedIdSchema("samlConnectionId"),
+        yupObject({
+          displayName: yupString().optional(),
+          allowSignIn: yupBoolean().optional(),
+          domain: yupString().optional(),
+          // IdP-side fields. The IdP X.509 cert is technically a public key,
+          // but it's environment-specific (different per IdP deployment) so it
+          // belongs here, not at the branch level.
+          idpEntityId: yupString().optional(),
+          idpSsoUrl: yupString().optional(),
+          idpCertificate: yupString().optional(),
+          // Attribute mapping — defaults to email -> "email", displayName -> "displayName".
+          attributeMapping: yupObject({
+            email: yupString().optional(),
+            displayName: yupString().optional(),
+          }).optional(),
         }),
       ),
     })),
@@ -625,6 +664,18 @@ const organizationConfigDefaults = {
         facebookConfigId: undefined,
         microsoftTenantId: undefined,
         appleBundles: undefined,
+      }),
+    },
+    saml: {
+      accountMergeStrategy: undefined,
+      connections: (key: string) => ({
+        displayName: 'Unnamed SAML connection',
+        allowSignIn: true,
+        domain: undefined,
+        idpEntityId: undefined,
+        idpSsoUrl: undefined,
+        idpCertificate: undefined,
+        attributeMapping: undefined,
       }),
     },
     signUpRules: (key: string) => ({

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -216,6 +216,9 @@ importers:
       '@vercel/sandbox':
         specifier: ^1.2.0
         version: 1.2.0
+      '@xmldom/xmldom':
+        specifier: ^0.8.10
+        version: 0.8.13
       ai:
         specifier: ^6.0.0
         version: 6.0.81(zod@3.25.76)
@@ -300,6 +303,9 @@ importers:
       vite:
         specifier: ^6.1.0
         version: 6.1.0(@types/node@20.17.6)(jiti@2.6.1)(lightningcss@1.30.1)(terser@5.44.0)(tsx@4.15.5)(yaml@2.4.5)
+      xpath:
+        specifier: ^0.0.34
+        version: 0.0.34
       yaml:
         specifier: ^2.4.5
         version: 2.4.5


### PR DESCRIPTION
Second of 3 stacked PRs adding SAML 2.0 SSO. **Stacked on:** #1395 (mock IdP). **Stacked above:** #1397 (client + tests).

> Note: target branch is \`pr/saml-mock-idp\`. Will be retargeted to \`dev\` once #1395 merges.

## What this PR adds

The backend half of SAML SSO. Purely server-side — client SDK methods, dashboard page, demo page, and e2e tests live in the next PR (which depends on this one).

### Database

- **3 new Prisma models** in \`apps/backend/prisma/schema.prisma\` + migration \`20260429000000_add_saml_sso_models\`:
  - **\`ProjectUserSamlAccount\`** — per-user SAML account, mirrors \`ProjectUserOAuthAccount\`. Unique \`(tenancyId, samlConnectionId, nameId)\` enforces multi-tenant connection isolation at the DB level — the same NameID arriving via a different connection is treated as a separate identity.
  - **\`SamlAuthMethod\`** — connects an \`AuthMethod\` to a \`ProjectUserSamlAccount\`.
  - **\`SamlOuterInfo\`** — in-flight AuthnRequest state, keyed by AuthnRequest ID (TEXT, since SAML xs:IDs aren't UUIDs).

### Connection config storage

Per-connection config (entity ID, IdP cert, ACS URL, attribute mapping, domain) is stored as **JSON in \`tenancy.config.auth.saml.connections\`** — same pattern as \`auth.oauth.providers\`. No dedicated SamlConnection Prisma model. Connection-isolation invariant lives at the per-user table level.

### Schema

- \`packages/stack-shared/src/config/schema.ts\` — adds \`auth.saml.{accountMergeStrategy, connections}\` at branch level (non-sensitive fields) + extends connections at environment level with IdP-side fields (entity ID, SSO URL, X.509 cert, attribute mapping). Defaults block adds a SAML record with a per-key default function. Fuzzer test config updated.

### Helpers

- **\`apps/backend/src/lib/external-auth.tsx\`** — extracts the email-merge strategy switch out of \`oauth.tsx\` into a shared helper so both protocols use the same contact-channel lookup and link_method/raise_error/allow_duplicates logic.
- **\`apps/backend/src/lib/saml-account.tsx\`** — SAML-side parallel of OAuth's findExisting/link/create user-linking helpers, scoped by \`(tenancyId, samlConnectionId, nameId)\`.

### Protocol wrapper

- **\`apps/backend/src/saml/saml.tsx\`** — wraps \`@node-saml/node-saml\`. \`buildSamlClient\`, \`buildAuthnRequestUrl\` (returns URL + extracted requestId for replay protection), \`parseAndVerifyAssertion\` (signature + audience + clock skew + InResponseTo), \`getSpMetadataXml\`. Defines \`SamlConnectionConfig\` locally.
- **\`apps/backend/src/saml/metadata-parser.tsx\`** — pulls entity ID, SSO URL, and signing X.509 out of pasted IdP metadata XML using xmldom + xpath.
- **\`apps/backend/src/saml/discovery.tsx\`** — email-domain → connection lookup for the upcoming \`signInWithSso({ email })\` SDK flow.

### Routes

Under \`apps/backend/src/app/api/latest/auth/saml/\`:

- **\`GET /auth/saml/login/[connection_id]\`** — receives the same OAuth client params as \`/auth/oauth/authorize\`, builds an AuthnRequest, persists OAuth context + AuthnRequest ID in \`SamlOuterInfo\`, sets a CSRF cookie, redirects to the IdP. Honors \`stack_response_mode=json\`.
- **\`POST /auth/saml/acs/[connection_id]\`** — receives the IdP's POST. Parses InResponseTo, looks up \`SamlOuterInfo\` to recover tenancy, validates CSRF cookie, runs node-saml's full \`validatePostResponseAsync\` (signature + audience + clock skew + InResponseTo). Defense-in-depth re-checks InResponseTo and **cross-connection mismatch** (an assertion sent to the wrong ACS endpoint is rejected — see e2e test #10 in the next PR).
- **\`GET /auth/saml/metadata/[connection_id]\`** — public-fetchable SP metadata XML for the customer's IdP admin to paste.
- **\`GET /auth/saml/discover\`** — email-domain → connection lookup.

ACS hands off to \`oauthServer.authorize()\` so Stack Auth issues a customer-facing OAuth code (Stack Auth itself acts as an OAuth2 provider to the customer's SDK — same pattern as the existing OAuth callback handler at \`oauth/callback/[provider_id]\`).

### Admin CRUD

- \`POST/GET/DELETE /api/v1/saml-connections\` + \`GET /api/v1/saml-connections/[id]\` — admin-only thin REST wrappers around the JSON-config storage.

## Out-of-scope (planned follow-ups)

- IdP-initiated SSO
- Signed AuthnRequests, encrypted assertions
- Single Logout (SLO)
- SCIM 2.0 user provisioning
- Group/role attribute mapping → team membership sync
- Automatic IdP metadata refresh from a URL

## Test plan

- [x] \`pnpm --filter @stackframe/backend typecheck\` passes
- [x] \`pnpm --filter @stackframe/backend lint\` passes
- [x] \`pnpm --filter @stackframe/stack-shared typecheck\` passes
- [x] Migration applies cleanly (\`prisma migrate dev\`)
- [x] Codegen succeeds (\`pnpm --filter @stackframe/backend codegen-prisma\`)
- [ ] Routes exercised end-to-end via the e2e suite in the next PR (round-trip test against mock IdP, plus failure matrix for bad-signature / expired / wrong-audience / replay / cross-connection forgery)