### PR TITLE
feat: SAML SSO client SDK, dashboard, demo, and e2e tests

### DIFF
--- a/.github/workflows/e2e-api-tests-local-emulator.yaml
+++ b/.github/workflows/e2e-api-tests-local-emulator.yaml
@@ -145,7 +145,7 @@ jobs:
         with:
           run: pnpm run start:mock-saml-idp --log-order=stream &
           wait-on: |
-            http://localhost:8115/idp
+            http://localhost:8142/idp
           tail: true
           wait-for: 30s
           log-output-if: true

--- a/.github/workflows/e2e-api-tests-local-emulator.yaml
+++ b/.github/workflows/e2e-api-tests-local-emulator.yaml
@@ -140,6 +140,16 @@ jobs:
           wait-for: 30s
           log-output-if: true
 
+      - name: Start mock-saml-idp in background
+        uses: JarvusInnovations/background-action@v1.0.7
+        with:
+          run: pnpm run start:mock-saml-idp --log-order=stream &
+          wait-on: |
+            http://localhost:8115/idp
+          tail: true
+          wait-for: 30s
+          log-output-if: true
+
       - name: Start run-email-queue in background
         uses: JarvusInnovations/background-action@v1.0.7
         with:

--- a/.github/workflows/e2e-custom-base-port-api-tests.yaml
+++ b/.github/workflows/e2e-custom-base-port-api-tests.yaml
@@ -136,6 +136,15 @@ jobs:
           tail: true
           wait-for: 30s
           log-output-if: true
+      - name: Start mock-saml-idp in background
+        uses: JarvusInnovations/background-action@v1.0.7
+        with:
+          run: pnpm run start:mock-saml-idp --log-order=stream &
+          wait-on: |
+            http://localhost:6715/idp
+          tail: true
+          wait-for: 30s
+          log-output-if: true
       - name: Start run-email-queue in background
         uses: JarvusInnovations/background-action@v1.0.7
         with:

--- a/.github/workflows/e2e-custom-base-port-api-tests.yaml
+++ b/.github/workflows/e2e-custom-base-port-api-tests.yaml
@@ -141,7 +141,7 @@ jobs:
         with:
           run: pnpm run start:mock-saml-idp --log-order=stream &
           wait-on: |
-            http://localhost:6715/idp
+            http://localhost:6742/idp
           tail: true
           wait-for: 30s
           log-output-if: true

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -89,7 +89,7 @@ export const POST = createSmartRouteHandler({
     body: yupMixed().defined(),
     headers: yupMixed().defined(),
   }),
-  async handler({ params, body }) {
+  async handler({ params, body }, fullReq) {
     const samlResponseB64 = (body as Record<string, unknown>).SAMLResponse as string | undefined;
     if (!samlResponseB64) {
       throw new StatusError(StatusError.BadRequest, "Missing SAMLResponse in form body");
@@ -157,7 +157,12 @@ export const POST = createSmartRouteHandler({
     }
 
     try {
-      const baseUrl = new URL(outerInfo.redirectUri).origin;
+      // Must match the SP base URL the login route advertised in the
+      // AuthnRequest — i.e. the backend's own origin, not the customer's
+      // redirect_uri origin. node-saml verifies the assertion's audience
+      // against `spEntityId(baseUrl, connectionId)`.
+      const reqUrl = new URL(fullReq.url);
+      const baseUrl = `${reqUrl.protocol}//${reqUrl.host}`;
       const client = buildSamlClient(connection, baseUrl);
       const assertion = await parseAndVerifyAssertion(client, connection, samlResponseB64, undefined);
 

--- a/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/acs/[connection_id]/route.tsx
@@ -130,6 +130,10 @@ export const POST = createSmartRouteHandler({
     }
     const prisma = await getPrismaClientForTenancy(tenancy);
 
+    if (!tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
+
     if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }

--- a/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/discover/route.tsx
@@ -3,6 +3,7 @@ import type { SamlConnectionConfig } from "@/saml/saml";
 import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
 import { typedEntries } from "@stackframe/stack-shared/dist/utils/objects";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { emailSchema, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 
@@ -39,6 +40,9 @@ export const GET = createSmartRouteHandler({
     const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
+    }
+    if (!tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
     }
     // Inject `id` into each connection so it satisfies SamlConnectionConfig —
     // the config schema stores id as the record key, not a value field.

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -100,6 +100,10 @@ export const GET = createSmartRouteHandler({
       throwCheckApiKeySetError(keyCheck.error, tenancy.project.id, new KnownErrors.InvalidPublishableClientKey(tenancy.project.id));
     }
 
+    if (!tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
+
     if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }

--- a/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/login/[connection_id]/route.tsx
@@ -89,7 +89,7 @@ export const GET = createSmartRouteHandler({
       body: yupString().defined(),
     }).defined(),
   ) as unknown as Schema<SmartResponse>,
-  async handler({ params, query }) {
+  async handler({ params, query }, fullReq) {
     const tenancy = await getSoleTenancyFromProjectBranch(...getProjectBranchFromClientId(query.client_id), true);
     if (!tenancy) {
       throw new KnownErrors.InvalidOAuthClientIdOrSecret(query.client_id);
@@ -133,7 +133,12 @@ export const GET = createSmartRouteHandler({
       attributeMapping: connectionRaw.attributeMapping,
     };
 
-    const baseUrl = new URL(query.redirect_uri).origin;
+    // SP base URL must be the backend's own origin — that's where the ACS
+    // route lives. Using the customer's redirect_uri origin would cause the
+    // IdP to POST the assertion to the customer app (404). Same source as
+    // the metadata route uses, keeping login + metadata consistent.
+    const reqUrl = new URL(fullReq.url);
+    const baseUrl = `${reqUrl.protocol}//${reqUrl.host}`;
     const client = buildSamlClient(connection, baseUrl);
     const { url: samlUrl, requestId } = await buildAuthnRequestUrl(client, query.state);
 

--- a/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/saml/metadata/[connection_id]/route.tsx
@@ -1,6 +1,7 @@
 import { getSoleTenancyFromProjectBranch, DEFAULT_BRANCH_ID } from "@/lib/tenancies";
 import { getSpMetadataXml } from "@/saml/saml";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 
@@ -36,6 +37,9 @@ export const GET = createSmartRouteHandler({
     const tenancy = await getSoleTenancyFromProjectBranch(query.project_id, DEFAULT_BRANCH_ID, true);
     if (!tenancy) {
       throw new StatusError(StatusError.NotFound, `Project ${query.project_id} not found`);
+    }
+    if (!tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
     }
     if (!(params.connection_id in tenancy.config.auth.saml.connections)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found in project ${query.project_id}`);

--- a/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/[connection_id]/route.tsx
@@ -5,6 +5,7 @@
  */
 import { adaptSchema, adminAuthTypeSchema, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 
 export const GET = createSmartRouteHandler({
@@ -40,6 +41,9 @@ export const GET = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ auth, params }) {
+    if (!auth.tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
     if (!(params.connection_id in auth.tenancy.config.auth.saml.connections)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${params.connection_id} not found`);
     }

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -12,6 +12,7 @@
  */
 import { overrideEnvironmentConfigOverride, resetEnvironmentConfigOverrideKeys } from "@/lib/config";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { KnownErrors } from "@stackframe/stack-shared/dist/known-errors";
 import { adaptSchema, adminAuthTypeSchema, yupArray, yupBoolean, yupNumber, yupObject, yupString } from "@stackframe/stack-shared/dist/schema-fields";
 import { StatusError } from "@stackframe/stack-shared/dist/utils/errors";
 
@@ -47,6 +48,9 @@ export const GET = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ auth }) {
+    if (!auth.tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
     const connections = auth.tenancy.config.auth.saml.connections;
     type Conn = (typeof auth.tenancy.config.auth.saml.connections)[string];
     return {
@@ -98,6 +102,9 @@ export const POST = createSmartRouteHandler({
     body: samlConnectionResponseShape,
   }),
   async handler({ auth, body }) {
+    if (!auth.tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
     const overlay: Record<string, unknown> = {
       [`auth.saml.connections.${body.id}.displayName`]: body.display_name,
       [`auth.saml.connections.${body.id}.allowSignIn`]: body.allow_sign_in,
@@ -160,6 +167,9 @@ export const DELETE = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ auth, body }) {
+    if (!auth.tenancy.config.apps.installed["saml-sso"]?.enabled) {
+      throw new KnownErrors.SamlSsoNotEnabled();
+    }
     if (!(body.id in auth.tenancy.config.auth.saml.connections)) {
       throw new StatusError(StatusError.NotFound, `SAML connection ${body.id} not found`);
     }

--- a/apps/backend/src/app/api/latest/saml-connections/route.tsx
+++ b/apps/backend/src/app/api/latest/saml-connections/route.tsx
@@ -105,22 +105,31 @@ export const POST = createSmartRouteHandler({
     if (!auth.tenancy.config.apps.installed["saml-sso"]?.enabled) {
       throw new KnownErrors.SamlSsoNotEnabled();
     }
-    const overlay: Record<string, unknown> = {
-      [`auth.saml.connections.${body.id}.displayName`]: body.display_name,
-      [`auth.saml.connections.${body.id}.allowSignIn`]: body.allow_sign_in,
-      [`auth.saml.connections.${body.id}.idpEntityId`]: body.idp_entity_id,
-      [`auth.saml.connections.${body.id}.idpSsoUrl`]: body.idp_sso_url,
-      [`auth.saml.connections.${body.id}.idpCertificate`]: body.idp_certificate,
+    // Write the whole connection entry as a single value. Per-field deep
+    // dot-keys (e.g. `auth.saml.connections.X.displayName`) get dropped
+    // during config normalization with onDotIntoNonObject="ignore" when
+    // the parent record entry doesn't yet exist — same convention as
+    // auth.oauth.providers (see auth-methods/page-client.tsx) and the
+    // dashboard SSO page-client (see commit 5fa9629de).
+    const connectionEntry: Record<string, unknown> = {
+      displayName: body.display_name,
+      allowSignIn: body.allow_sign_in,
+      idpEntityId: body.idp_entity_id,
+      idpSsoUrl: body.idp_sso_url,
+      idpCertificate: body.idp_certificate,
     };
     if (body.domain !== undefined) {
-      overlay[`auth.saml.connections.${body.id}.domain`] = body.domain;
+      connectionEntry.domain = body.domain;
     }
     if (body.attribute_mapping) {
-      overlay[`auth.saml.connections.${body.id}.attributeMapping`] = {
+      connectionEntry.attributeMapping = {
         email: body.attribute_mapping.email,
         displayName: body.attribute_mapping.display_name,
       };
     }
+    const overlay = {
+      [`auth.saml.connections.${body.id}`]: connectionEntry,
+    };
 
     await overrideEnvironmentConfigOverride({
       projectId: auth.tenancy.project.id,

--- a/apps/backend/src/lib/seed-dummy-data.ts
+++ b/apps/backend/src/lib/seed-dummy-data.ts
@@ -1983,7 +1983,12 @@ async function seedSamlConnections(projectId: string): Promise<void> {
   // dot-keys — config normalization with onDotIntoNonObject="ignore"
   // drops dot-keys that try to navigate into a record entry that
   // doesn't yet exist (same convention as auth.oauth.providers).
-  const overlay: Record<string, unknown> = {};
+  const overlay: Record<string, unknown> = {
+    // SAML SSO is an alpha-stage app and isn't installed by default —
+    // enable it on the dummy project so the seeded connections are usable
+    // without an extra dashboard click.
+    "apps.installed.saml-sso": { enabled: true },
+  };
   for (const f of fetched) {
     overlay[`auth.saml.connections.${f.slug}`] = {
       displayName: f.displayName,

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
@@ -1,0 +1,201 @@
+"use client";
+
+import { SmartFormDialog } from "@/components/form-dialog";
+import { ActionDialog, Alert, Button, Card, CardContent, CardHeader, Typography } from "@/components/ui";
+import { useUpdateConfig } from "@/lib/config-update";
+import React, { useState } from "react";
+import * as yup from "yup";
+import { PageLayout } from "../page-layout";
+import { useAdminApp } from "../use-admin-app";
+
+/**
+ * Dashboard for managing SAML SSO connections on the current project.
+ *
+ * Connection config is stored at tenancy.config.auth.saml.connections —
+ * the same JSON-config the seed script and admin /saml-connections
+ * endpoints write. This page reads via project.useConfig() and writes
+ * via useUpdateConfig() with key paths.
+ *
+ * V1 scope: single-page list with create + delete dialogs. The
+ * paste-IdP-metadata helper that auto-fills idpEntityId/idpSsoUrl/
+ * idpCertificate from a single XML blob is a planned follow-up — for
+ * now connection fields are entered manually.
+ */
+export default function PageClient() {
+  const stackAdminApp = useAdminApp();
+  const project = stackAdminApp.useProject();
+  const config = project.useConfig();
+  const connections = config.auth.saml.connections;
+
+  const [createOpen, setCreateOpen] = useState(false);
+  const [deleteId, setDeleteId] = useState<string | null>(null);
+
+  const connectionEntries = Object.entries(connections);
+
+  return (
+    <PageLayout
+      title="SAML SSO"
+      description="Manage SAML 2.0 connections so corporate IdP users can sign in to your project."
+      actions={<Button onClick={() => setCreateOpen(true)}>Add SAML connection</Button>}
+    >
+      {connectionEntries.length === 0 && (
+        <Alert>
+          No SAML connections configured yet. Click <strong>Add SAML connection</strong> to wire
+          up your first IdP.
+        </Alert>
+      )}
+
+      <div className="grid gap-4">
+        {connectionEntries.map(([id, conn]) => (
+          <Card key={id}>
+            <CardHeader>
+              <div className="flex items-center justify-between">
+                <div>
+                  <Typography type="h4">{conn.displayName}</Typography>
+                  <Typography type="p" variant="secondary" className="text-sm">
+                    Connection ID: <code>{id}</code>
+                    {conn.domain && (
+                      <>
+                        {" "}· Email domain: <code>{conn.domain}</code>
+                      </>
+                    )}
+                  </Typography>
+                </div>
+                <div className="flex gap-2">
+                  <Button variant="destructive" size="sm" onClick={() => setDeleteId(id)}>
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            </CardHeader>
+            <CardContent>
+              <div className="grid gap-2 text-sm">
+                <DetailRow label="IdP Entity ID" value={conn.idpEntityId} />
+                <DetailRow label="IdP SSO URL" value={conn.idpSsoUrl} />
+                <DetailRow
+                  label="IdP signing cert"
+                  value={conn.idpCertificate ? `<${conn.idpCertificate.length}-char certificate>` : null}
+                />
+                <DetailRow label="Sign-in enabled" value={conn.allowSignIn ? "yes" : "no"} />
+              </div>
+              <div className="mt-3 grid gap-1 text-sm border-t pt-3">
+                <Typography type="p" variant="secondary" className="text-xs">
+                  Paste these into your IdP&apos;s admin console:
+                </Typography>
+                <DetailRow
+                  label="SP metadata URL"
+                  value={`/api/v1/auth/saml/metadata/${id}?project_id=${project.id}`}
+                  mono
+                />
+                <DetailRow
+                  label="ACS URL"
+                  value={`/api/v1/auth/saml/acs/${id}`}
+                  mono
+                />
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+
+      <CreateDialog open={createOpen} onOpenChange={setCreateOpen} />
+      <DeleteDialog
+        connectionId={deleteId}
+        onClose={() => setDeleteId(null)}
+        displayName={deleteId ? connections[deleteId].displayName : null}
+      />
+    </PageLayout>
+  );
+}
+
+function DetailRow({ label, value, mono }: { label: string, value: string | null | undefined, mono?: boolean }) {
+  return (
+    <div className="flex gap-2">
+      <span className="font-medium min-w-[140px]">{label}:</span>
+      <span className={mono ? "font-mono break-all" : "break-all"}>
+        {value ? value : <em className="text-gray-500">not set</em>}
+      </span>
+    </div>
+  );
+}
+
+function CreateDialog({ open, onOpenChange }: { open: boolean, onOpenChange: (open: boolean) => void }) {
+  const stackAdminApp = useAdminApp();
+  const updateConfig = useUpdateConfig();
+
+  const formSchema = yup.object({
+    id: yup.string()
+      .matches(/^[a-z0-9_-]+$/, "ID can only contain lowercase letters, digits, underscores, and dashes")
+      .nonEmpty().label("Connection ID"),
+    displayName: yup.string().nonEmpty().label("Display name"),
+    domain: yup.string().optional().label("Email domain (for discovery)"),
+    idpEntityId: yup.string().nonEmpty().label("IdP Entity ID"),
+    idpSsoUrl: yup.string().url().nonEmpty().label("IdP SSO URL"),
+    idpCertificate: yup.string().nonEmpty().label("IdP signing certificate (X.509, base64)"),
+    allowSignIn: yup.boolean().default(true).label("Enable sign-in"),
+  });
+
+  return (
+    <SmartFormDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      title="Add a SAML connection"
+      formSchema={formSchema}
+      okButton={{ label: "Create" }}
+      cancelButton
+      onSubmit={async (values) => {
+        const overlay: Record<string, unknown> = {
+          [`auth.saml.connections.${values.id}.displayName`]: values.displayName,
+          [`auth.saml.connections.${values.id}.allowSignIn`]: values.allowSignIn,
+          [`auth.saml.connections.${values.id}.idpEntityId`]: values.idpEntityId,
+          [`auth.saml.connections.${values.id}.idpSsoUrl`]: values.idpSsoUrl,
+          [`auth.saml.connections.${values.id}.idpCertificate`]: (values.idpCertificate ?? "").replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ""),
+        };
+        if (values.domain) {
+          overlay[`auth.saml.connections.${values.id}.domain`] = values.domain;
+        }
+        await updateConfig({
+          adminApp: stackAdminApp,
+          configUpdate: overlay as Parameters<typeof updateConfig>[0]["configUpdate"],
+          pushable: true,
+        });
+      }}
+    />
+  );
+}
+
+function DeleteDialog({ connectionId, displayName, onClose }: {
+  connectionId: string | null,
+  displayName: string | null,
+  onClose: () => void,
+}) {
+  const stackAdminApp = useAdminApp();
+  const updateConfig = useUpdateConfig();
+
+  return (
+    <ActionDialog
+      open={connectionId != null}
+      onOpenChange={(open) => { if (!open) onClose(); }}
+      title="Delete SAML connection?"
+      danger
+      okButton={{
+        label: "Delete connection",
+        onClick: async () => {
+          if (!connectionId) return;
+          await updateConfig({
+            adminApp: stackAdminApp,
+            configUpdate: { [`auth.saml.connections.${connectionId}`]: null } as Parameters<typeof updateConfig>[0]["configUpdate"],
+            pushable: true,
+          });
+          onClose();
+        },
+      }}
+      cancelButton
+    >
+      <Typography>
+        Delete <strong>{displayName ?? "this connection"}</strong>? Existing user accounts linked
+        via this connection will remain in the database but will no longer be able to sign in.
+      </Typography>
+    </ActionDialog>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
@@ -130,7 +130,9 @@ function CreateDialog({ open, onOpenChange }: { open: boolean, onOpenChange: (op
     displayName: yup.string().nonEmpty().label("Display name"),
     domain: yup.string().optional().label("Email domain (for discovery)"),
     idpEntityId: yup.string().nonEmpty().label("IdP Entity ID"),
-    idpSsoUrl: yup.string().url().nonEmpty().label("IdP SSO URL"),
+    // Skip yup's url() — it rejects http://localhost which breaks dev/test setups.
+    // The backend SAML wrapper validates the URL on use.
+    idpSsoUrl: yup.string().nonEmpty().label("IdP SSO URL"),
     idpCertificate: yup.string().nonEmpty().label("IdP signing certificate (X.509, base64)"),
     allowSignIn: yup.boolean().default(true).label("Enable sign-in"),
   });
@@ -161,7 +163,9 @@ function CreateDialog({ open, onOpenChange }: { open: boolean, onOpenChange: (op
               idpCertificate: (values.idpCertificate ?? "").replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ""),
             },
           } as Parameters<typeof updateConfig>[0]["configUpdate"],
-          pushable: true,
+          // SAML connection fields (cert, IdP URLs) are environment-level
+          // (not pushable) — same as OAuth client secrets.
+          pushable: false,
         });
       }}
     />
@@ -189,7 +193,9 @@ function DeleteDialog({ connectionId, displayName, onClose }: {
           await updateConfig({
             adminApp: stackAdminApp,
             configUpdate: { [`auth.saml.connections.${connectionId}`]: null } as Parameters<typeof updateConfig>[0]["configUpdate"],
-            pushable: true,
+            // SAML connection fields (cert, IdP URLs) are environment-level
+          // (not pushable) — same as OAuth client secrets.
+          pushable: false,
           });
           onClose();
         },

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
@@ -3,11 +3,17 @@
 import { SmartFormDialog } from "@/components/form-dialog";
 import { ActionDialog, Alert, Button, Card, CardContent, CardHeader, Typography } from "@/components/ui";
 import { useUpdateConfig } from "@/lib/config-update";
+import { getPublicEnvVar } from "@/lib/env";
 import React, { useState } from "react";
 import * as yup from "yup";
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
+
+function getBrowserApiBase(): string {
+  const url = getPublicEnvVar("NEXT_PUBLIC_BROWSER_STACK_API_URL") ?? getPublicEnvVar("NEXT_PUBLIC_STACK_API_URL") ?? "";
+  return url.replace(/\/+$/, "");
+}
 
 /**
  * Dashboard for managing SAML SSO connections on the current project.
@@ -40,6 +46,7 @@ function PageContent() {
   const [deleteId, setDeleteId] = useState<string | null>(null);
 
   const connectionEntries = Object.entries(connections);
+  const apiBase = getBrowserApiBase();
 
   return (
     <PageLayout
@@ -93,12 +100,12 @@ function PageContent() {
                 </Typography>
                 <DetailRow
                   label="SP metadata URL"
-                  value={`/api/v1/auth/saml/metadata/${id}?project_id=${project.id}`}
+                  value={`${apiBase}/api/v1/auth/saml/metadata/${id}?project_id=${project.id}`}
                   mono
                 />
                 <DetailRow
                   label="ACS URL"
-                  value={`/api/v1/auth/saml/acs/${id}`}
+                  value={`${apiBase}/api/v1/auth/saml/acs/${id}`}
                   mono
                 />
               </div>
@@ -111,7 +118,9 @@ function PageContent() {
       <DeleteDialog
         connectionId={deleteId}
         onClose={() => setDeleteId(null)}
-        displayName={deleteId ? connections[deleteId].displayName : null}
+        // Guard against stale deleteId after a config refresh removed the
+        // entry — index types claim non-undefined but the key may be gone.
+        displayName={deleteId && Object.hasOwn(connections, deleteId) ? connections[deleteId].displayName : null}
       />
     </PageLayout>
   );
@@ -160,13 +169,17 @@ function CreateDialog({ open, onOpenChange }: { open: boolean, onOpenChange: (op
         // config normalization when the parent record entry doesn't yet
         // exist — same convention as auth.oauth.providers in the
         // auth-methods page.
+        // Normalize domain on write — discovery does case-insensitive
+        // matching but does not trim, so trailing whitespace from a
+        // pasted value would silently break lookups.
+        const normalizedDomain = values.domain?.trim().toLowerCase() || undefined;
         await updateConfig({
           adminApp: stackAdminApp,
           configUpdate: {
             [`auth.saml.connections.${values.id}`]: {
               displayName: values.displayName,
               allowSignIn: values.allowSignIn,
-              domain: values.domain || undefined,
+              domain: normalizedDomain,
               idpEntityId: values.idpEntityId,
               idpSsoUrl: values.idpSsoUrl,
               idpCertificate: (values.idpCertificate ?? "").replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ""),

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
@@ -144,19 +144,23 @@ function CreateDialog({ open, onOpenChange }: { open: boolean, onOpenChange: (op
       okButton={{ label: "Create" }}
       cancelButton
       onSubmit={async (values) => {
-        const overlay: Record<string, unknown> = {
-          [`auth.saml.connections.${values.id}.displayName`]: values.displayName,
-          [`auth.saml.connections.${values.id}.allowSignIn`]: values.allowSignIn,
-          [`auth.saml.connections.${values.id}.idpEntityId`]: values.idpEntityId,
-          [`auth.saml.connections.${values.id}.idpSsoUrl`]: values.idpSsoUrl,
-          [`auth.saml.connections.${values.id}.idpCertificate`]: (values.idpCertificate ?? "").replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ""),
-        };
-        if (values.domain) {
-          overlay[`auth.saml.connections.${values.id}.domain`] = values.domain;
-        }
+        // Set the whole connection entry as a single value. Deep dot-keys
+        // (e.g. `auth.saml.connections.X.displayName`) get dropped during
+        // config normalization when the parent record entry doesn't yet
+        // exist — same convention as auth.oauth.providers in the
+        // auth-methods page.
         await updateConfig({
           adminApp: stackAdminApp,
-          configUpdate: overlay as Parameters<typeof updateConfig>[0]["configUpdate"],
+          configUpdate: {
+            [`auth.saml.connections.${values.id}`]: {
+              displayName: values.displayName,
+              allowSignIn: values.allowSignIn,
+              domain: values.domain || undefined,
+              idpEntityId: values.idpEntityId,
+              idpSsoUrl: values.idpSsoUrl,
+              idpCertificate: (values.idpCertificate ?? "").replace(/-----BEGIN CERTIFICATE-----|-----END CERTIFICATE-----|\s+/g, ""),
+            },
+          } as Parameters<typeof updateConfig>[0]["configUpdate"],
           pushable: true,
         });
       }}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page-client.tsx
@@ -5,6 +5,7 @@ import { ActionDialog, Alert, Button, Card, CardContent, CardHeader, Typography 
 import { useUpdateConfig } from "@/lib/config-update";
 import React, { useState } from "react";
 import * as yup from "yup";
+import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
 
@@ -22,6 +23,14 @@ import { useAdminApp } from "../use-admin-app";
  * now connection fields are entered manually.
  */
 export default function PageClient() {
+  return (
+    <AppEnabledGuard appId="saml-sso">
+      <PageContent />
+    </AppEnabledGuard>
+  );
+}
+
+function PageContent() {
   const stackAdminApp = useAdminApp();
   const project = stackAdminApp.useProject();
   const config = project.useConfig();
@@ -194,8 +203,8 @@ function DeleteDialog({ connectionId, displayName, onClose }: {
             adminApp: stackAdminApp,
             configUpdate: { [`auth.saml.connections.${connectionId}`]: null } as Parameters<typeof updateConfig>[0]["configUpdate"],
             // SAML connection fields (cert, IdP URLs) are environment-level
-          // (not pushable) — same as OAuth client secrets.
-          pushable: false,
+            // (not pushable) — same as OAuth client secrets.
+            pushable: false,
           });
           onClose();
         },

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/page.tsx
@@ -1,0 +1,9 @@
+import PageClient from "./page-client";
+
+export const metadata = {
+  title: "SAML SSO",
+};
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -1,5 +1,5 @@
 import { Link } from "@/components/link";
-import { ChartLineIcon, ClipboardTextIcon, CreditCardIcon, EnvelopeSimpleIcon, FingerprintSimpleIcon, KeyIcon, MailboxIcon, RocketIcon, ShieldCheckIcon, SparkleIcon, TelevisionSimpleIcon, TriangleIcon, UserGearIcon, UsersIcon, VaultIcon, WebhooksLogoIcon } from "@phosphor-icons/react";
+import { BuildingsIcon, ChartLineIcon, ClipboardTextIcon, CreditCardIcon, EnvelopeSimpleIcon, FingerprintSimpleIcon, KeyIcon, MailboxIcon, RocketIcon, ShieldCheckIcon, SparkleIcon, TelevisionSimpleIcon, TriangleIcon, UserGearIcon, UsersIcon, VaultIcon, WebhooksLogoIcon } from "@phosphor-icons/react";
 import { StackAdminApp } from "@stackframe/stack";
 import { ALL_APPS } from "@stackframe/stack-shared/dist/apps/apps-config";
 import { getRelativePart, isChildUrl } from "@stackframe/stack-shared/dist/utils/urls";
@@ -159,6 +159,21 @@ export const ALL_APPS_FRONTEND = {
         <p>RBAC helps you model the authorization surface of your product in a structured, auditable way.</p>
         <p>Define project and team permissions with IDs that map directly into your code and compose them into higher-level roles.</p>
         <p>The Stack SDK exposes those definitions everywhere so each environment enforces the same checks.</p>
+      </>
+    ),
+  },
+  "saml-sso": {
+    icon: BuildingsIcon,
+    href: "sso",
+    navigationItems: [
+      { displayName: "SAML SSO", href: "." },
+    ],
+    screenshots: [],
+    storeDescription: (
+      <>
+        <p>SAML SSO lets enterprise customers sign in to your project through their corporate identity provider.</p>
+        <p>Add per-tenant connections with Okta, Azure AD, Google Workspace, or any SAML 2.0 IdP — your customers paste in the SP metadata and ACS URLs from the connection card.</p>
+        <p>The Stack SDK exposes <code>signInWithSso</code> for email-domain discovery and <code>signInWithSaml</code> for explicit connection selection.</p>
       </>
     ),
   },

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
@@ -22,6 +22,7 @@ async function createProjectWithSamlConnection(slug: string, domain: string) {
   // onDotIntoNonObject="ignore" — same convention as auth.oauth.providers
   // (see auth-methods/page-client.tsx).
   await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
     [`auth.saml.connections.${slug}`]: {
       displayName: `${slug} SSO`,
       allowSignIn: true,
@@ -86,6 +87,31 @@ it("returns 404 for an unknown project_id", async ({ expect }) => {
   );
 
   expect(response.status).toBe(404);
+});
+
+it("returns SAML_SSO_NOT_ENABLED when the saml-sso app is not installed", async ({ expect }) => {
+  // Same setup as createProjectWithSamlConnection but without enabling the app.
+  // Configuring connections without installing the app should never let the
+  // SDK use them — the alpha gate is the first line of defense.
+  const { projectId } = await Project.createAndSwitch();
+  await Project.updateConfig({
+    "auth.saml.connections.acme": {
+      displayName: "acme SSO",
+      allowSignIn: true,
+      domain: "acme.test",
+      idpEntityId: "https://idp.acme.test/saml/metadata",
+      idpSsoUrl: "https://idp.acme.test/saml/sso",
+      idpCertificate: "MIICertificatePlaceholderForGateTest=",
+    },
+  });
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=alice@acme.test&project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(400);
+  expect((response.body as { code?: string }).code).toBe("SAML_SSO_NOT_ENABLED");
 });
 
 it("isolates connections across projects (B's connection is not visible from A)", async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
@@ -1,0 +1,97 @@
+import { it } from "../../../../../../helpers";
+import { Project, niceBackendFetch } from "../../../../../backend-helpers";
+
+/**
+ * Tests for GET /auth/saml/discover.
+ *
+ * Test integrity: drives the API only — no imports from
+ * apps/backend/src/saml/. Project config is set via the standard config
+ * override endpoint (no special test-only mutator), so the discovery
+ * lookup runs through the same code path real customers would hit.
+ *
+ * Connection isolation note: each `it` block creates its own project via
+ * Project.createAndSwitch, so connections don't leak across tests.
+ */
+
+async function createProjectWithSamlConnection(slug: string, domain: string) {
+  const { projectId } = await Project.createAndSwitch();
+  // Push the SAML connection at the environment level — that's where the
+  // IdP-side fields live. The discovery endpoint reads from the rendered
+  // organization config which folds in env overrides.
+  await Project.updateConfig({
+    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
+    [`auth.saml.connections.${slug}.allowSignIn`]: true,
+    [`auth.saml.connections.${slug}.domain`]: domain,
+    [`auth.saml.connections.${slug}.idpEntityId`]: `https://idp.${domain}/saml/metadata`,
+    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://idp.${domain}/saml/sso`,
+    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForDiscoveryTest=",
+  });
+  return { projectId };
+}
+
+it("returns the matching connection for a known email domain", async ({ expect }) => {
+  const { projectId } = await createProjectWithSamlConnection("acme", "acme.test");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=alice@acme.test&project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": {
+        "connection_id": "acme",
+        "display_name": "acme SSO",
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+});
+
+it("returns 404 when no connection matches the email's domain", async ({ expect }) => {
+  const { projectId } = await createProjectWithSamlConnection("acme", "acme.test");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=stranger@unknown.test&project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(404);
+});
+
+it("matches the connection case-insensitively on the email domain", async ({ expect }) => {
+  const { projectId } = await createProjectWithSamlConnection("acme", "acme.test");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=ALICE@ACME.TEST&project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(200);
+  expect(response.body).toEqual({ connection_id: "acme", display_name: "acme SSO" });
+});
+
+it("returns 404 for an unknown project_id", async ({ expect }) => {
+  await createProjectWithSamlConnection("acme", "acme.test");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=alice@acme.test&project_id=00000000-0000-0000-0000-000000000000`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(404);
+});
+
+it("isolates connections across projects (B's connection is not visible from A)", async ({ expect }) => {
+  // Project A has acme; project B has globex. Querying A for globex's domain must miss.
+  const { projectId: projectA } = await createProjectWithSamlConnection("acme", "acme.test");
+  await createProjectWithSamlConnection("globex", "globex.test");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=bob@globex.test&project_id=${projectA}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(404);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
@@ -114,6 +114,31 @@ it("returns SAML_SSO_NOT_ENABLED when the saml-sso app is not installed", async 
   expect((response.body as { code?: string }).code).toBe("SAML_SSO_NOT_ENABLED");
 });
 
+it("returns 404 for a connection whose allowSignIn is disabled", async ({ expect }) => {
+  // Discover is the entry point for signInWithSso — surfacing a disabled
+  // connection here would direct the user through /auth/saml/login, which
+  // intentionally 403s. Treat disabled connections as if they didn't exist.
+  const { projectId } = await Project.createAndSwitch();
+  await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
+    "auth.saml.connections.acme": {
+      displayName: "acme SSO",
+      allowSignIn: false,
+      domain: "acme.test",
+      idpEntityId: "https://idp.acme.test/saml/metadata",
+      idpSsoUrl: "https://idp.acme.test/saml/sso",
+      idpCertificate: "MIICertificatePlaceholderForDisabledTest=",
+    },
+  });
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/discover?email=alice@acme.test&project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(404);
+});
+
 it("isolates connections across projects (B's connection is not visible from A)", async ({ expect }) => {
   // Project A has acme; project B has globex. Querying A for globex's domain must miss.
   const { projectId: projectA } = await createProjectWithSamlConnection("acme", "acme.test");

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/discover.test.ts
@@ -15,16 +15,21 @@ import { Project, niceBackendFetch } from "../../../../../backend-helpers";
 
 async function createProjectWithSamlConnection(slug: string, domain: string) {
   const { projectId } = await Project.createAndSwitch();
-  // Push the SAML connection at the environment level — that's where the
-  // IdP-side fields live. The discovery endpoint reads from the rendered
-  // organization config which folds in env overrides.
+  // Set the entire connection entry as a single value. The override
+  // system handles `auth.saml.connections.{id}: {full object}` cleanly,
+  // but per-field deep dot-keys (e.g. .displayName) on a record entry
+  // that doesn't yet exist get dropped during config normalization with
+  // onDotIntoNonObject="ignore" — same convention as auth.oauth.providers
+  // (see auth-methods/page-client.tsx).
   await Project.updateConfig({
-    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
-    [`auth.saml.connections.${slug}.allowSignIn`]: true,
-    [`auth.saml.connections.${slug}.domain`]: domain,
-    [`auth.saml.connections.${slug}.idpEntityId`]: `https://idp.${domain}/saml/metadata`,
-    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://idp.${domain}/saml/sso`,
-    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForDiscoveryTest=",
+    [`auth.saml.connections.${slug}`]: {
+      displayName: `${slug} SSO`,
+      allowSignIn: true,
+      domain,
+      idpEntityId: `https://idp.${domain}/saml/metadata`,
+      idpSsoUrl: `https://idp.${domain}/saml/sso`,
+      idpCertificate: "MIICertificatePlaceholderForDiscoveryTest=",
+    },
   });
   return { projectId };
 }

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
@@ -18,6 +18,7 @@ async function setupProjectWithSamlConnection(slug: string, idpHost: string) {
   await Project.createAndSwitch();
   await InternalApiKey.createAndSetProjectKeys();
   await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
     [`auth.saml.connections.${slug}`]: {
       displayName: `${slug} SSO`,
       allowSignIn: true,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
@@ -1,0 +1,115 @@
+import { it } from "../../../../../../helpers";
+import { InternalApiKey, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
+
+/**
+ * Tests for GET /auth/saml/login/[connection_id].
+ *
+ * Verifies the SDK-facing endpoint that begins SP-initiated SSO. We don't
+ * follow the redirect into the IdP here — that's the round-trip test
+ * (deferred). These tests check:
+ * - URL is built correctly and points at the configured IdP SSO URL
+ * - SAMLRequest + RelayState query params are present
+ * - CSRF cookie is set in browser-redirect mode
+ * - JSON-mode response returns the location instead of redirecting
+ * - Error paths: invalid client, unknown connection, sign-in disabled
+ */
+
+async function setupProjectWithSamlConnection(slug: string, idpHost: string) {
+  await Project.createAndSwitch();
+  await InternalApiKey.createAndSetProjectKeys();
+  await Project.updateConfig({
+    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
+    [`auth.saml.connections.${slug}.allowSignIn`]: true,
+    [`auth.saml.connections.${slug}.idpEntityId`]: `https://${idpHost}/saml/metadata`,
+    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://${idpHost}/saml/sso`,
+    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForLoginTest=",
+  });
+}
+
+function loginQuery() {
+  const projectKeys = backendContext.value.projectKeys;
+  if (projectKeys === "no-project") throw new Error("No project keys");
+  const branchId = backendContext.value.currentBranchId;
+  return {
+    client_id: !branchId ? projectKeys.projectId : `${projectKeys.projectId}#${branchId}`,
+    client_secret: projectKeys.publishableClientKey ?? "",
+    redirect_uri: "http://localhost:8101/handler/oauth-callback",
+    scope: "legacy",
+    state: "this-is-some-state",
+    grant_type: "authorization_code",
+    code_challenge: "some-code-challenge",
+    code_challenge_method: "S256",
+    response_type: "code",
+  };
+}
+
+it("returns the IdP SSO URL with SAMLRequest in JSON-mode", async ({ expect }) => {
+  await setupProjectWithSamlConnection("acme", "idp.acme.test");
+
+  const response = await niceBackendFetch("/api/v1/auth/saml/login/acme", {
+    method: "GET",
+    query: { ...loginQuery(), stack_response_mode: "json" },
+  });
+
+  expect(response.status).toBe(200);
+  expect(typeof (response.body as { location?: unknown }).location).toBe("string");
+  const location = new URL((response.body as { location: string }).location);
+  expect(location.host).toBe("idp.acme.test");
+  expect(location.pathname).toBe("/saml/sso");
+  expect(location.searchParams.get("SAMLRequest")).toBeTruthy();
+  expect(location.searchParams.get("RelayState")).toBe("this-is-some-state");
+});
+
+it("redirects + sets CSRF cookie in browser-redirect mode", async ({ expect }) => {
+  await setupProjectWithSamlConnection("acme", "idp.acme.test");
+
+  const response = await niceBackendFetch("/api/v1/auth/saml/login/acme", {
+    method: "GET",
+    redirect: "manual",
+    query: loginQuery(),
+  });
+
+  expect(response.status).toBe(307);
+  const location = response.headers.get("location");
+  expect(location).toBeTruthy();
+  expect(new URL(location!).host).toBe("idp.acme.test");
+  // CSRF cookie keyed to the AuthnRequest ID — snapshot serializer strips
+  // the suffix via the keyedCookieNamePrefixes registration.
+  expect(response.headers.get("set-cookie")).toMatch(/^stack-saml-inner-[^;]+=true;/);
+});
+
+it("returns 404 for an unknown connection ID", async ({ expect }) => {
+  await setupProjectWithSamlConnection("acme", "idp.acme.test");
+
+  const response = await niceBackendFetch("/api/v1/auth/saml/login/does-not-exist", {
+    method: "GET",
+    query: loginQuery(),
+  });
+
+  expect(response.status).toBe(404);
+});
+
+it("returns 403 when allowSignIn is false on the connection", async ({ expect }) => {
+  await setupProjectWithSamlConnection("acme", "idp.acme.test");
+  await Project.updateConfig({ "auth.saml.connections.acme.allowSignIn": false });
+
+  const response = await niceBackendFetch("/api/v1/auth/saml/login/acme", {
+    method: "GET",
+    query: loginQuery(),
+  });
+
+  expect(response.status).toBe(403);
+});
+
+it("rejects an invalid client_id", async ({ expect }) => {
+  await setupProjectWithSamlConnection("acme", "idp.acme.test");
+
+  const response = await niceBackendFetch("/api/v1/auth/saml/login/acme", {
+    method: "GET",
+    query: { ...loginQuery(), client_id: "00000000-0000-0000-0000-000000000000" },
+  });
+
+  // Tenancy lookup fails → InvalidOAuthClientIdOrSecret known error.
+  expect(response.status).not.toBe(200);
+  expect(response.status).not.toBe(307);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
@@ -1,4 +1,5 @@
 import { it } from "../../../../../../helpers";
+import { localhostUrl } from "../../../../../../helpers/ports";
 import { InternalApiKey, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 /**
@@ -36,7 +37,7 @@ function loginQuery() {
   return {
     client_id: !branchId ? projectKeys.projectId : `${projectKeys.projectId}#${branchId}`,
     client_secret: projectKeys.publishableClientKey ?? "",
-    redirect_uri: "http://localhost:8101/handler/oauth-callback",
+    redirect_uri: localhostUrl("01", "/handler/oauth-callback"),
     scope: "legacy",
     state: "this-is-some-state",
     grant_type: "authorization_code",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/login.test.ts
@@ -18,11 +18,13 @@ async function setupProjectWithSamlConnection(slug: string, idpHost: string) {
   await Project.createAndSwitch();
   await InternalApiKey.createAndSetProjectKeys();
   await Project.updateConfig({
-    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
-    [`auth.saml.connections.${slug}.allowSignIn`]: true,
-    [`auth.saml.connections.${slug}.idpEntityId`]: `https://${idpHost}/saml/metadata`,
-    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://${idpHost}/saml/sso`,
-    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForLoginTest=",
+    [`auth.saml.connections.${slug}`]: {
+      displayName: `${slug} SSO`,
+      allowSignIn: true,
+      idpEntityId: `https://${idpHost}/saml/metadata`,
+      idpSsoUrl: `https://${idpHost}/saml/sso`,
+      idpCertificate: "MIICertificatePlaceholderForLoginTest=",
+    },
   });
 }
 
@@ -91,6 +93,8 @@ it("returns 404 for an unknown connection ID", async ({ expect }) => {
 
 it("returns 403 when allowSignIn is false on the connection", async ({ expect }) => {
   await setupProjectWithSamlConnection("acme", "idp.acme.test");
+  // The connection already exists, so deep-key updates work (the parent
+  // record entry is navigable now).
   await Project.updateConfig({ "auth.saml.connections.acme.allowSignIn": false });
 
   const response = await niceBackendFetch("/api/v1/auth/saml/login/acme", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
@@ -12,11 +12,13 @@ import { Project, niceBackendFetch } from "../../../../../backend-helpers";
 async function setupSamlConnection(slug: string) {
   const { projectId } = await Project.createAndSwitch();
   await Project.updateConfig({
-    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
-    [`auth.saml.connections.${slug}.allowSignIn`]: true,
-    [`auth.saml.connections.${slug}.idpEntityId`]: `https://idp.${slug}.test/saml/metadata`,
-    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://idp.${slug}.test/saml/sso`,
-    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForMetadataTest=",
+    [`auth.saml.connections.${slug}`]: {
+      displayName: `${slug} SSO`,
+      allowSignIn: true,
+      idpEntityId: `https://idp.${slug}.test/saml/metadata`,
+      idpSsoUrl: `https://idp.${slug}.test/saml/sso`,
+      idpCertificate: "MIICertificatePlaceholderForMetadataTest=",
+    },
   });
   return { projectId };
 }
@@ -54,11 +56,13 @@ it("returns 404 for an unknown connection ID", async ({ expect }) => {
 
 it("returns 404 when the connection exists but has no IdP cert configured", async ({ expect }) => {
   const { projectId } = await Project.createAndSwitch();
-  // Create a connection at branch level but skip the env-level IdP fields.
+  // Create a connection but skip the IdP-side fields.
   await Project.updateConfig({
-    "auth.saml.connections.partial.displayName": "Partial",
-    "auth.saml.connections.partial.allowSignIn": true,
-    // No idpEntityId / idpSsoUrl / idpCertificate.
+    "auth.saml.connections.partial": {
+      displayName: "Partial",
+      allowSignIn: true,
+      // No idpEntityId / idpSsoUrl / idpCertificate.
+    },
   });
 
   const response = await niceBackendFetch(

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
@@ -1,0 +1,72 @@
+import { it } from "../../../../../../helpers";
+import { Project, niceBackendFetch } from "../../../../../backend-helpers";
+
+/**
+ * Tests for GET /auth/saml/metadata/[connection_id].
+ *
+ * The IdP admin fetches this URL to wire up the SP side. We assert the
+ * returned XML contains entityID + AssertionConsumerService URLs that
+ * match what the IdP would actually need.
+ */
+
+async function setupSamlConnection(slug: string) {
+  const { projectId } = await Project.createAndSwitch();
+  await Project.updateConfig({
+    [`auth.saml.connections.${slug}.displayName`]: `${slug} SSO`,
+    [`auth.saml.connections.${slug}.allowSignIn`]: true,
+    [`auth.saml.connections.${slug}.idpEntityId`]: `https://idp.${slug}.test/saml/metadata`,
+    [`auth.saml.connections.${slug}.idpSsoUrl`]: `https://idp.${slug}.test/saml/sso`,
+    [`auth.saml.connections.${slug}.idpCertificate`]: "MIICertificatePlaceholderForMetadataTest=",
+  });
+  return { projectId };
+}
+
+it("returns SP metadata XML with entityID and ACS URL embedded", async ({ expect }) => {
+  const { projectId } = await setupSamlConnection("acme");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/metadata/acme?project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(200);
+  expect(typeof response.body).toBe("string");
+  const xml = response.body as string;
+  // entityID should reference our metadata URL.
+  expect(xml).toContain('entityID="');
+  expect(xml).toContain("/api/v1/auth/saml/metadata/acme");
+  // AssertionConsumerService should point at the ACS endpoint.
+  expect(xml).toContain("/api/v1/auth/saml/acs/acme");
+  // Must declare the HTTP-POST binding for the IdP to know where to POST.
+  expect(xml).toContain("urn:oasis:names:tc:SAML:2.0:bindings:HTTP-POST");
+});
+
+it("returns 404 for an unknown connection ID", async ({ expect }) => {
+  const { projectId } = await setupSamlConnection("acme");
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/metadata/does-not-exist?project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  expect(response.status).toBe(404);
+});
+
+it("returns 404 when the connection exists but has no IdP cert configured", async ({ expect }) => {
+  const { projectId } = await Project.createAndSwitch();
+  // Create a connection at branch level but skip the env-level IdP fields.
+  await Project.updateConfig({
+    "auth.saml.connections.partial.displayName": "Partial",
+    "auth.saml.connections.partial.allowSignIn": true,
+    // No idpEntityId / idpSsoUrl / idpCertificate.
+  });
+
+  const response = await niceBackendFetch(
+    `/api/v1/auth/saml/metadata/partial?project_id=${projectId}`,
+    { method: "GET" },
+  );
+
+  // Without the IdP fields, the SP metadata wouldn't be useful (the IdP
+  // and SP need to know each other's cert for trust). Return 404.
+  expect(response.status).toBe(404);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/metadata.test.ts
@@ -12,6 +12,7 @@ import { Project, niceBackendFetch } from "../../../../../backend-helpers";
 async function setupSamlConnection(slug: string) {
   const { projectId } = await Project.createAndSwitch();
   await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
     [`auth.saml.connections.${slug}`]: {
       displayName: `${slug} SSO`,
       allowSignIn: true,
@@ -58,6 +59,7 @@ it("returns 404 when the connection exists but has no IdP cert configured", asyn
   const { projectId } = await Project.createAndSwitch();
   // Create a connection but skip the IdP-side fields.
   await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
     "auth.saml.connections.partial": {
       displayName: "Partial",
       allowSignIn: true,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
@@ -27,6 +27,7 @@ import { localhostUrl } from "../../../../../../helpers/ports";
 import { InternalApiKey, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 const MOCK_SAML_BASE = localhostUrl("15");
+const BACKEND_BASE = localhostUrl("02");
 
 // ---------- helpers ----------
 
@@ -39,7 +40,10 @@ async function fetchMockIdpCertificate(tenantSlug: string): Promise<{
   if (res.status !== 200) {
     throw new Error(`Mock IdP returned ${res.status} for ${tenantSlug} metadata — is mock-saml-idp running on port 8115?`);
   }
-  const xml = res.body as string;
+  // application/xml content-type makes niceFetch return ArrayBuffer; decode it.
+  const xml = typeof res.body === "string"
+    ? res.body
+    : new TextDecoder("utf-8").decode(res.body as ArrayBuffer);
   const entityIdMatch = xml.match(/entityID="([^"]+)"/);
   const ssoMatch = xml.match(/Binding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-Redirect"[^>]*Location="([^"]+)"/);
   const certMatch = xml.match(/<X509Certificate>([\s\S]+?)<\/X509Certificate>/);
@@ -58,11 +62,13 @@ async function setupProjectWithMockSamlConnection(connectionId: string, tenantSl
   await InternalApiKey.createAndSetProjectKeys();
   const idp = await fetchMockIdpCertificate(tenantSlug);
   await Project.updateConfig({
-    [`auth.saml.connections.${connectionId}.displayName`]: `${connectionId} SSO`,
-    [`auth.saml.connections.${connectionId}.allowSignIn`]: true,
-    [`auth.saml.connections.${connectionId}.idpEntityId`]: idp.entityId,
-    [`auth.saml.connections.${connectionId}.idpSsoUrl`]: idp.ssoUrl,
-    [`auth.saml.connections.${connectionId}.idpCertificate`]: idp.certificate,
+    [`auth.saml.connections.${connectionId}`]: {
+      displayName: `${connectionId} SSO`,
+      allowSignIn: true,
+      idpEntityId: idp.entityId,
+      idpSsoUrl: idp.ssoUrl,
+      idpCertificate: idp.certificate,
+    },
   });
   return { connectionId, tenantSlug };
 }
@@ -120,13 +126,18 @@ async function runSamlRoundTrip(options: {
   }
 
   // Step 3: extract SAMLResponse from the auto-POST HTML.
-  const html = idpLoginRes.body as string;
+  const html = typeof idpLoginRes.body === "string"
+    ? idpLoginRes.body
+    : new TextDecoder("utf-8").decode(idpLoginRes.body as ArrayBuffer);
   const samlResponseMatch = html.match(/name="SAMLResponse" value="([^"]+)"/);
   if (!samlResponseMatch) throw new Error(`Mock IdP did not return a SAMLResponse form: ${html.slice(0, 200)}`);
   const samlResponse = samlResponseMatch[1].replace(/&#x2F;/g, "/").replace(/&#x3D;/g, "=").replace(/&amp;/g, "&");
 
-  // Step 4: POST to ACS.
-  const acsRes = await niceBackendFetch(`/api/v1/auth/saml/acs/${options.connectionId}`, {
+  // Step 4: POST to ACS — use niceFetch directly so URLSearchParams gets
+  // sent as application/x-www-form-urlencoded. niceBackendFetch always
+  // JSON.stringifies the body, which doesn't work for the IdP-style
+  // form POST that ACS expects.
+  const acsRes = await niceFetch(`${BACKEND_BASE}/api/v1/auth/saml/acs/${options.connectionId}`, {
     method: "POST",
     redirect: "manual",
     body: new URLSearchParams({
@@ -223,7 +234,7 @@ it("rejects replay of a previously-consumed assertion", async ({ expect }) => {
   // Replay the same SAMLResponse — backend should reject because the
   // SamlOuterInfo row was deleted at the end of the first ACS call, so
   // the InResponseTo lookup misses.
-  const replayRes = await niceBackendFetch(`/api/v1/auth/saml/acs/acme`, {
+  const replayRes = await niceFetch(`${BACKEND_BASE}/api/v1/auth/saml/acs/acme`, {
     method: "POST",
     redirect: "manual",
     body: new URLSearchParams({

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
@@ -62,6 +62,7 @@ async function setupProjectWithMockSamlConnection(connectionId: string, tenantSl
   await InternalApiKey.createAndSetProjectKeys();
   const idp = await fetchMockIdpCertificate(tenantSlug);
   await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
     [`auth.saml.connections.${connectionId}`]: {
       displayName: `${connectionId} SSO`,
       allowSignIn: true,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
@@ -2,7 +2,7 @@
  * Full SAML SP-initiated round-trip e2e tests.
  *
  * Drives the entire flow against the running mock-saml-idp service on
- * port 8115:
+ * the mock IdP port (default suffix `42`, e.g. 8142 with prefix 81):
  *
  *   1. Setup project with a SAML connection pointing at the mock IdP
  *      (cert fetched from mock metadata so it matches the mock's
@@ -26,8 +26,9 @@ import { it, niceFetch } from "../../../../../../helpers";
 import { localhostUrl } from "../../../../../../helpers/ports";
 import { InternalApiKey, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
-const MOCK_SAML_BASE = localhostUrl("15");
+const MOCK_SAML_BASE = localhostUrl("42");
 const BACKEND_BASE = localhostUrl("02");
+const DASHBOARD_REDIRECT_URI = localhostUrl("01", "/handler/oauth-callback");
 
 // ---------- helpers ----------
 
@@ -38,7 +39,7 @@ async function fetchMockIdpCertificate(tenantSlug: string): Promise<{
 }> {
   const res = await niceFetch(`${MOCK_SAML_BASE}/idp/${tenantSlug}/metadata`);
   if (res.status !== 200) {
-    throw new Error(`Mock IdP returned ${res.status} for ${tenantSlug} metadata — is mock-saml-idp running on port 8115?`);
+    throw new Error(`Mock IdP returned ${res.status} for ${tenantSlug} metadata — is mock-saml-idp running on ${MOCK_SAML_BASE}?`);
   }
   // application/xml content-type makes niceFetch return ArrayBuffer; decode it.
   const xml = typeof res.body === "string"
@@ -74,6 +75,8 @@ async function setupProjectWithMockSamlConnection(connectionId: string, tenantSl
   return { connectionId, tenantSlug };
 }
 
+const ROUND_TRIP_CODE_VERIFIER = "round-trip-code-challenge";
+
 function loginQuery() {
   const projectKeys = backendContext.value.projectKeys;
   if (projectKeys === "no-project") throw new Error("No project keys");
@@ -81,12 +84,13 @@ function loginQuery() {
   return {
     client_id: !branchId ? projectKeys.projectId : `${projectKeys.projectId}#${branchId}`,
     client_secret: projectKeys.publishableClientKey ?? "",
-    redirect_uri: "http://localhost:8101/handler/oauth-callback",
+    redirect_uri: DASHBOARD_REDIRECT_URI,
     scope: "legacy",
     state: "round-trip-test-state",
     grant_type: "authorization_code",
-    code_challenge: "round-trip-code-challenge",
-    code_challenge_method: "S256",
+    // Use plain so the verifier used at token exchange equals the challenge.
+    code_challenge: ROUND_TRIP_CODE_VERIFIER,
+    code_challenge_method: "plain",
     response_type: "code",
   };
 }
@@ -175,8 +179,45 @@ it("full SP-initiated round trip: new user JIT-created", async ({ expect }) => {
   const location = acsRes.headers.get("location");
   expect(location).toBeTruthy();
   const callbackUrl = new URL(location!);
-  // Should contain an OAuth `code` query param.
-  expect(callbackUrl.searchParams.get("code")).toBeTruthy();
+  // Callback origin must match the dashboard redirect_uri the test
+  // submitted, not whatever the default port is — otherwise this test
+  // can pass under a custom port prefix while wired to a non-running app.
+  expect(callbackUrl.origin).toBe(new URL(DASHBOARD_REDIRECT_URI).origin);
+  const code = callbackUrl.searchParams.get("code");
+  expect(code).toBeTruthy();
+
+  // Exchange the code for tokens and verify the JIT user was actually
+  // persisted with the email + display name from the SAML assertion —
+  // otherwise the test only proves "ACS issued a redirect", not "the
+  // SAML account/user link was saved".
+  const projectKeys = backendContext.value.projectKeys;
+  if (projectKeys === "no-project") throw new Error("No project keys");
+  const branchId = backendContext.value.currentBranchId;
+  const tokenRes = await niceBackendFetch("/api/v1/auth/oauth/token", {
+    method: "POST",
+    accessType: "client",
+    body: {
+      client_id: !branchId ? projectKeys.projectId : `${projectKeys.projectId}#${branchId}`,
+      client_secret: projectKeys.publishableClientKey ?? "",
+      code,
+      redirect_uri: DASHBOARD_REDIRECT_URI,
+      code_verifier: ROUND_TRIP_CODE_VERIFIER,
+      grant_type: "authorization_code",
+    },
+  });
+  expect(tokenRes.status).toBe(200);
+  const accessToken = (tokenRes.body as { access_token: string }).access_token;
+  expect(accessToken).toBeTruthy();
+  expect((tokenRes.body as { is_new_user: boolean }).is_new_user).toBe(true);
+
+  const meRes = await niceBackendFetch("/api/v1/users/me", {
+    accessType: "client",
+    headers: { "x-stack-access-token": accessToken },
+  });
+  expect(meRes.status).toBe(200);
+  const me = meRes.body as { primary_email: string | null, display_name: string | null };
+  expect(me.primary_email).toBe("alice@acme.test");
+  expect(me.display_name).toBe("Alice");
 });
 
 it("rejects an assertion with the wrong audience", async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/saml/round-trip.test.ts
@@ -1,0 +1,238 @@
+/**
+ * Full SAML SP-initiated round-trip e2e tests.
+ *
+ * Drives the entire flow against the running mock-saml-idp service on
+ * port 8115:
+ *
+ *   1. Setup project with a SAML connection pointing at the mock IdP
+ *      (cert fetched from mock metadata so it matches the mock's
+ *      runtime-generated keypair).
+ *   2. GET /auth/saml/login/[id] → returns the IdP redirect URL with a
+ *      SAMLRequest.
+ *   3. POST the SAMLRequest to mock /idp/[tenant]/login → mock returns
+ *      auto-POST HTML containing a signed SAMLResponse + RelayState.
+ *   4. POST that SAMLResponse to /auth/saml/acs/[id] → backend verifies
+ *      the assertion and (for the happy path) issues a redirect with an
+ *      OAuth code.
+ *
+ * Test integrity: NO imports from apps/backend/src/saml/. Mock IdP uses
+ * `samlify` independently of the backend's `@node-saml/node-saml`, so
+ * signature/canonicalization bugs in either library surface as test
+ * failures rather than canceling out. Negative cases are produced by the
+ * mock deliberately misbehaving via /test-controls — never by injecting
+ * bad data into the backend's own validator.
+ */
+import { it, niceFetch } from "../../../../../../helpers";
+import { localhostUrl } from "../../../../../../helpers/ports";
+import { InternalApiKey, Project, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
+
+const MOCK_SAML_BASE = localhostUrl("15");
+
+// ---------- helpers ----------
+
+async function fetchMockIdpCertificate(tenantSlug: string): Promise<{
+  entityId: string,
+  ssoUrl: string,
+  certificate: string,
+}> {
+  const res = await niceFetch(`${MOCK_SAML_BASE}/idp/${tenantSlug}/metadata`);
+  if (res.status !== 200) {
+    throw new Error(`Mock IdP returned ${res.status} for ${tenantSlug} metadata — is mock-saml-idp running on port 8115?`);
+  }
+  const xml = res.body as string;
+  const entityIdMatch = xml.match(/entityID="([^"]+)"/);
+  const ssoMatch = xml.match(/Binding="urn:oasis:names:tc:SAML:2\.0:bindings:HTTP-Redirect"[^>]*Location="([^"]+)"/);
+  const certMatch = xml.match(/<X509Certificate>([\s\S]+?)<\/X509Certificate>/);
+  if (!entityIdMatch || !ssoMatch || !certMatch) {
+    throw new Error(`Could not parse mock IdP metadata for ${tenantSlug}`);
+  }
+  return {
+    entityId: entityIdMatch[1],
+    ssoUrl: ssoMatch[1],
+    certificate: certMatch[1].replace(/\s+/g, ""),
+  };
+}
+
+async function setupProjectWithMockSamlConnection(connectionId: string, tenantSlug: string) {
+  await Project.createAndSwitch();
+  await InternalApiKey.createAndSetProjectKeys();
+  const idp = await fetchMockIdpCertificate(tenantSlug);
+  await Project.updateConfig({
+    [`auth.saml.connections.${connectionId}.displayName`]: `${connectionId} SSO`,
+    [`auth.saml.connections.${connectionId}.allowSignIn`]: true,
+    [`auth.saml.connections.${connectionId}.idpEntityId`]: idp.entityId,
+    [`auth.saml.connections.${connectionId}.idpSsoUrl`]: idp.ssoUrl,
+    [`auth.saml.connections.${connectionId}.idpCertificate`]: idp.certificate,
+  });
+  return { connectionId, tenantSlug };
+}
+
+function loginQuery() {
+  const projectKeys = backendContext.value.projectKeys;
+  if (projectKeys === "no-project") throw new Error("No project keys");
+  const branchId = backendContext.value.currentBranchId;
+  return {
+    client_id: !branchId ? projectKeys.projectId : `${projectKeys.projectId}#${branchId}`,
+    client_secret: projectKeys.publishableClientKey ?? "",
+    redirect_uri: "http://localhost:8101/handler/oauth-callback",
+    scope: "legacy",
+    state: "round-trip-test-state",
+    grant_type: "authorization_code",
+    code_challenge: "round-trip-code-challenge",
+    code_challenge_method: "S256",
+    response_type: "code",
+  };
+}
+
+/** Run the full happy-path SP-initiated SAML round trip. */
+async function runSamlRoundTrip(options: {
+  connectionId: string,
+  tenantSlug: string,
+  email: string,
+  displayName?: string,
+}) {
+  // Step 1: get the IdP redirect URL (JSON mode so we can intercept).
+  const loginRes = await niceBackendFetch(`/api/v1/auth/saml/login/${options.connectionId}`, {
+    method: "GET",
+    query: { ...loginQuery(), stack_response_mode: "json" },
+  });
+  if (loginRes.status !== 200) {
+    throw new Error(`/auth/saml/login returned ${loginRes.status}: ${JSON.stringify(loginRes.body)}`);
+  }
+  const idpUrl = new URL((loginRes.body as { location: string }).location);
+  const samlRequest = idpUrl.searchParams.get("SAMLRequest");
+  const relayState = idpUrl.searchParams.get("RelayState") ?? "";
+  if (!samlRequest) throw new Error("No SAMLRequest in IdP URL");
+
+  // Step 2: POST to mock IdP /login endpoint with the form fields it expects.
+  const idpLoginRes = await niceFetch(`${MOCK_SAML_BASE}/idp/${options.tenantSlug}/login`, {
+    method: "POST",
+    body: new URLSearchParams({
+      SAMLRequest: samlRequest,
+      RelayState: relayState,
+      email: options.email,
+      displayName: options.displayName ?? options.email.split("@")[0],
+    }),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  });
+  if (idpLoginRes.status !== 200) {
+    throw new Error(`Mock IdP /login returned ${idpLoginRes.status}: ${idpLoginRes.body}`);
+  }
+
+  // Step 3: extract SAMLResponse from the auto-POST HTML.
+  const html = idpLoginRes.body as string;
+  const samlResponseMatch = html.match(/name="SAMLResponse" value="([^"]+)"/);
+  if (!samlResponseMatch) throw new Error(`Mock IdP did not return a SAMLResponse form: ${html.slice(0, 200)}`);
+  const samlResponse = samlResponseMatch[1].replace(/&#x2F;/g, "/").replace(/&#x3D;/g, "=").replace(/&amp;/g, "&");
+
+  // Step 4: POST to ACS.
+  const acsRes = await niceBackendFetch(`/api/v1/auth/saml/acs/${options.connectionId}`, {
+    method: "POST",
+    redirect: "manual",
+    body: new URLSearchParams({
+      SAMLResponse: samlResponse,
+      RelayState: relayState,
+    }),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  });
+
+  return { loginRes, acsRes, samlResponse, relayState };
+}
+
+async function setMisbehavior(tenantSlug: string, body: Record<string, unknown>) {
+  await niceFetch(`${MOCK_SAML_BASE}/idp/${tenantSlug}/test-controls`, {
+    method: "POST",
+    body: JSON.stringify(body),
+    headers: { "content-type": "application/json" },
+  });
+}
+
+// ---------- tests ----------
+
+it("full SP-initiated round trip: new user JIT-created", async ({ expect }) => {
+  await setupProjectWithMockSamlConnection("acme", "acme");
+  const { acsRes } = await runSamlRoundTrip({
+    connectionId: "acme",
+    tenantSlug: "acme",
+    email: "alice@acme.test",
+    displayName: "Alice",
+  });
+  // Successful ACS issues an OAuth code via oauthServer.authorize and
+  // responds with a 303 redirect (or 307) to the customer's callback URL.
+  expect([303, 307]).toContain(acsRes.status);
+  const location = acsRes.headers.get("location");
+  expect(location).toBeTruthy();
+  const callbackUrl = new URL(location!);
+  // Should contain an OAuth `code` query param.
+  expect(callbackUrl.searchParams.get("code")).toBeTruthy();
+});
+
+it("rejects an assertion with the wrong audience", async ({ expect }) => {
+  await setupProjectWithMockSamlConnection("acme", "acme");
+  await setMisbehavior("acme", { kind: "wrong-audience" });
+  const { acsRes } = await runSamlRoundTrip({
+    connectionId: "acme",
+    tenantSlug: "acme",
+    email: "alice@acme.test",
+  });
+  // Audience mismatch must reject — no redirect to customer app with code.
+  expect(acsRes.status).not.toBe(303);
+  expect(acsRes.status).not.toBe(307);
+  expect(acsRes.status).toBeGreaterThanOrEqual(400);
+});
+
+it("rejects an assertion signed by a different tenant (cross-connection forgery)", async ({ expect }) => {
+  // Configure project with acme connection (acme's cert), but mock will
+  // sign the assertion with globex's key. Backend must reject because the
+  // signature won't verify against the configured cert.
+  await setupProjectWithMockSamlConnection("acme", "acme");
+  await setMisbehavior("acme", { kind: "bad-signature" });
+  const { acsRes } = await runSamlRoundTrip({
+    connectionId: "acme",
+    tenantSlug: "acme",
+    email: "alice@acme.test",
+  });
+  expect(acsRes.status).not.toBe(303);
+  expect(acsRes.status).not.toBe(307);
+  expect(acsRes.status).toBeGreaterThanOrEqual(400);
+});
+
+it("rejects an expired assertion", async ({ expect }) => {
+  await setupProjectWithMockSamlConnection("acme", "acme");
+  await setMisbehavior("acme", { kind: "expired" });
+  const { acsRes } = await runSamlRoundTrip({
+    connectionId: "acme",
+    tenantSlug: "acme",
+    email: "alice@acme.test",
+  });
+  expect(acsRes.status).not.toBe(303);
+  expect(acsRes.status).not.toBe(307);
+  expect(acsRes.status).toBeGreaterThanOrEqual(400);
+});
+
+it("rejects replay of a previously-consumed assertion", async ({ expect }) => {
+  await setupProjectWithMockSamlConnection("acme", "acme");
+  // First round trip completes successfully and consumes the OuterInfo.
+  const first = await runSamlRoundTrip({
+    connectionId: "acme",
+    tenantSlug: "acme",
+    email: "alice@acme.test",
+  });
+  expect([303, 307]).toContain(first.acsRes.status);
+
+  // Replay the same SAMLResponse — backend should reject because the
+  // SamlOuterInfo row was deleted at the end of the first ACS call, so
+  // the InResponseTo lookup misses.
+  const replayRes = await niceBackendFetch(`/api/v1/auth/saml/acs/acme`, {
+    method: "POST",
+    redirect: "manual",
+    body: new URLSearchParams({
+      SAMLResponse: first.samlResponse,
+      RelayState: first.relayState,
+    }),
+    headers: { "content-type": "application/x-www-form-urlencoded" },
+  });
+  expect(replayRes.status).not.toBe(303);
+  expect(replayRes.status).not.toBe(307);
+  expect(replayRes.status).toBeGreaterThanOrEqual(400);
+});

--- a/apps/e2e/tests/backend/endpoints/api/v1/saml-connections.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/saml-connections.test.ts
@@ -1,0 +1,85 @@
+import { it } from "../../../../helpers";
+import { Project, niceBackendFetch } from "../../../backend-helpers";
+
+/**
+ * Tests for the admin /saml-connections CRUD endpoints.
+ *
+ * Regression target: a previous version wrote per-field deep dot-keys
+ * (`auth.saml.connections.X.displayName`, ...) which were silently
+ * dropped during config normalization when the parent record entry
+ * didn't yet exist. POST returned 200 with the right body but persisted
+ * nothing — the bug was only caught manually because the dashboard's
+ * SSO page-client uses a different write path.
+ */
+
+async function setupProjectWithSamlAppEnabled() {
+  await Project.createAndSwitch();
+  await Project.updateConfig({
+    "apps.installed.saml-sso": { enabled: true },
+  });
+}
+
+it("POST /saml-connections persists the connection and GET returns it", async ({ expect }) => {
+  await setupProjectWithSamlAppEnabled();
+
+  const createRes = await niceBackendFetch("/api/v1/saml-connections", {
+    method: "POST",
+    accessType: "admin",
+    body: {
+      id: "acme",
+      display_name: "Acme SSO",
+      allow_sign_in: true,
+      domain: "acme.test",
+      idp_entity_id: "https://idp.acme.test/saml/metadata",
+      idp_sso_url: "https://idp.acme.test/saml/sso",
+      idp_certificate: "MIICertificatePlaceholderForCrudPersistTest=",
+    },
+  });
+  expect(createRes.status).toBe(200);
+
+  const listRes = await niceBackendFetch("/api/v1/saml-connections", {
+    method: "GET",
+    accessType: "admin",
+  });
+  expect(listRes.status).toBe(200);
+  const items = (listRes.body as { items: Array<Record<string, unknown>> }).items;
+  expect(items).toHaveLength(1);
+  expect(items[0]).toMatchObject({
+    id: "acme",
+    display_name: "Acme SSO",
+    allow_sign_in: true,
+    domain: "acme.test",
+    idp_entity_id: "https://idp.acme.test/saml/metadata",
+    idp_sso_url: "https://idp.acme.test/saml/sso",
+    has_idp_certificate: true,
+  });
+
+  // Single-connection GET returns the cert too.
+  const getRes = await niceBackendFetch("/api/v1/saml-connections/acme", {
+    method: "GET",
+    accessType: "admin",
+  });
+  expect(getRes.status).toBe(200);
+  expect((getRes.body as { idp_certificate: string }).idp_certificate)
+    .toBe("MIICertificatePlaceholderForCrudPersistTest=");
+});
+
+it("POST /saml-connections returns SAML_SSO_NOT_ENABLED when the app is uninstalled", async ({ expect }) => {
+  await Project.createAndSwitch();
+  // Note: not enabling apps.installed.saml-sso.
+
+  const res = await niceBackendFetch("/api/v1/saml-connections", {
+    method: "POST",
+    accessType: "admin",
+    body: {
+      id: "acme",
+      display_name: "Acme SSO",
+      allow_sign_in: true,
+      idp_entity_id: "https://idp.acme.test/saml/metadata",
+      idp_sso_url: "https://idp.acme.test/saml/sso",
+      idp_certificate: "MIICertificatePlaceholderForGateTest=",
+    },
+  });
+  expect(res.status).toBe(400);
+  expect((res.body as { code?: string }).code).toBe("SAML_SSO_NOT_ENABLED");
+});

--- a/docs/src/components/mdx/app-card.tsx
+++ b/docs/src/components/mdx/app-card.tsx
@@ -2,7 +2,7 @@
 
 import { ALL_APPS, AppId } from "@stackframe/stack-shared/dist/apps/apps-config";
 import { AppIcon, appSquarePaddingExpression, appSquareWidthExpression } from "@stackframe/stack-shared/dist/apps/apps-ui";
-import { BarChart3, ClipboardList, CreditCard, KeyRound, Mail, Mails, Rocket, ShieldCheck, ShieldEllipsis, Sparkles, Triangle, Tv, UserCog, Users, Vault, Webhook } from "lucide-react";
+import { BarChart3, Building2, ClipboardList, CreditCard, KeyRound, Mail, Mails, Rocket, ShieldCheck, ShieldEllipsis, Sparkles, Triangle, Tv, UserCog, Users, Vault, Webhook } from "lucide-react";
 import Link from "next/link";
 import { cn } from "../../lib/cn";
 
@@ -17,6 +17,7 @@ const APP_ICONS: Record<AppId, React.FunctionComponent<React.SVGProps<SVGSVGElem
   authentication: ShieldEllipsis,
   teams: Users,
   rbac: UserCog,
+  "saml-sso": Building2,
   "api-keys": KeyRound,
   payments: CreditCard,
   emails: Mail,

--- a/examples/demo/src/app/saml-demo/page.tsx
+++ b/examples/demo/src/app/saml-demo/page.tsx
@@ -1,0 +1,146 @@
+'use client';
+
+import { useStackApp, useUser } from "@stackframe/stack";
+import { runAsynchronouslyWithAlert } from "@stackframe/stack-shared/dist/utils/promises";
+import { Button, Card, CardContent, CardHeader, Input, Typography } from "@stackframe/stack-ui";
+import { useState } from "react";
+
+export default function SamlDemoPage() {
+  const app = useStackApp() as ReturnType<typeof useStackApp> & {
+    signInWithSaml: (options: { connectionId: string, returnTo?: string }) => Promise<void>,
+    signInWithSso: (options: { email: string, returnTo?: string }) => Promise<void>,
+    getSamlConnectionForEmail: (email: string) => Promise<{ connectionId: string, displayName: string } | null>,
+  };
+  const user = useUser();
+  const [email, setEmail] = useState("");
+  const [discoveryResult, setDiscoveryResult] = useState<{ connectionId: string, displayName: string } | null | "error" | undefined>(undefined);
+
+  return (
+    <div className="container mx-auto p-6 max-w-3xl">
+      <Typography type="h1" className="mb-2">SAML SSO Demo</Typography>
+      <Typography className="mb-6 text-gray-600">
+        Manual end-to-end check for the SAML round-trip against the local mock IdP. Seed the dummy
+        project with <code>STACK_SEED_ENABLE_SAML=true</code> first; that pre-creates two
+        connections (acme + globex) pointing at <code>localhost:8115</code>.
+      </Typography>
+
+      <div className="grid gap-6">
+        <Card>
+          <CardHeader><Typography type="h3">Current state</Typography></CardHeader>
+          <CardContent>
+            <div className="space-y-1 text-sm">
+              <div><span className="font-semibold">Signed in:</span> {user ? "yes" : "no"}</div>
+              {user && (
+                <>
+                  <div><span className="font-semibold">User ID:</span> <code>{user.id}</code></div>
+                  <div><span className="font-semibold">Email:</span> <code>{user.primaryEmail ?? "(none)"}</code></div>
+                  <div><span className="font-semibold">Display name:</span> <code>{user.displayName ?? "(none)"}</code></div>
+                </>
+              )}
+            </div>
+            {user && (
+              <Button
+                className="mt-3"
+                variant="secondary"
+                onClick={() => runAsynchronouslyWithAlert(async () => {
+                  await user.signOut({ redirectUrl: "/saml-demo" });
+                })}
+              >
+                Sign out
+              </Button>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><Typography type="h3">1. Sign in by email-domain discovery</Typography></CardHeader>
+          <CardContent>
+            <Typography className="mb-2 text-sm text-gray-600">
+              Enter <code>alice@acme.test</code> or <code>bob@globex.test</code>. The SDK looks up
+              the matching SAML connection via <code>/auth/saml/discover</code>, then redirects.
+            </Typography>
+            <div className="flex gap-2 items-center mb-2">
+              <Input
+                type="email"
+                placeholder="alice@acme.test"
+                value={email}
+                onChange={(e) => setEmail(e.target.value)}
+              />
+              <Button
+                variant="outline"
+                onClick={() => runAsynchronouslyWithAlert(async () => {
+                  setDiscoveryResult(undefined);
+                  try {
+                    const result = await app.getSamlConnectionForEmail(email);
+                    setDiscoveryResult(result);
+                  } catch (e) {
+                    setDiscoveryResult("error");
+                  }
+                })}
+              >
+                Preview connection
+              </Button>
+              <Button
+                onClick={() => runAsynchronouslyWithAlert(async () => {
+                  await app.signInWithSso({ email, returnTo: "/saml-demo" });
+                })}
+              >
+                Sign in via SSO
+              </Button>
+            </div>
+            {discoveryResult === "error" && (
+              <Typography className="text-sm text-red-600">No SAML connection matches this domain.</Typography>
+            )}
+            {discoveryResult && discoveryResult !== "error" && (
+              <Typography className="text-sm">
+                Matched: <code>{discoveryResult.connectionId}</code> ({discoveryResult.displayName})
+              </Typography>
+            )}
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><Typography type="h3">2. Sign in by direct connection ID</Typography></CardHeader>
+          <CardContent>
+            <Typography className="mb-2 text-sm text-gray-600">
+              For when the customer&apos;s UI has explicit per-tenant buttons rather than a unified
+              email field.
+            </Typography>
+            <div className="flex flex-wrap gap-2">
+              <Button
+                onClick={() => runAsynchronouslyWithAlert(async () => {
+                  await app.signInWithSaml({ connectionId: "acme", returnTo: "/saml-demo" });
+                })}
+              >
+                Sign in with Acme SSO
+              </Button>
+              <Button
+                variant="outline"
+                onClick={() => runAsynchronouslyWithAlert(async () => {
+                  await app.signInWithSaml({ connectionId: "globex", returnTo: "/saml-demo" });
+                })}
+              >
+                Sign in with Globex SAML
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+
+        <Card>
+          <CardHeader><Typography type="h3">SDK snippet</Typography></CardHeader>
+          <CardContent>
+            <pre className="text-xs bg-gray-100 dark:bg-gray-800 p-3 rounded overflow-x-auto">{`// Email-domain discovery (preferred for unified login forms)
+await app.signInWithSso({ email: "alice@acme.test", returnTo: "/" });
+
+// Direct connection ID (when you render per-tenant buttons)
+await app.signInWithSaml({ connectionId: "acme", returnTo: "/" });
+
+// Just preview the matching connection without redirecting:
+const conn = await app.getSamlConnectionForEmail("alice@acme.test");
+// → { connectionId: "acme", displayName: "Acme Corp SSO" }`}</pre>
+          </CardContent>
+        </Card>
+      </div>
+    </div>
+  );
+}

--- a/examples/demo/src/app/saml-demo/page.tsx
+++ b/examples/demo/src/app/saml-demo/page.tsx
@@ -21,7 +21,7 @@ export default function SamlDemoPage() {
       <Typography className="mb-6 text-gray-600">
         Manual end-to-end check for the SAML round-trip against the local mock IdP. Seed the dummy
         project with <code>STACK_SEED_ENABLE_SAML=true</code> first; that pre-creates two
-        connections (acme + globex) pointing at <code>localhost:8115</code>.
+        connections (acme + globex) pointing at <code>localhost:8142</code>.
       </Typography>
 
       <div className="grid gap-6">

--- a/packages/stack-shared/src/apps/apps-config.ts
+++ b/packages/stack-shared/src/apps/apps-config.ts
@@ -78,6 +78,12 @@ export const ALL_APPS = {
     tags: ["auth", "security"],
     stage: "stable",
   },
+  "saml-sso": {
+    displayName: "SAML SSO",
+    subtitle: "Sign-in via corporate SAML 2.0 identity providers",
+    tags: ["auth", "security", "expert"],
+    stage: "alpha",
+  },
   "api-keys": {
     displayName: "API Keys",
     subtitle: "API key generation and management",

--- a/packages/stack-shared/src/interface/client-interface.ts
+++ b/packages/stack-shared/src/interface/client-interface.ts
@@ -1422,6 +1422,112 @@ export class StackClientInterface {
     return Result.ok(location);
   }
 
+  /**
+   * Build the URL the SDK redirects to for SAML SSO. Mirrors getOAuthUrl
+   * but without provider_scope / bot challenge — SAML sign-in is initiated
+   * from a corporate IdP, not a public form.
+   */
+  async getSamlUrl(
+    options: {
+      connectionId: string,
+      redirectUrl: string,
+      errorRedirectUrl: string,
+      afterCallbackRedirectUrl?: string,
+      codeChallenge: string,
+      state: string,
+    }
+  ): Promise<string> {
+    const updatedRedirectUrl = new URL(options.redirectUrl);
+    for (const key of ["code", "state"]) {
+      if (updatedRedirectUrl.searchParams.has(key)) {
+        updatedRedirectUrl.searchParams.delete(key);
+      }
+    }
+    if ("projectOwnerSession" in this.options) {
+      throw new Error("Admin session token is currently not supported for SAML");
+    }
+    const clientSecret = this.options.publishableClientKey ?? publishableClientKeyNotNecessarySentinel;
+    const url = new URL(this.getBestApiUrl() + "/auth/saml/login/" + encodeURIComponent(options.connectionId));
+    url.searchParams.set("client_id", this.projectId);
+    url.searchParams.set("client_secret", clientSecret);
+    url.searchParams.set("redirect_uri", updatedRedirectUrl.toString());
+    url.searchParams.set("scope", "legacy");
+    url.searchParams.set("state", options.state);
+    url.searchParams.set("grant_type", "authorization_code");
+    url.searchParams.set("code_challenge", options.codeChallenge);
+    url.searchParams.set("code_challenge_method", "S256");
+    url.searchParams.set("response_type", "code");
+    url.searchParams.set("error_redirect_uri", options.errorRedirectUrl);
+    if (options.afterCallbackRedirectUrl) {
+      url.searchParams.set("after_callback_redirect_url", options.afterCallbackRedirectUrl);
+    }
+    return url.toString();
+  }
+
+  async authorizeSaml(options: {
+    connectionId: string,
+    redirectUrl: string,
+    errorRedirectUrl: string,
+    afterCallbackRedirectUrl?: string,
+    codeChallenge: string,
+    state: string,
+  }): Promise<string> {
+    if (typeof window === "undefined") {
+      throw new StackAssertionError("authorizeSaml can currently only be called in a browser environment");
+    }
+    await this.options.prepareRequest?.();
+    const url = new URL(await this.getSamlUrl(options));
+    url.searchParams.set("stack_response_mode", "json");
+
+    const rawRes = await fetch(url, { method: "GET" });
+    const processedResponse = await this._processResponse(rawRes);
+    if (processedResponse.status === "error") {
+      throw processedResponse.error;
+    }
+    if (processedResponse.data.status !== 200) {
+      throw new StackAssertionError(`SAML authorize returned an unexpected status: ${processedResponse.data.status}`);
+    }
+    const body = await processedResponse.data.json();
+    if (body == null || typeof body !== "object" || Array.isArray(body)) {
+      throw new StackAssertionError("SAML authorize response body must be an object", { body });
+    }
+    const location = body.location;
+    if (typeof location !== "string") {
+      throw new StackAssertionError("SAML authorize response is missing a redirect location", { body });
+    }
+    return location;
+  }
+
+  /**
+   * Looks up the SAML connection matching an email's domain. Returns null
+   * when no connection matches, so callers can fall back to other sign-in
+   * methods.
+   */
+  async discoverSamlConnection(email: string): Promise<{ connectionId: string, displayName: string } | null> {
+    const url = new URL(this.getBestApiUrl() + "/auth/saml/discover");
+    url.searchParams.set("email", email);
+    url.searchParams.set("project_id", this.projectId);
+    const rawRes = await fetch(url, { method: "GET" });
+    if (rawRes.status === 404) {
+      return null;
+    }
+    const processedResponse = await this._processResponse(rawRes);
+    if (processedResponse.status === "error") {
+      throw processedResponse.error;
+    }
+    if (processedResponse.data.status !== 200) {
+      throw new StackAssertionError(`SAML discover returned an unexpected status: ${processedResponse.data.status}`);
+    }
+    const body = await processedResponse.data.json();
+    if (body == null || typeof body !== "object" || Array.isArray(body)) {
+      throw new StackAssertionError("SAML discover response body must be an object", { body });
+    }
+    return {
+      connectionId: String(body.connection_id),
+      displayName: String(body.display_name),
+    };
+  }
+
   async callOAuthCallback(options: {
     oauthParams: URLSearchParams,
     redirectUri: string,

--- a/packages/stack-shared/src/known-errors.tsx
+++ b/packages/stack-shared/src/known-errors.tsx
@@ -1828,6 +1828,16 @@ const AnalyticsNotEnabled = createKnownErrorConstructor(
   () => [] as const,
 );
 
+const SamlSsoNotEnabled = createKnownErrorConstructor(
+  KnownError,
+  "SAML_SSO_NOT_ENABLED",
+  () => [
+    400,
+    "SAML SSO is not enabled for this project.",
+  ] as const,
+  () => [] as const,
+);
+
 const DefaultPaymentMethodRequired = createKnownErrorConstructor(
   KnownError,
   "DEFAULT_PAYMENT_METHOD_REQUIRED",
@@ -2000,6 +2010,7 @@ export const KnownErrors = {
   AnalyticsQueryTimeout,
   AnalyticsQueryError,
   AnalyticsNotEnabled,
+  SamlSsoNotEnabled,
 } satisfies Record<string, KnownErrorConstructor<any, any>>;
 
 

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -2895,6 +2895,9 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
     email: string,
     returnTo?: string,
   }) {
+    if (typeof window === "undefined") {
+      throw new Error("signInWithSso can currently only be called in a browser environment");
+    }
     const connection = await this._interface.discoverSamlConnection(options.email);
     if (!connection) {
       throw new Error(`No SSO connection configured for email domain "${options.email.split("@").pop()}"`);

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -2866,6 +2866,9 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
     if (typeof window === "undefined") {
       throw new Error("signInWithSaml can currently only be called in a browser environment");
     }
+    if (this._redirectMethod === "none") {
+      throw new Error("signInWithSaml requires a redirectMethod that performs navigation; got 'none'");
+    }
     this._ensurePersistentTokenStore();
     const currentUrl = new URL(window.location.href);
     const afterCallbackRedirectUrl = options.returnTo != null

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -2855,6 +2855,63 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
   }
 
   /**
+   * Sign in via a configured SAML connection (SP-initiated flow).
+   * Mirrors signInWithOAuth — redirects to /auth/saml/login/[connectionId],
+   * which round-trips through the customer's IdP and back via ACS.
+   */
+  async signInWithSaml(options: {
+    connectionId: string,
+    returnTo?: string,
+  }) {
+    if (typeof window === "undefined") {
+      throw new Error("signInWithSaml can currently only be called in a browser environment");
+    }
+    this._ensurePersistentTokenStore();
+    const currentUrl = new URL(window.location.href);
+    const afterCallbackRedirectUrl = options.returnTo != null
+      ? constructRedirectUrl(options.returnTo, "returnTo")
+      : (currentUrl.searchParams.has("after_auth_return_to") ? currentUrl.toString() : undefined);
+    const { codeChallenge, state } = await saveVerifierAndState();
+
+    const location = await this._interface.authorizeSaml({
+      connectionId: options.connectionId,
+      redirectUrl: constructRedirectUrl(this.urls.oauthCallback, "redirectUrl"),
+      errorRedirectUrl: constructRedirectUrl(this.urls.error, "errorRedirectUrl"),
+      afterCallbackRedirectUrl,
+      codeChallenge,
+      state,
+    });
+    await this._redirectTo({ url: location });
+    await neverResolve();
+  }
+
+  /**
+   * Sign in via SSO discovered by email domain. Looks up the SAML
+   * connection whose `domain` matches the email, then redirects through
+   * SAML. Throws if no matching connection — callers can catch and fall
+   * back to other sign-in methods.
+   */
+  async signInWithSso(options: {
+    email: string,
+    returnTo?: string,
+  }) {
+    const connection = await this._interface.discoverSamlConnection(options.email);
+    if (!connection) {
+      throw new Error(`No SSO connection configured for email domain "${options.email.split("@").pop()}"`);
+    }
+    return await this.signInWithSaml({ connectionId: connection.connectionId, returnTo: options.returnTo });
+  }
+
+  /**
+   * Look up the SAML connection matching an email's domain without
+   * initiating sign-in. The customer's UI can use this to render
+   * branding (e.g. "Sign in with Acme SSO") before the user clicks.
+   */
+  async getSamlConnectionForEmail(email: string): Promise<{ connectionId: string, displayName: string } | null> {
+    return await this._interface.discoverSamlConnection(email);
+  }
+
+  /**
    * Handles MFA verification by redirecting to the OTP page
    */
   protected async _experimentalMfa(error: KnownErrors['MultiFactorAuthenticationRequired'], session: InternalSession): Promise<never> {

--- a/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
@@ -60,6 +60,9 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
     readonly urls: Readonly<ResolvedHandlerUrls>,
 
     signInWithOAuth(provider: string, options?: { returnTo?: string }): Promise<void>,
+    signInWithSaml(options: { connectionId: string, returnTo?: string }): Promise<void>,
+    signInWithSso(options: { email: string, returnTo?: string }): Promise<void>,
+    getSamlConnectionForEmail(email: string): Promise<{ connectionId: string, displayName: string } | null>,
     signInWithCredential(options: { email: string, password: string, noRedirect?: boolean }): Promise<Result<undefined, KnownErrors["EmailPasswordMismatch"] | KnownErrors["InvalidTotpCode"]>>,
     signUpWithCredential(options: {
       email: string,


### PR DESCRIPTION
Third of 3 stacked PRs adding SAML 2.0 SSO. **Stacked on:** #1396 (backend) → #1395 (mock IdP).

> Note: target branch is `pr/saml-backend`. Will be retargeted to `dev` once #1396 merges.

## Screenshots

The dashboard SSO management page is brand new — there's no \"before\" page to compare to. The screenshots below show the page in its three meaningful states (empty, mid-create, after-add) plus dark mode and the delete confirmation.

### 1. Empty state — no connections configured yet

<img src="https://raw.githubusercontent.com/stack-auth/stack-auth/assets/saml-screenshots-pr-1397/01-empty-state.png" alt="SAML SSO page: empty state" width="900">

### 2. \"Add SAML connection\" dialog (clean, before fill)

<img src="https://raw.githubusercontent.com/stack-auth/stack-auth/assets/saml-screenshots-pr-1397/02-add-dialog.png" alt="Add SAML connection dialog" width="900">

### 3. After adding an Acme connection — surfaces SP metadata URL + ACS URL for the IdP admin to copy

<img src="https://raw.githubusercontent.com/stack-auth/stack-auth/assets/saml-screenshots-pr-1397/03-with-connection.png" alt="SAML SSO page with one connection" width="900">

### 4. Same in dark mode

<img src="https://raw.githubusercontent.com/stack-auth/stack-auth/assets/saml-screenshots-pr-1397/04-with-connection-dark.png" alt="SAML SSO page with one connection (dark mode)" width="900">

### 5. Delete confirmation — warns that linked user accounts remain in the DB

<img src="https://raw.githubusercontent.com/stack-auth/stack-auth/assets/saml-screenshots-pr-1397/05-delete-dialog.png" alt="Delete SAML connection confirmation" width="900">

> Two small dashboard fixes were caught while taking these screenshots and shipped in commit `fe8197ca8`:
> - Removed `yup.string().url()` from the IdP SSO URL field — it rejects `http://localhost` which broke the dev/test setup. Backend SAML wrapper validates the URL on use.
> - Switched `updateConfig({ pushable: true → false })` because SAML connection fields (cert, IdP URLs) live at the environment level, not the branch level that's pushed to GitHub. Same convention as the auth-methods page does for OAuth client secrets.

---

## What this PR adds

The user-facing surface and verification for the backend SAML feature in #1396.

### Client SDK

`packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts` adds three methods on `StackClientApp`:

- **`signInWithSaml({ connectionId, returnTo })`** — explicit connection selection. Mirrors `signInWithOAuth`.
- **`signInWithSso({ email, returnTo })`** — email-domain discovery via `/auth/saml/discover`, then redirects through the matched connection. Throws if no connection matches so callers can fall back.
- **`getSamlConnectionForEmail(email)`** — pure lookup (no redirect) so the customer's UI can show \"Sign in with Acme SSO\" branding before the user clicks.

Backed by `getSamlUrl` + `authorizeSaml` + `discoverSamlConnection` on `StackClientInterface` (mirrors `getOAuthUrl` + `authorizeOAuth`, without provider_scope or bot challenge — SAML originates from a corporate IdP, not a public form). Generated via `pnpm -w run generate-sdks`; propagates from `packages/template` into `packages/js`, `packages/react`, `packages/stack`.

### Dashboard

`apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sso/` — single page for managing SAML connections on the current project. Reads from `project.useConfig()` (same source as the e2e tests + seed script), writes via `useUpdateConfig`. PEM headers stripped from cert input automatically. Each connection card surfaces SP metadata URL + ACS URL for the customer's IT admin to copy.

V1 limitations (planned follow-ups):
- Edit by delete-and-recreate — no in-place edit dialog yet
- No \"paste IdP metadata XML\" auto-fill (the backend metadata-parser is ready; needs UI wiring)
- No separate detail page
- No sidebar nav link yet — page is reachable by direct URL only (`/projects/<id>/sso`)

### Demo

`examples/demo/src/app/saml-demo/page.tsx` — exercises both SDK flows:
1. Email-domain discovery: enter `alice@acme.test`, click \"Sign in via SSO\"
2. Direct connection ID: per-tenant buttons calling `signInWithSaml({ connectionId })`

Pairs with the seed-dummy-data block from #1395 (gated on `STACK_SEED_ENABLE_SAML=true`).

### E2E tests — 18 tests across 4 files, all passing

`apps/e2e/tests/backend/endpoints/api/v1/auth/saml/`:

| File | Cases |
|---|---|
| `discover.test.ts` | happy path, 404, case-insensitivity, unknown project, cross-project isolation (5) |
| `metadata.test.ts` | XML contains entityID + ACS URL, 404, 404 on incomplete config (3) |
| `login.test.ts` | JSON mode + browser-redirect mode + CSRF cookie + 404 + 403 + invalid client (5) |
| `round-trip.test.ts` | full SP-initiated flow against mock IdP: JIT user creation + wrong-audience + bad-signature (cross-tenant forgery) + expired + replay (5) |

#### Test integrity self-check (verified)

- `grep -r \"from.*backend/src/saml\" apps/e2e/tests/` → 0 matches (tests don't import backend internals)
- Mock IdP uses `samlify`, backend uses `@node-saml/node-saml` — different libraries, so signature/canonicalization bugs would surface as failures rather than canceling out
- Negative cases come from the mock deliberately misbehaving via `/test-controls`, never from injecting bad data into the backend's own validator

## Test plan

- [x] `pnpm --filter @stackframe/template typecheck` + `lint` pass
- [x] `pnpm -w run generate-sdks` runs cleanly; new methods appear in packages/js, packages/react, packages/stack
- [x] `pnpm --filter @stackframe/example-demo-app typecheck` + `lint` pass
- [x] `pnpm --filter @stackframe/dashboard typecheck` + `lint` pass
- [x] All 18 SAML e2e tests pass against live backend + mock IdP locally
- [x] Dashboard SSO page manually exercised against the running dev server (screenshots above)