### PR TITLE
Fix browser compatibility: guard requestIdleCallback and startViewTransition

### DIFF
--- a/apps/dashboard/src/components/theme-toggle.tsx
+++ b/apps/dashboard/src/components/theme-toggle.tsx
@@ -18,6 +18,11 @@ export default function ThemeToggle() {
       return;
     }
 
+    if (typeof document.startViewTransition !== "function") {
+      setTheme(nextTheme);
+      return;
+    }
+
     document.documentElement.classList.add("vt-disable-transitions");
 
     const transition = document.startViewTransition(() => {

--- a/apps/dashboard/src/hooks/use-wait-for-idle.tsx
+++ b/apps/dashboard/src/hooks/use-wait-for-idle.tsx
@@ -5,10 +5,15 @@ export function useWaitForIdle(min = 0, max = 5000) {
   useEffect(() => {
     let cancelled = false;
     setTimeout(() => {
-      requestIdleCallback(() => {
+      const cb = () => {
         if (cancelled) return;
         setHasWaited(true);
-      }, { timeout: max - min });
+      };
+      if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(cb, { timeout: max - min });
+      } else {
+        setTimeout(cb, max - min);
+      }
     }, min);
     return () => {
       cancelled = true;


### PR DESCRIPTION
Add feature checks for two browser APIs that aren't universally supported:

- **`requestIdleCallback`**: Falls back to `setTimeout` on browsers that don't support it (e.g. Safari)
- **`document.startViewTransition`**: Applies the theme change directly when the View Transitions API is unavailable

Link to Devin session: https://app.devin.ai/sessions/c77b612db7834e9aa71c6b5a0fde316b
Requested by: @N2D4