### PR TITLE
Show enabled alpha apps in sidebar and app store

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/apps/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/apps/page-client.tsx
@@ -46,9 +46,9 @@ export default function PageClient() {
   const filteredApps = useMemo(() => {
     let apps = Object.keys(ALL_APPS) as AppId[];
 
-    // Filter out alpha apps in production
+    // Filter out alpha apps in production, but keep enabled ones
     if (process.env.NODE_ENV !== "development") {
-      apps = apps.filter(appId => ALL_APPS[appId].stage !== "alpha");
+      apps = apps.filter(appId => ALL_APPS[appId].stage !== "alpha" || installedAppsSet.has(appId));
     }
 
     // Apply category filter
@@ -88,14 +88,14 @@ export default function PageClient() {
   const getCategoryCount = (categoryId: string) => {
     if (categoryId === "installed") return installedApps.length;
     if (categoryId === "all") return Object.keys(ALL_APPS).filter(appId =>
-      process.env.NODE_ENV === "development" || ALL_APPS[appId as AppId].stage !== "alpha"
+      process.env.NODE_ENV === "development" || ALL_APPS[appId as AppId].stage !== "alpha" || installedAppsSet.has(appId as AppId)
     ).length;
 
     const category = CATEGORIES.find(c => c.id === categoryId);
     if (!category) return 0;
 
     return (Object.entries(ALL_APPS) as [AppId, typeof ALL_APPS[AppId]][]).filter(([appId, app]) => {
-      if (process.env.NODE_ENV !== "development" && app.stage === "alpha") return false;
+      if (process.env.NODE_ENV !== "development" && app.stage === "alpha" && !installedAppsSet.has(appId)) return false;
       return app.tags.some((tag: string) => category.tags.includes(tag));
     }).length;
   };

--- a/apps/dashboard/src/lib/apps-utils.ts
+++ b/apps/dashboard/src/lib/apps-utils.ts
@@ -38,9 +38,13 @@ export function isAppEnabled(installedApps: InstalledAppsMap, appId: AppId): boo
 
 /**
  * Get all enabled app IDs using centralized enabled/sub-app logic.
+ *
+ * Unlike `getAllAvailableAppIds`, this intentionally includes alpha-stage apps
+ * that are explicitly enabled. The alpha filter only gates *discovery*
+ * (app store listing, onboarding wizard), not functionality.
  */
 export function getEnabledAppIds(installedApps: InstalledAppsMap): AppId[] {
-  return getAllAvailableAppIds().filter((appId) => isAppEnabled(installedApps, appId));
+  return (Object.keys(ALL_APPS) as AppId[]).filter((appId) => isAppEnabled(installedApps, appId));
 }
 
 /**


### PR DESCRIPTION
`getEnabledAppIds` was filtering through `getAllAvailableAppIds` which excludes alpha-stage apps in production. Enabled alpha apps (like support) were hidden from the sidebar, CmdK, and app store.

Now the alpha filter only gates *discovery* (app store listing for new apps, onboarding wizard), not already-enabled apps.

Link to Devin session: https://app.devin.ai/sessions/ff257efb19ca4d7d9889bfb21bb80c2b
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes production filtering so alpha-stage apps can appear when already enabled, affecting which apps are visible in the app store and counts. Risk is moderate because it alters feature-gating/visibility logic and could unintentionally surface alpha apps if enablement detection is wrong.
> 
> **Overview**
> Updates the dashboard app catalog to **hide alpha apps in production only when they are not enabled**, so already-installed/activated alpha apps remain visible and discoverable within the Apps page.
> 
> Adjusts `getEnabledAppIds` to derive enabled apps from `ALL_APPS` directly (instead of `getAllAvailableAppIds`), ensuring enabled alpha apps are included for sidebar/CmdK/navigation enablement logic, while keeping alpha filtering as a *discovery* gate for unenabled apps.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 934a8a536c4845cef8eda575d13ff85bd486e582. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Alpha apps that are installed in your project now remain visible in production environments.
  * App category counts now accurately reflect installed alpha applications.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1449?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->