### PR TITLE
fix: wait for stack/stack-shared builds before generate-openapi-docs:watch

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
     "generate-sdks": "pnpm exec tsx ./scripts/generate-sdks.ts",
     "generate-setup-prompt-docs": "pnpm exec tsx ./scripts/generate-setup-prompt-docs.ts",
     "generate-sdks:watch": "chokidar --silent -c 'pnpm run generate-sdks' './packages/template' --ignore './packages/template/package.json' --ignore '**/node_modules/**' --ignore '**/dist/**' --ignore '**/.turbo/**' --throttle 2000",
-    "generate-openapi-docs:watch": "pnpm run --filter=@stackframe/backend codegen-docs && chokidar --silent -c 'pnpm run --filter=@stackframe/backend codegen-docs' './apps/backend/src/app/api/latest/**/route.{js,jsx,ts,tsx}' './apps/backend/src/lib/openapi.ts' './packages/stack-shared/src/interface/webhooks.ts' --throttle 2000",
+    "generate-openapi-docs:watch": "wait-on packages/stack/dist/esm/index.js packages/stack-shared/dist/esm/index.js && pnpm run --filter=@stackframe/backend codegen-docs && chokidar --silent -c 'pnpm run --filter=@stackframe/backend codegen-docs' './apps/backend/src/app/api/latest/**/route.{js,jsx,ts,tsx}' './apps/backend/src/lib/openapi.ts' './packages/stack-shared/src/interface/webhooks.ts' --throttle 2000",
     "generate-setup-prompt-docs:watch": "pnpm run generate-setup-prompt-docs && chokidar --silent -c 'pnpm run generate-setup-prompt-docs' './packages/stack-shared/src/ai/prompts.ts' './scripts/generate-setup-prompt-docs.ts' --throttle 2000"
   },
   "devDependencies": {


### PR DESCRIPTION
## Summary
- `generate-openapi-docs:watch` now waits for `packages/stack/dist/esm/index.js` and `packages/stack-shared/dist/esm/index.js` via `wait-on` before kicking off `codegen-docs`, preventing a startup race where docs generation runs before its dependencies are built.

## Test plan
- [ ] Run `pnpm run generate-openapi-docs:watch` from a clean state and confirm it blocks until the dist files exist, then proceeds normally.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved build process reliability by ensuring required dependencies are built before generating API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->