### PR TITLE
Fix skill.stack-auth.com CDN serving HTML to curl

### DIFF
--- a/apps/skills/src/app/route.ts
+++ b/apps/skills/src/app/route.ts
@@ -210,6 +210,8 @@ For the full, current flag list and any commands added after this skill was gene
 
 const COMMON_HEADERS = {
   "Cache-Control": "public, max-age=3600, s-maxage=3600",
+  // CDN must cache markdown (curl/agents) and HTML (browser navigate) separately.
+  "Vary": "Sec-Fetch-Mode, Sec-Fetch-Dest",
   "Access-Control-Allow-Origin": "*",
   "Access-Control-Allow-Methods": "GET, HEAD, OPTIONS",
   "Access-Control-Allow-Headers": "*",


### PR DESCRIPTION
## Summary

- Adds `Vary: Sec-Fetch-Mode, Sec-Fetch-Dest` on the skills app root route so the CDN caches markdown and HTML responses separately.
- Fixes production behavior where `curl https://skill.stack-auth.com/` could return the browser HTML landing page (cached from a `Sec-Fetch-Mode: navigate` request) instead of the canonical `SKILL.md` body.

## Context

The route already content-negotiates: browsers with `Sec-Fetch-Mode: navigate` get HTML; `curl` and agents get markdown. Without `Vary`, Vercel served a single cached variant to all clients.

## Test plan

- [ ] Deploy or preview the skills app
- [ ] `curl -sSL https://skill.stack-auth.com/ | head -3` returns markdown (`---` frontmatter), not `<!doctype html>`
- [ ] Open `https://skill.stack-auth.com/` in a browser — still shows the HTML landing page
- [ ] Purge Vercel cache if stale HTML persists after deploy


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Improved CDN caching configuration to optimize content delivery and response handling across different content formats.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1452?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->