### PR TITLE
Use redirectToHandler in StackHandler and disallow string default URL target

### DIFF
--- a/packages/stack-shared/src/interface/handler-urls.ts
+++ b/packages/stack-shared/src/interface/handler-urls.ts
@@ -36,10 +36,8 @@ export type HandlerUrlTarget = HandlerUrls[keyof HandlerUrls];
 /**
  * The default handler URL target, applied to any key not explicitly set.
  *
- * - `{ type: "handler-component" }` — render the page inside the local `StackHandler` component (default).
+ * - `{ type: "handler-component" }` — render the page inside the local `StackHandler` component (current default, may change in the next breaking version).
  * - `{ type: "hosted" }` — redirect to Stack's hosted auth pages.
- *
- * Plain strings are NOT accepted; use the object form above.
  */
 export type DefaultHandlerUrlTarget = { type: "hosted" | "handler-component" };
 
@@ -47,7 +45,7 @@ export type DefaultHandlerUrlTarget = { type: "hosted" | "handler-component" };
  * Configuration for where each auth page/redirect lives.
  *
  * **`default`** — fallback target for every key not set individually:
- *   - `{ type: "handler-component" }` — use the local `StackHandler` (default).
+ *   - `{ type: "handler-component" }` — use the local `StackHandler` (current default, may change in the next breaking version).
  *   - `{ type: "hosted" }` — use Stack's hosted auth pages.
  *
  * **Page keys** (`signIn`, `signUp`, `signOut`, `emailVerification`, `passwordReset`,

--- a/packages/stack-shared/src/interface/handler-urls.ts
+++ b/packages/stack-shared/src/interface/handler-urls.ts
@@ -32,7 +32,35 @@ export type HandlerRedirectUrls = Record<
 
 export type HandlerUrls = HandlerPageUrls & HandlerRedirectUrls;
 export type HandlerUrlTarget = HandlerUrls[keyof HandlerUrls];
-export type DefaultHandlerUrlTarget = string | { type: "hosted" | "handler-component" };
+
+/**
+ * The default handler URL target, applied to any key not explicitly set.
+ *
+ * - `{ type: "handler-component" }` — render the page inside the local `StackHandler` component (default).
+ * - `{ type: "hosted" }` — redirect to Stack's hosted auth pages.
+ *
+ * Plain strings are NOT accepted; use the object form above.
+ */
+export type DefaultHandlerUrlTarget = { type: "hosted" | "handler-component" };
+
+/**
+ * Configuration for where each auth page/redirect lives.
+ *
+ * **`default`** — fallback target for every key not set individually:
+ *   - `{ type: "handler-component" }` — use the local `StackHandler` (default).
+ *   - `{ type: "hosted" }` — use Stack's hosted auth pages.
+ *
+ * **Page keys** (`signIn`, `signUp`, `signOut`, `emailVerification`, `passwordReset`,
+ * `forgotPassword`, `oauthCallback`, `magicLinkCallback`, `accountSettings`,
+ * `teamInvitation`, `cliAuthConfirm`, `mfa`, `error`, `onboarding`, `handler`):
+ *   - A URL string (e.g. `"/my-sign-in"`) — custom path.
+ *   - `{ type: "custom", url: "...", version: 0 }` — custom URL with version tracking.
+ *   - `{ type: "hosted" }` — Stack's hosted page.
+ *   - `{ type: "handler-component" }` — local `StackHandler`.
+ *
+ * **Redirect keys** (`afterSignIn`, `afterSignUp`, `afterSignOut`, `home`):
+ *   - A URL string (e.g. `"/dashboard"`) — where to redirect after the action.
+ */
 export type HandlerUrlOptions = Partial<HandlerUrls> & { default?: DefaultHandlerUrlTarget };
 export type ResolvedHandlerUrls = {
   [K in keyof HandlerUrls]: string;

--- a/packages/template/src/components-page/stack-handler-client.tsx
+++ b/packages/template/src/components-page/stack-handler-client.tsx
@@ -2,12 +2,12 @@
 
 import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
 import { FilterUndefined, filterUndefined } from "@stackframe/stack-shared/dist/utils/objects";
-import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
+import { runAsynchronouslyWithAlert } from "@stackframe/stack-shared/dist/utils/promises";
 import { getRelativePart } from "@stackframe/stack-shared/dist/utils/urls";
 import { notFound, redirect, RedirectType, usePathname, useSearchParams } from 'next/navigation'; // THIS_LINE_PLATFORM next
-import { useMemo } from 'react';
+import { useEffect, useMemo } from 'react';
 /* IF_PLATFORM react
-import { useEffect, useRef } from 'react';
+import { useRef } from 'react';
 // END_PLATFORM */
 import { SignIn, SignUp, StackServerApp } from "..";
 import { useStackApp } from "../lib/hooks";
@@ -26,9 +26,7 @@ import { PasswordReset } from "./password-reset";
 import { SignOut } from "./sign-out";
 import { TeamInvitation } from "./team-invitation";
 
-/* IF_PLATFORM react
 import { MessageCard } from "../components/message-cards/message-card";
-// END_PLATFORM react */
 
 type Components = {
   SignIn: typeof SignIn,
@@ -302,9 +300,19 @@ export function StackHandlerClient(props: BaseHandlerProps & Partial<RouteProps>
     app: stackApp,
   });
 
-  if (result && 'redirectToPage' in result) {
-    runAsynchronously(stackApp[stackAppInternalsSymbol].redirectToHandler(result.redirectToPage, { replace: true }));
-    return null;
+  const redirectToPage = (result != null && typeof result === 'object' && 'redirectToPage' in result) ? result.redirectToPage : undefined;
+
+  useEffect(() => {
+    if (redirectToPage == null) return;
+    runAsynchronouslyWithAlert(
+      stackApp[stackAppInternalsSymbol].redirectToHandler(redirectToPage, { replace: true })
+    );
+  }, [redirectToPage, stackApp]);
+
+  if (redirectToPage != null) {
+    return (
+      <MessageCard title="Redirecting..." fullPage={props.fullPage} />
+    );
   }
 
   if (result && 'redirect' in result) {

--- a/packages/template/src/components-page/stack-handler-client.tsx
+++ b/packages/template/src/components-page/stack-handler-client.tsx
@@ -2,6 +2,7 @@
 
 import { StackAssertionError } from "@stackframe/stack-shared/dist/utils/errors";
 import { FilterUndefined, filterUndefined } from "@stackframe/stack-shared/dist/utils/objects";
+import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
 import { getRelativePart } from "@stackframe/stack-shared/dist/utils/urls";
 import { notFound, redirect, RedirectType, usePathname, useSearchParams } from 'next/navigation'; // THIS_LINE_PLATFORM next
 import { useMemo } from 'react';
@@ -89,16 +90,16 @@ function renderComponent(props: {
   searchParams: Record<string, string>,
   fullPage: boolean,
   componentProps?: BaseHandlerProps['componentProps'],
-  redirectIfNotHandler?: (name: keyof HandlerUrls) => void,
+  shouldRedirectToPage?: (name: keyof HandlerUrls) => boolean,
   getDefaultUnknownPathUrl?: (path: string) => string | null,
   onNotFound: () => any,
   app: StackClientApp<any> | StackServerApp<any>,
 }) {
-  const { path, searchParams, fullPage, componentProps, redirectIfNotHandler, getDefaultUnknownPathUrl, onNotFound, app } = props;
+  const { path, searchParams, fullPage, componentProps, shouldRedirectToPage, getDefaultUnknownPathUrl, onNotFound, app } = props;
 
   switch (path) {
     case availablePaths.signIn: {
-      redirectIfNotHandler?.('signIn');
+      if (shouldRedirectToPage?.('signIn')) return { redirectToPage: 'signIn' as const };
       return <SignIn
         fullPage={fullPage}
         automaticRedirect
@@ -106,7 +107,7 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.signUp: {
-      redirectIfNotHandler?.('signUp');
+      if (shouldRedirectToPage?.('signUp')) return { redirectToPage: 'signUp' as const };
       return <SignUp
         fullPage={fullPage}
         automaticRedirect
@@ -114,7 +115,7 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.emailVerification: {
-      redirectIfNotHandler?.('emailVerification');
+      if (shouldRedirectToPage?.('emailVerification')) return { redirectToPage: 'emailVerification' as const };
       return <EmailVerification
         searchParams={searchParams}
         fullPage={fullPage}
@@ -122,7 +123,7 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.passwordReset: {
-      redirectIfNotHandler?.('passwordReset');
+      if (shouldRedirectToPage?.('passwordReset')) return { redirectToPage: 'passwordReset' as const };
       return <PasswordReset
         searchParams={searchParams}
         fullPage={fullPage}
@@ -130,28 +131,28 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.forgotPassword: {
-      redirectIfNotHandler?.('forgotPassword');
+      if (shouldRedirectToPage?.('forgotPassword')) return { redirectToPage: 'forgotPassword' as const };
       return <ForgotPassword
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.ForgotPassword)}
       />;
     }
     case availablePaths.signOut: {
-      redirectIfNotHandler?.('signOut');
+      if (shouldRedirectToPage?.('signOut')) return { redirectToPage: 'signOut' as const };
       return <SignOut
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.SignOut)}
       />;
     }
     case availablePaths.oauthCallback: {
-      redirectIfNotHandler?.('oauthCallback');
+      if (shouldRedirectToPage?.('oauthCallback')) return { redirectToPage: 'oauthCallback' as const };
       return <OAuthCallback
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.OAuthCallback)}
       />;
     }
     case availablePaths.magicLinkCallback: {
-      redirectIfNotHandler?.('magicLinkCallback');
+      if (shouldRedirectToPage?.('magicLinkCallback')) return { redirectToPage: 'magicLinkCallback' as const };
       return <MagicLinkCallback
         searchParams={searchParams}
         fullPage={fullPage}
@@ -159,7 +160,7 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.teamInvitation: {
-      redirectIfNotHandler?.('teamInvitation');
+      if (shouldRedirectToPage?.('teamInvitation')) return { redirectToPage: 'teamInvitation' as const };
       return <TeamInvitation
         searchParams={searchParams}
         fullPage={fullPage}
@@ -180,21 +181,21 @@ function renderComponent(props: {
       />;
     }
     case availablePaths.cliAuthConfirm: {
-      redirectIfNotHandler?.('cliAuthConfirm');
+      if (shouldRedirectToPage?.('cliAuthConfirm')) return { redirectToPage: 'cliAuthConfirm' as const };
       return <CliAuthConfirmation
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.CliAuthConfirmation)}
       />;
     }
     case availablePaths.mfa: {
-      redirectIfNotHandler?.('mfa');
+      if (shouldRedirectToPage?.('mfa')) return { redirectToPage: 'mfa' as const };
       return <MFA
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.MFA)}
       />;
     }
     case availablePaths.onboarding: {
-      redirectIfNotHandler?.('onboarding');
+      if (shouldRedirectToPage?.('onboarding')) return { redirectToPage: 'onboarding' as const };
       return <Onboarding
         fullPage={fullPage}
         {...filterUndefinedINU(componentProps?.Onboarding)}
@@ -262,31 +263,17 @@ export function StackHandlerClient(props: BaseHandlerProps & Partial<RouteProps>
     });
   };
 
-  const redirectIfNotHandler = (name: keyof HandlerUrls) => {
+  const shouldRedirectToPage = (name: keyof HandlerUrls): boolean => {
     const url = stackApp.urls[name];
     const isCrossDomainLocalOauthCallback = name === "oauthCallback" && searchParams.stack_cross_domain_auth === "1";
     if (isCrossDomainLocalOauthCallback) {
-      return;
+      return false;
     }
-    const isLocalHandlerTarget = isLocalHandlerUrlTarget({
+    return !isLocalHandlerUrlTarget({
       targetUrl: url,
       handlerPath,
       currentOrigin: typeof window === "undefined" ? undefined : window.location.origin,
     });
-    if (isLocalHandlerTarget) {
-      return;
-    }
-
-    const urlObj = new URL(url, placeholderOrigin);
-    for (const [key, value] of Object.entries(searchParams)) {
-      urlObj.searchParams.set(key, value);
-    }
-
-    // IF_PLATFORM next
-    redirect(toAbsoluteOrRelativeRedirectTarget(urlObj), RedirectType.replace);
-    /* ELSE_IF_PLATFORM react
-    redirectTargets.push(toAbsoluteOrRelativeRedirectTarget(urlObj));
-    END_PLATFORM */
   };
 
   const result = renderComponent({
@@ -294,7 +281,7 @@ export function StackHandlerClient(props: BaseHandlerProps & Partial<RouteProps>
     searchParams,
     fullPage: props.fullPage,
     componentProps: props.componentProps,
-    redirectIfNotHandler,
+    shouldRedirectToPage,
     getDefaultUnknownPathUrl,
     onNotFound: () =>
       // IF_PLATFORM next
@@ -314,6 +301,11 @@ export function StackHandlerClient(props: BaseHandlerProps & Partial<RouteProps>
     ,
     app: stackApp,
   });
+
+  if (result && 'redirectToPage' in result) {
+    runAsynchronously(stackApp[stackAppInternalsSymbol].redirectToHandler(result.redirectToPage, { replace: true }));
+    return null;
+  }
 
   if (result && 'redirect' in result) {
     // IF_PLATFORM next

--- a/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/client-app-impl.ts
@@ -3931,6 +3931,9 @@ export class _StackClientAppImplIncomplete<HasTokenStore extends boolean, Projec
       redirectToUrl: async (url: string | URL, options?: { replace?: boolean }) => {
         await this._redirectTo({ url, ...options });
       },
+      redirectToHandler: async (handlerName: keyof HandlerUrls, options?: RedirectToOptions) => {
+        await this._redirectToHandler(handlerName, options);
+      },
       refreshOwnedProjects: async () => {
         await this._refreshOwnedProjects(await this._getSession());
       },

--- a/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/stack-app/apps/interfaces/client-app.ts
@@ -127,6 +127,7 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
       sendRequest(path: string, requestOptions: RequestInit, requestType?: "client" | "server" | "admin"): Promise<Response>,
       getRedirectMethod(): RedirectMethod,
       redirectToUrl(url: string | URL, options?: { replace?: boolean }): Promise<void>,
+      redirectToHandler(handlerName: keyof HandlerUrls, options?: RedirectToOptions): Promise<void>,
       signInWithTokens(tokens: { accessToken: string, refreshToken: string }): Promise<void>,
     },
   }

--- a/packages/template/src/lib/stack-app/url-targets.test.ts
+++ b/packages/template/src/lib/stack-app/url-targets.test.ts
@@ -122,16 +122,28 @@ describe("handler URL targets", () => {
     `);
   });
 
-  it("does not inherit an absolute default target for the OAuth callback", () => {
+  it("rejects a string value for the default URL option", () => {
+    expect(() => resolveHandlerUrls({
+      projectId: "project-id",
+      urls: {
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing runtime validation for JS users
+        default: "https://app.example.test/handler" as any,
+      },
+    })).toThrowError(/must be an object/);
+  });
+
+  it("does not inherit a hosted default target for the OAuth callback", () => {
+    vi.stubEnv("NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX", ".example-stack-hosted.test");
+
     const urls = resolveHandlerUrls({
       projectId: "project-id",
       urls: {
-        default: "https://app.example.test/handler",
+        default: { type: "hosted" },
       },
     });
 
-    expect(urls.signIn).toBe("https://app.example.test/handler");
-    expect(urls.oauthCallback).toBe("/handler/oauth-callback");
+    expect(urls.signIn).toBe("https://project-id.example-stack-hosted.test/handler/sign-in");
+    expect(urls.oauthCallback).toBe("https://project-id.example-stack-hosted.test/handler/oauth-callback");
   });
 
   it("supports custom CLI auth confirmation targets", () => {

--- a/packages/template/src/lib/stack-app/url-targets.test.ts
+++ b/packages/template/src/lib/stack-app/url-targets.test.ts
@@ -122,17 +122,7 @@ describe("handler URL targets", () => {
     `);
   });
 
-  it("rejects a string value for the default URL option", () => {
-    expect(() => resolveHandlerUrls({
-      projectId: "project-id",
-      urls: {
-        // eslint-disable-next-line @typescript-eslint/no-explicit-any -- testing runtime validation for JS users
-        default: "https://app.example.test/handler" as any,
-      },
-    })).toThrowError(/must be an object/);
-  });
-
-  it("does not inherit a hosted default target for the OAuth callback", () => {
+  it("inherits a hosted default target for the OAuth callback", () => {
     vi.stubEnv("NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX", ".example-stack-hosted.test");
 
     const urls = resolveHandlerUrls({

--- a/packages/template/src/lib/stack-app/url-targets.ts
+++ b/packages/template/src/lib/stack-app/url-targets.ts
@@ -185,9 +185,6 @@ const assertOAuthCallbackTargetIsRelative = (target: HandlerUrlTarget): void => 
 
 export const resolveHandlerUrls = (options: { urls: HandlerUrlOptions | undefined, projectId: string }): ResolvedHandlerUrls => {
   const configuredUrls = options.urls;
-  if (typeof configuredUrls?.default === "string") {
-    throw new StackAssertionError(`The 'default' URL option must be an object (eg. { type: "hosted" } or { type: "handler-component" }), but received a string: "${configuredUrls.default}". If you meant to use hosted URLs, use { type: "hosted" } instead.`);
-  }
   const defaultTarget = configuredUrls?.default ?? { type: "handler-component" } as const;
   const oauthCallbackTarget: HandlerUrlTarget = configuredUrls?.oauthCallback ?? (
     defaultTarget.type === "hosted"

--- a/packages/template/src/lib/stack-app/url-targets.ts
+++ b/packages/template/src/lib/stack-app/url-targets.ts
@@ -185,9 +185,12 @@ const assertOAuthCallbackTargetIsRelative = (target: HandlerUrlTarget): void => 
 
 export const resolveHandlerUrls = (options: { urls: HandlerUrlOptions | undefined, projectId: string }): ResolvedHandlerUrls => {
   const configuredUrls = options.urls;
-  const defaultTarget: HandlerUrlTarget = configuredUrls?.default ?? { type: "handler-component" };
+  if (typeof configuredUrls?.default === "string") {
+    throw new StackAssertionError(`The 'default' URL option must be an object (eg. { type: "hosted" } or { type: "handler-component" }), but received a string: "${configuredUrls.default}". If you meant to use hosted URLs, use { type: "hosted" } instead.`);
+  }
+  const defaultTarget = configuredUrls?.default ?? { type: "handler-component" } as const;
   const oauthCallbackTarget: HandlerUrlTarget = configuredUrls?.oauthCallback ?? (
-    typeof defaultTarget !== "string" && defaultTarget.type === "hosted"
+    defaultTarget.type === "hosted"
       ? defaultTarget
       : { type: "handler-component" }
   );
@@ -339,10 +342,7 @@ export const resolveUnknownHandlerPathFallbackUrl = (options: {
   projectId: string,
   unknownPath: string,
 }): string | null => {
-  const defaultTarget = options.defaultTarget ?? { type: "handler-component" } satisfies HandlerUrlTarget;
-  if (typeof defaultTarget === "string") {
-    return defaultTarget;
-  }
+  const defaultTarget = options.defaultTarget ?? { type: "handler-component" } satisfies DefaultHandlerUrlTarget;
 
   switch (defaultTarget.type) {
     case "handler-component": {


### PR DESCRIPTION
- StackHandler now calls `redirectToHandler(page)` via internals instead of raw `redirect()` when a route's URL is not configured for the handler. This ensures proper cross-domain auth and redirect-back parameter handling.

- `DefaultHandlerUrlTarget` no longer accepts plain strings — must use `{ type: "hosted" }` or `{ type: "handler-component" }`. Runtime validation throws a descriptive error for JS users who accidentally pass a string.

- Added JSDoc documentation to `HandlerUrlOptions` and `DefaultHandlerUrlTarget` summarizing valid values for each key.

Link to Devin session: https://app.devin.ai/sessions/8db35e6835b849c38ebafde2f243fb31
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Breaking Changes**
  * Default handler target must now be specified as an object with type "hosted" or "handler-component"; plain-string defaults are no longer supported.

* **New Features**
  * Added a public programmatic client-side API to initiate handler redirects.

* **Improvements**
  * Redirect flow now computes targets during render and performs redirects asynchronously (renders a temporary "Redirecting…" message); OAuth-callback defaulting aligned with hosted targets.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1472?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->