### PR TITLE
fix: stabilize useSyncExternalStore snapshots to prevent infinite re-renders (error #185)

### DIFF
--- a/apps/dashboard/src/app/layout-client.tsx
+++ b/apps/dashboard/src/app/layout-client.tsx
@@ -100,16 +100,18 @@ function getDevEnvironmentHealthSnapshot() {
   return devEnvironmentHealthSnapshot;
 }
 
+const SERVER_DEV_ENVIRONMENT_HEALTH_SNAPSHOT: DevEnvironmentHealthSnapshot = { status: "checking" };
 function getServerDevEnvironmentHealthSnapshot(): DevEnvironmentHealthSnapshot {
-  return { status: "checking" };
+  return SERVER_DEV_ENVIRONMENT_HEALTH_SNAPSHOT;
 }
 
 function subscribeHealthyDevEnvironment(_callback: () => void) {
   return () => {};
 }
 
+const HEALTHY_DEV_ENVIRONMENT_SNAPSHOT: DevEnvironmentHealthSnapshot = { status: "healthy" };
 function getHealthyDevEnvironmentSnapshot(): DevEnvironmentHealthSnapshot {
-  return { status: "healthy" };
+  return HEALTHY_DEV_ENVIRONMENT_SNAPSHOT;
 }
 
 function DevEnvironmentStoppedScreen(props: { restartCommand: string }) {


### PR DESCRIPTION
## Summary

Fixes the React error #185 ("Maximum update depth exceeded") on staging (app.dev.stack-auth.com).

## Root Cause

`getHealthyDevEnvironmentSnapshot()` and `getServerDevEnvironmentHealthSnapshot()` in `apps/dashboard/src/app/layout-client.tsx` returned **new object references** on every call:

```typescript
function getHealthyDevEnvironmentSnapshot(): DevEnvironmentHealthSnapshot {
  return { status: "healthy" }; // ← new object every call
}
```

This violates `useSyncExternalStore`'s contract — `getSnapshot` must return a referentially stable value when the store hasn't changed.

On non-development environments (like staging), the `DevEnvironmentHealthGate` component uses these functions with `useSyncExternalStore`. React's passive effect consistency check calls `getSnapshot()` after commit and compares with the rendered value. Since `{ status: "healthy" } !== { status: "healthy" }` (different object references), React thinks the store changed, forces a re-render, which produces yet another new object — creating the infinite loop that triggers error #185.

## Fix

Hoist the snapshot objects to module-level constants so `getSnapshot` always returns the same reference:

```typescript
const HEALTHY_DEV_ENVIRONMENT_SNAPSHOT: DevEnvironmentHealthSnapshot = { status: "healthy" };
function getHealthyDevEnvironmentSnapshot(): DevEnvironmentHealthSnapshot {
  return HEALTHY_DEV_ENVIRONMENT_SNAPSHOT;
}
```

Same pattern applied to `getServerDevEnvironmentHealthSnapshot`.

Link to Devin session: https://app.devin.ai/sessions/eb1eed3d5a5c4dea88a740b347d1a927
Requested by: @N2D4