### PR TITLE
Fix browser compatibility: guard requestIdleCallback and startViewTransition

### DIFF
--- a/apps/dashboard/src/components/theme-toggle.tsx
+++ b/apps/dashboard/src/components/theme-toggle.tsx
@@ -22,6 +22,11 @@ export default function ThemeToggle() {
       return;
     }
 
+    if (typeof document.startViewTransition !== "function") {
+      setTheme(nextTheme);
+      return;
+    }
+
     document.documentElement.classList.add("vt-disable-transitions");
 
     const transition = document.startViewTransition(() => {

--- a/apps/dashboard/src/hooks/use-wait-for-idle.tsx
+++ b/apps/dashboard/src/hooks/use-wait-for-idle.tsx
@@ -5,10 +5,15 @@ export function useWaitForIdle(min = 0, max = 5000) {
   useEffect(() => {
     let cancelled = false;
     setTimeout(() => {
-      requestIdleCallback(() => {
+      const cb = () => {
         if (cancelled) return;
         setHasWaited(true);
-      }, { timeout: max - min });
+      };
+      if (typeof requestIdleCallback === "function") {
+        requestIdleCallback(cb, { timeout: max - min });
+      } else {
+        setTimeout(cb, max - min);
+      }
     }, min);
     return () => {
       cancelled = true;


### PR DESCRIPTION
Add feature checks for two browser APIs that aren't universally supported:

- **`requestIdleCallback`**: Falls back to `setTimeout` on browsers that don't support it (e.g. Safari)
- **`document.startViewTransition`**: Applies the theme change directly when the View Transitions API is unavailable

Link to Devin session: https://app.devin.ai/sessions/c77b612db7834e9aa71c6b5a0fde316b
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: adds simple runtime feature-detection with safe fallbacks for unsupported browser APIs, affecting only theme toggling animation and an idle-wait hook.
> 
> **Overview**
> Improves dashboard browser compatibility by **adding runtime guards and fallbacks for unsupported web APIs**.
> 
> `ThemeToggle` now skips the View Transitions path when `document.startViewTransition` isn’t a function, applying the theme change directly instead. `useWaitForIdle` now falls back to `setTimeout` when `requestIdleCallback` is unavailable, while preserving the existing min/max delay behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5232a139e750a0054165138762d48d78ce7fdca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Improved browser compatibility for theme switching and idle callback handling by adding fallback mechanisms when modern browser APIs are unavailable.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1464?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->