### PR TITLE
Handle payout.created and payout.reconciliation_completed Stripe webhook events

### DIFF
--- a/apps/backend/src/app/api/latest/integrations/stripe/webhooks/route.tsx
+++ b/apps/backend/src/app/api/latest/integrations/stripe/webhooks/route.tsx
@@ -49,6 +49,8 @@ const ignoredEvents = [
   "balance.available",
   "customer.updated",
   "customer.created",
+  "payout.created",
+  "payout.reconciliation_completed",
 ] as const satisfies Stripe.Event.Type[];
 
 const isSubscriptionChangedEvent = (event: Stripe.Event): event is Stripe.Event & { type: (typeof subscriptionChangedEvents)[number] } => {


### PR DESCRIPTION
Add `payout.created` and `payout.reconciliation_completed` to the `ignoredEvents` array in the Stripe webhook handler so they are acknowledged without throwing an error.

Link to Devin session: https://app.devin.ai/sessions/6bedec87599349d9804ca0fd52db55ae
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved Stripe webhook handling to properly process additional payment reconciliation event types, preventing unnecessary error logs.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1461?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->