### PR TITLE
Fix globe drag not ending when pointer released outside element

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/globe.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/globe.tsx
@@ -1024,6 +1024,31 @@ function GlobeSectionInner({ countryData, totalUsers, activeUsersByCountry, sate
     };
   }, [globeReady, mounted, liveAvatars]);
 
+  // When the pointer leaves the globe canvas and the button is released
+  // outside, OrbitControls may miss the pointerup (pointer capture can be
+  // lost intermittently). Listen on window and forward the event to the
+  // canvas so the controls properly end the drag.
+  useEffect(() => {
+    if (!globeReady) return;
+    const domElement = globeRef.current?.renderer().domElement;
+    if (!domElement) return;
+
+    const handleWindowPointerUp = (e: PointerEvent) => {
+      if (e.target !== domElement && !domElement.contains(e.target as Node)) {
+        domElement.dispatchEvent(new PointerEvent('pointerup', {
+          pointerId: e.pointerId,
+          pointerType: e.pointerType,
+          bubbles: true,
+        }));
+      }
+    };
+
+    window.addEventListener('pointerup', handleWindowPointerUp);
+    return () => {
+      window.removeEventListener('pointerup', handleWindowPointerUp);
+    };
+  }, [globeReady]);
+
   // set globeReady to true after a bit in case onGlobeReady was not called
   useEffect(() => {
     const timeout = setTimeout(() => {


### PR DESCRIPTION
Fixes the overview globe continuing to rotate when re-entering it after releasing the mouse button outside. Listens for `pointerup` on `window` and forwards it to the canvas when it originated outside the globe element.

Link to Devin session: https://app.devin.ai/sessions/a1b15005ef104bbe8d77b54ace75f66f
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk UI interaction fix that only adds a `window`-level `pointerup` listener to ensure OrbitControls ends drags correctly; main concern is unintended event forwarding if the target detection is wrong.
> 
> **Overview**
> Fixes the overview globe getting “stuck” rotating after a drag when the pointer is released outside the globe canvas.
> 
> Adds a `useEffect` that listens for `pointerup` on `window` and, when the event originated outside the canvas, dispatches a synthetic `pointerup` to the globe renderer element so OrbitControls reliably terminates the drag state.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 714f60de8edcbb6b8dbec0c72ea4664ae8795a25. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes

* Fixed globe dragging behavior to properly handle pointer release events when the cursor exits the canvas area, preventing drag operations from stalling and improving interaction reliability.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1447?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->