### PR TITLE
fix(oauth): stop forcing prompt=consent on non-Google providers

### DIFF
--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -204,8 +204,6 @@ export abstract class OAuthBaseProvider {
       }),
       state: options.state,
       response_type: "code",
-      access_type: "offline",
-      prompt: "consent",
       ...this.authorizationExtraParams,
     });
   }

--- a/apps/backend/src/oauth/providers/google.tsx
+++ b/apps/backend/src/oauth/providers/google.tsx
@@ -24,6 +24,7 @@ export class GoogleProvider extends OAuthBaseProvider {
       baseScope: "https://www.googleapis.com/auth/userinfo.email https://www.googleapis.com/auth/userinfo.profile",
       authorizationExtraParams: {
         prompt: "consent",
+        access_type: "offline",
         include_granted_scopes: "true",
       },
       ...options,

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/authorize.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/authorize.test.ts
@@ -44,7 +44,7 @@ it("should redirect the user to the OAuth provider with the right arguments even
   expect(response.authorizeResponse.status).toBe(307);
   const secondLocation = response.authorizeResponse.headers.get("location");
   expect(secondLocation).toBeTruthy();
-  expect(secondLocation).toMatchInlineSnapshot(`"http://localhost:<$NEXT_PUBLIC_STACK_PORT_PREFIX>14/auth?client_id=spotify&scope=openid+offline_access&response_type=code&redirect_uri=%3Cstripped+query+param%3E&code_challenge_method=S256&code_challenge=%3Cstripped+query+param%3E&state=%3Cstripped+query+param%3E&access_type=offline&prompt=consent"`);
+  expect(secondLocation).toMatchInlineSnapshot(`"http://localhost:<$NEXT_PUBLIC_STACK_PORT_PREFIX>14/auth?client_id=spotify&scope=openid+offline_access&response_type=code&redirect_uri=%3Cstripped+query+param%3E&code_challenge_method=S256&code_challenge=%3Cstripped+query+param%3E&state=%3Cstripped+query+param%3E"`);
   expect(response.authorizeResponse.headers.get("set-cookie")).toMatch(/^stack-oauth-inner-[^;]+=[^;]+; Path=\/; Expires=[^;]+; Max-Age=\d+;( Secure;)? HttpOnly$/);
 });
 
@@ -59,7 +59,7 @@ it("should return the OAuth location as JSON when requested by the SDK flow", as
   expect(response).toMatchInlineSnapshot(`
     NiceResponse {
       "status": 200,
-      "body": { "location": "http://localhost:<$NEXT_PUBLIC_STACK_PORT_PREFIX>14/auth?client_id=spotify&scope=openid+offline_access&response_type=code&redirect_uri=%3Cstripped+query+param%3E&code_challenge_method=S256&code_challenge=%3Cstripped+query+param%3E&state=%3Cstripped+query+param%3E&access_type=offline&prompt=consent" },
+      "body": { "location": "http://localhost:<$NEXT_PUBLIC_STACK_PORT_PREFIX>14/auth?client_id=spotify&scope=openid+offline_access&response_type=code&redirect_uri=%3Cstripped+query+param%3E&code_challenge_method=S256&code_challenge=%3Cstripped+query+param%3E&state=%3Cstripped+query+param%3E" },
       "headers": Headers { <some fields may have been hidden> },
     }
   `);


### PR DESCRIPTION
The base OAuth provider hardcoded `prompt=consent` and `access_type=offline` on every authorize URL. Both are Google-specific:

- `prompt=consent` caused GitHub, Microsoft, Discord, GitLab, Apple, and X to re-show their authorization screen on **every** sign-in instead of only on first authorization or scope change.
- `access_type=offline` is a Google-only param that was silently ignored by every other provider.

This PR moves both params into Google's `authorizationExtraParams` so Google's behavior is unchanged (refresh token still reliably issued via `prompt=consent` + `access_type=offline`). Other providers now follow standard OAuth behavior: consent shown only on first authorization, new scopes, or after the user revokes the grant on the provider side.

### Behavioral change per provider

| Provider | Before | After |
|---|---|---|
| GitHub, Microsoft, Discord, GitLab, Apple, X | Consent every sign-in | Consent only on first auth / new scope / after revoke |
| Spotify, Twitch, Facebook, LinkedIn, Bitbucket | Param ignored | Param ignored (no change) |
| Google | `prompt=consent` + `access_type=offline` | Same — moved into Google's own params |

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed OAuth authorization flow to use provider-specific parameter configurations instead of applying parameters globally, improving compatibility across different OAuth providers and ensuring proper authorization handling for each provider.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->