### PR TITLE
docs: add Cursor Cloud specific instructions to AGENTS.md

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -116,3 +116,42 @@ To see all development ports, refer to the index.html of `apps/dev-launchpad/pub
 
 ### Code-related
 - Use ES6 maps instead of records wherever you can.
+
+## Cursor Cloud specific instructions
+
+### Environment overview
+Stack Auth is a monorepo (pnpm workspaces + Turbo). The core dev services are:
+- **Backend** (Next.js API): port 8102
+- **Dashboard** (Next.js): port 8101
+- **Mock OAuth Server**: port 8114
+- **Docker deps** (Postgres, ClickHouse, Inbucket, Svix, S3 mock, LocalStack, QStash, etc.)
+
+All commands and scripts are documented in the root `README.md` and `package.json`.
+
+### Starting services
+1. Docker must be running. Start deps with `pnpm start-deps` (or `pnpm restart-deps` to reset). This also runs `db:init`.
+2. Start the dev server: `pnpm dev:basic` (backend + dashboard + MCP + mock-oauth-server). Use `pnpm dev` for all services including examples/docs.
+3. The update script handles `pnpm install` only. You must build packages (`pnpm build:packages`) and run codegen (`pnpm codegen`) at least once before starting the dev server. After that, `pnpm dev` watches for changes automatically.
+
+### Docker Hub rate limit (Cloud VM gotcha)
+The shared Cloud VM IP frequently hits Docker Hub's unauthenticated pull rate limit (100 pulls/6h). To work around this, configure a registry mirror before pulling images:
+```json
+// /etc/docker/daemon.json
+{
+  "storage-driver": "fuse-overlayfs",
+  "registry-mirrors": ["https://mirror.gcr.io"]
+}
+```
+Also ensure `fuse-overlayfs` is installed and iptables is set to legacy mode (required for Docker-in-Docker in the Firecracker VM).
+
+### Jaeger container
+The Jaeger (OpenTelemetry tracing) container may fail to start with a cgroup error in the nested container environment. This is optional and does not affect development or testing.
+
+### Testing
+- `pnpm test run` runs all tests (Vitest). Filter with `pnpm test run <file-pattern>`.
+- Tests require the backend to be running on port 8102.
+- Performance tests (e.g. `bulldozer/db/index.perf.test.ts`) may fail in resource-constrained VMs; this is expected.
+- Use `--bail 1` to stop on first failure.
+
+### Dashboard sign-in for testing
+Navigate to http://localhost:8101, click "Sign in with GitHub", and on the mock OAuth page enter `admin@example.com`.


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Adds a `## Cursor Cloud specific instructions` section to `AGENTS.md` with non-obvious environment caveats for future Cloud Agents.

### Key additions:
- **Docker Hub rate limit workaround**: Cloud VM shared IPs hit the 100-pull/6h limit; configuring `mirror.gcr.io` as a registry mirror resolves this.
- **Docker-in-Docker requirements**: `fuse-overlayfs` storage driver and `iptables-legacy` mode are needed for the nested Firecracker environment.
- **Jaeger container note**: Fails with a cgroup error in the nested container setup — it's optional and doesn't affect development.
- **Performance test expectations**: VM resource constraints may cause perf tests to fail with higher-than-threshold latencies.
- **Dashboard sign-in**: Quick reference for mock OAuth flow (`admin@example.com` via GitHub mock).

### Evidence of working setup:

[Dashboard projects page showing authenticated state](https://cursor.com/agents/bc-aeb1fc3e-6335-4efa-b05a-31cf5130d26b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2F03-dashboard-projects-page.webp)

[demo-stack-auth-dashboard-overview.mp4](https://cursor.com/agents/bc-aeb1fc3e-6335-4efa-b05a-31cf5130d26b/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fdemo-stack-auth-dashboard-overview.mp4)

All core checks pass:
- ✅ `pnpm lint` (28 tasks, all passed)
- ✅ `pnpm typecheck` (28 tasks, all passed)
- ✅ `pnpm test run auth/password/sign-up` (8 tests passed)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-aeb1fc3e-6335-4efa-b05a-31cf5130d26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-aeb1fc3e-6335-4efa-b05a-31cf5130d26b"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

