### PR TITLE
Regenerate OpenAPI schemas

### DIFF
--- a/docs-mintlify/openapi/admin.json
+++ b/docs-mintlify/openapi/admin.json
@@ -1123,7 +1123,7 @@
                 "properties": {
                   "expires_in_millis": {
                     "type": "number",
-                    "default": 7200000
+                    "default": 120000
                   },
                   "anon_refresh_token": {
                     "type": "string"

--- a/docs-mintlify/openapi/client.json
+++ b/docs-mintlify/openapi/client.json
@@ -893,7 +893,7 @@
                 "properties": {
                   "expires_in_millis": {
                     "type": "number",
-                    "default": 7200000
+                    "default": 120000
                   },
                   "anon_refresh_token": {
                     "type": "string"

--- a/docs-mintlify/openapi/server.json
+++ b/docs-mintlify/openapi/server.json
@@ -1071,7 +1071,7 @@
                 "properties": {
                   "expires_in_millis": {
                     "type": "number",
-                    "default": 7200000
+                    "default": 120000
                   },
                   "anon_refresh_token": {
                     "type": "string"


### PR DESCRIPTION
## Summary
- The CLI auth-attempt schema in `apps/backend/src/app/api/latest/auth/cli/route.tsx` changed `expires_in_millis.default` from 7,200,000 (2hr) to 120,000 (2min), but the checked-in OpenAPI JSONs in `docs-mintlify/openapi/` were never regenerated.
- This causes `lint_and_build` to fail on `dev` (and on every PR branched off `dev`) because CI runs the codegen and then errors on the resulting uncommitted diff.

## Changes
- Regenerated `admin.json`, `client.json`, `server.json` via `pnpm --filter=@stackframe/backend codegen-docs`.

## Test plan
- [ ] CI's `lint_and_build` passes on this PR.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated CLI authentication token default expiration time from 2 hours to 2 minutes across API specifications.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->