### PR TITLE
feat: automatically trust project's hosted handler domain (built-with domain)

### DIFF
--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -1,10 +1,11 @@
-import { describe, expect, it } from 'vitest';
+import { describe, expect, it, vi } from 'vitest';
 import { isAcceptedNativeAppUrl, validateRedirectUrl } from './redirect-urls';
 import { Tenancy } from './tenancies';
 
 describe('validateRedirectUrl', () => {
-  const createMockTenancy = (config: Partial<Tenancy['config']>): Tenancy => {
+  const createMockTenancy = (config: Partial<Tenancy['config']>, projectId: string = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee'): Tenancy => {
     return {
+      project: { id: projectId },
       config: {
         domains: {
           allowLocalhost: false,
@@ -471,6 +472,73 @@ describe('validateRedirectUrl', () => {
       expect(validateRedirectUrl('https://api.v2.production.com/callback', tenancy)).toBe(true);
       expect(validateRedirectUrl('https://api.v2.production.com/', tenancy)).toBe(true);
       expect(validateRedirectUrl('https://other.com/handler', tenancy)).toBe(false);
+    });
+  });
+
+  describe('hosted handler domain (built-with domain)', () => {
+    it('should trust the project hosted handler domain with default suffix', () => {
+      vi.stubEnv('NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX', '.built-with-stack-auth.com');
+      const projectId = '12345678-1234-1234-1234-123456789012';
+      const tenancy = createMockTenancy({
+        domains: {
+          allowLocalhost: false,
+          trustedDomains: {},
+        },
+      }, projectId);
+
+      // HTTPS on the built-with domain should be trusted
+      expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/callback`, tenancy)).toBe(true);
+      expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/`, tenancy)).toBe(true);
+      expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/handler/oauth-callback`, tenancy)).toBe(true);
+
+      // HTTP on the built-with domain should also be trusted
+      expect(validateRedirectUrl(`http://${projectId}.built-with-stack-auth.com/callback`, tenancy)).toBe(true);
+
+      // Different project IDs should NOT be trusted
+      expect(validateRedirectUrl('https://other-project.built-with-stack-auth.com/callback', tenancy)).toBe(false);
+
+      // Unrelated domains should NOT be trusted
+      expect(validateRedirectUrl('https://example.com/callback', tenancy)).toBe(false);
+
+      vi.unstubAllEnvs();
+    });
+
+    it('should trust the hosted handler domain with a custom suffix (e.g. local dev)', () => {
+      vi.stubEnv('NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX', '.localhost:8109');
+      const projectId = '12345678-1234-1234-1234-123456789012';
+      const tenancy = createMockTenancy({
+        domains: {
+          allowLocalhost: false,
+          trustedDomains: {},
+        },
+      }, projectId);
+
+      expect(validateRedirectUrl(`http://${projectId}.localhost:8109/callback`, tenancy)).toBe(true);
+      expect(validateRedirectUrl(`https://${projectId}.localhost:8109/callback`, tenancy)).toBe(true);
+
+      // Wrong port should NOT be trusted
+      expect(validateRedirectUrl(`http://${projectId}.localhost:9999/callback`, tenancy)).toBe(false);
+
+      vi.unstubAllEnvs();
+    });
+
+    it('should trust the hosted handler domain even when other trusted domains exist', () => {
+      vi.stubEnv('NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX', '.built-with-stack-auth.com');
+      const projectId = '12345678-1234-1234-1234-123456789012';
+      const tenancy = createMockTenancy({
+        domains: {
+          allowLocalhost: false,
+          trustedDomains: {
+            '1': { baseUrl: 'https://myapp.com', handlerPath: '/handler' },
+          },
+        },
+      }, projectId);
+
+      // Both the configured trusted domain and the hosted handler domain should work
+      expect(validateRedirectUrl('https://myapp.com/callback', tenancy)).toBe(true);
+      expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/callback`, tenancy)).toBe(true);
+
+      vi.unstubAllEnvs();
     });
   });
 

--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -491,8 +491,8 @@ describe('validateRedirectUrl', () => {
       expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/`, tenancy)).toBe(true);
       expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/handler/oauth-callback`, tenancy)).toBe(true);
 
-      // HTTP on the built-with domain should also be trusted
-      expect(validateRedirectUrl(`http://${projectId}.built-with-stack-auth.com/callback`, tenancy)).toBe(true);
+      // HTTP on the built-with domain should NOT be trusted
+      expect(validateRedirectUrl(`http://${projectId}.built-with-stack-auth.com/callback`, tenancy)).toBe(false);
 
       // Different project IDs should NOT be trusted
       expect(validateRedirectUrl('https://other-project.built-with-stack-auth.com/callback', tenancy)).toBe(false);
@@ -513,8 +513,9 @@ describe('validateRedirectUrl', () => {
         },
       }, projectId);
 
-      expect(validateRedirectUrl(`http://${projectId}.localhost:8109/callback`, tenancy)).toBe(true);
+      // Only HTTPS should be trusted, even for localhost-based dev suffix
       expect(validateRedirectUrl(`https://${projectId}.localhost:8109/callback`, tenancy)).toBe(true);
+      expect(validateRedirectUrl(`http://${projectId}.localhost:8109/callback`, tenancy)).toBe(false);
 
       // Wrong port should NOT be trusted
       expect(validateRedirectUrl(`http://${projectId}.localhost:9999/callback`, tenancy)).toBe(false);

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -23,7 +23,6 @@ export function validateRedirectUrl(
     allowLocalhost: tenancy.config.domains.allowLocalhost,
     trustedDomains: [
       ...Object.values(tenancy.config.domains.trustedDomains).map(domain => domain.baseUrl),
-      `http://${hostedDomain}`,
       `https://${hostedDomain}`,
     ],
   });

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -1,14 +1,30 @@
 import { isAcceptedNativeAppUrl, validateRedirectUrl as validateRedirectUrlAgainstTrustedDomains } from "@stackframe/stack-shared/dist/utils/redirect-urls";
+import { getEnvVariable } from "@stackframe/stack-shared/dist/utils/env";
 import { Tenancy } from "./tenancies";
 
 export { isAcceptedNativeAppUrl };
+
+const defaultHostedHandlerDomainSuffix = ".built-with-stack-auth.com";
+
+/**
+ * Returns the domain suffix for the hosted handler (e.g. ".built-with-stack-auth.com" in
+ * production, ".localhost:8109" in local dev).
+ */
+export function getHostedHandlerDomainSuffix(): string {
+  return getEnvVariable("NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX", defaultHostedHandlerDomainSuffix);
+}
 
 export function validateRedirectUrl(
   urlOrString: string | URL,
   tenancy: Tenancy,
 ): boolean {
+  const hostedDomain = `${tenancy.project.id}${getHostedHandlerDomainSuffix()}`;
   return validateRedirectUrlAgainstTrustedDomains(urlOrString, {
     allowLocalhost: tenancy.config.domains.allowLocalhost,
-    trustedDomains: Object.values(tenancy.config.domains.trustedDomains).map(domain => domain.baseUrl),
+    trustedDomains: [
+      ...Object.values(tenancy.config.domains.trustedDomains).map(domain => domain.baseUrl),
+      `http://${hostedDomain}`,
+      `https://${hostedDomain}`,
+    ],
   });
 }

--- a/apps/backend/src/lib/turnstile.tsx
+++ b/apps/backend/src/lib/turnstile.tsx
@@ -12,6 +12,7 @@ import {
 } from "@stackframe/stack-shared/dist/utils/turnstile";
 import { createUrlIfValid, isLocalhost, matchHostnamePattern } from "@stackframe/stack-shared/dist/utils/urls";
 import { BestEffortEndUserRequestContext, getBestEffortEndUserRequestContext } from "./end-users";
+import { getHostedHandlerDomainSuffix } from "./redirect-urls";
 import { Tenancy } from "./tenancies";
 
 
@@ -50,6 +51,13 @@ function isAllowedTurnstileHostname(hostname: string, tenancy: Tenancy): boolean
   if (tenancy.config.domains.allowLocalhost && isLocalhost(`http://${hostname}`)) {
     return true;
   }
+
+  // The project's hosted handler domain (e.g. <project-id>.built-with-stack-auth.com) is always trusted
+  const hostedHandlerUrl = createUrlIfValid(`https://${tenancy.project.id}${getHostedHandlerDomainSuffix()}`);
+  if (hostedHandlerUrl != null && hostedHandlerUrl.hostname === hostname) {
+    return true;
+  }
+
   return Object.values(tenancy.config.domains.trustedDomains).some(({ baseUrl }) => {
     if (baseUrl == null) return false;
     const pattern = createUrlIfValid(baseUrl)?.hostname

--- a/apps/backend/src/oauth/model.tsx
+++ b/apps/backend/src/oauth/model.tsx
@@ -3,7 +3,7 @@ import { usersCrudHandlers } from "@/app/api/latest/users/crud";
 import { Prisma } from "@/generated/prisma/client";
 import { withExternalDbSyncUpdate } from "@/lib/external-db-sync";
 import { checkApiKeySet } from "@/lib/internal-api-keys";
-import { isAcceptedNativeAppUrl, validateRedirectUrl } from "@/lib/redirect-urls";
+import { getHostedHandlerDomainSuffix, isAcceptedNativeAppUrl, validateRedirectUrl } from "@/lib/redirect-urls";
 import { getSoleTenancyFromProjectBranch, getTenancy } from "@/lib/tenancies";
 import { createRefreshTokenObj, decodeAccessToken, generateAccessTokenFromRefreshTokenIfValid, isRefreshTokenValid } from "@/lib/tokens";
 import { getPrismaClientForTenancy, globalPrismaClient } from "@/prisma-client";
@@ -75,6 +75,10 @@ export class OAuthModel implements AuthorizationCodeModel {
       });
       throw e;
     }
+
+    // The project's hosted handler domain is always trusted
+    const hostedDomain = `${tenancy.project.id}${getHostedHandlerDomainSuffix()}`;
+    redirectUris.push(new URL("/handler", `https://${hostedDomain}`).toString());
 
     if (redirectUris.length === 0 && tenancy.config.domains.allowLocalhost) {
       redirectUris.push("http://localhost");


### PR DESCRIPTION
Automatically accept `<project-id>.built-with-stack-auth.com` (or whatever the configured hosted handler domain suffix is) as a trusted domain for each project, without requiring it to be explicitly added in the project config.

Changes:
- `redirect-urls.tsx`: Include hosted handler domain (both HTTP and HTTPS) in trusted domains for redirect URL validation — this covers OAuth callbacks, passkeys, and all other redirect checks
- `turnstile.tsx`: Accept the hosted handler hostname for Turnstile verification
- `oauth/model.tsx`: Include hosted handler URL in OAuth client redirect URIs
- Added unit tests for the new behavior

Link to Devin session: https://app.devin.ai/sessions/11f027a384674ca9b703b14db1a80d46
Requested by: @N2D4

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Expands the set of automatically trusted redirect/hostname origins based on an env-configured suffix and project ID, affecting OAuth redirect validation and bot-challenge hostname checks. Risk is moderate because mistakes could unintentionally widen redirect URI acceptance.
> 
> **Overview**
> **Automatically trusts the project hosted handler domain** (`<project-id>${NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX}`) without requiring it in tenancy config.
> 
> `validateRedirectUrl` now always includes `https://<project-id>.<suffix>` in its trusted domain list (with a new `getHostedHandlerDomainSuffix()` helper), `OAuthModel.getClient` always adds the hosted handler `/handler` URL to `redirectUris`, and Turnstile hostname validation now treats the hosted handler hostname as allowed.
> 
> Adds unit tests covering default/custom suffix behavior and ensuring only the correct project/HTTPS hosted domain is accepted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cfb9af807aeeaece21d5c31270c85245f5ab1aea. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for platform-provided hosted handler domains as trusted endpoints across redirect URL validation, OAuth configuration, and Turnstile verification.
  * Hosted handler domains are now configurable via environment variables with a default built-with domain suffix.

* **Tests**
  * Added test coverage for hosted handler domain validation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1470?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->