### PR TITLE
fix: fix failing CI/CD on dev branch

### DIFF
--- a/.github/workflows/qemu-emulator-build.yaml
+++ b/.github/workflows/qemu-emulator-build.yaml
@@ -148,10 +148,12 @@ jobs:
       - name: Build stack-cli (for emulator CLI)
         if: matrix.arch == 'amd64'
         run: |
-          pnpm install --frozen-lockfile --filter '@stackframe/stack-cli...'
-          # Turbo's trailing `...` filter builds stack-cli AND its workspace
-          # deps (@stackframe/js, @stackframe/stack-shared, etc.) — stack-cli
-          # imports them at runtime from their dist/ outputs.
+          # Turbo's task graph for stack-cli#build includes
+          # @stackframe/dashboard#build:rde-standalone, which transitively
+          # depends on @stackframe/stack#build (via dashboard → stack).
+          # The pnpm filter must cover the dashboard dep tree too so that
+          # devDependencies like tailwindcss are installed for the build.
+          pnpm install --frozen-lockfile --filter '@stackframe/stack-cli...' --filter '@stackframe/dashboard...'
           pnpm exec turbo run build --filter='@stackframe/stack-cli...'
 
       - name: Start emulator and verify

--- a/.github/workflows/qemu-emulator-build.yaml
+++ b/.github/workflows/qemu-emulator-build.yaml
@@ -269,10 +269,8 @@ jobs:
 
       - name: Install stack-cli deps + build
         run: |
-          pnpm install --frozen-lockfile --filter '@stackframe/stack-cli...'
-          # Turbo's trailing `...` filter builds stack-cli AND its workspace
-          # deps (@stackframe/js, @stackframe/stack-shared, etc.) — stack-cli
-          # imports them at runtime from their dist/ outputs.
+          # See "Build stack-cli" step comment for why dashboard filter is needed
+          pnpm install --frozen-lockfile --filter '@stackframe/stack-cli...' --filter '@stackframe/dashboard...'
           pnpm exec turbo run build --filter='@stackframe/stack-cli...'
 
       - name: Download built image

--- a/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
@@ -39,6 +39,7 @@ it("gets current project (internal)", async ({ expect }) => {
       "status": 200,
       "body": {
         "config": {
+          "allow_localhost": true,
           "allow_team_api_keys": false,
           "allow_user_api_keys": false,
           "client_team_creation_enabled": true,

--- a/apps/e2e/tests/js/cross-domain-auth.test.ts
+++ b/apps/e2e/tests/js/cross-domain-auth.test.ts
@@ -9,10 +9,21 @@ function createMockDocument(): Document {
       return [...cookieJar.entries()].map(([k, v]) => `${k}=${v}`).join('; ');
     },
     set cookie(str: string) {
-      const [nameValue] = str.split(';');
+      const parts = str.split(';');
+      const [nameValue] = parts;
       const eqIndex = nameValue.indexOf('=');
       if (eqIndex >= 0) {
-        cookieJar.set(nameValue.slice(0, eqIndex).trim(), nameValue.slice(eqIndex + 1).trim());
+        const name = nameValue.slice(0, eqIndex).trim();
+        const isExpired = parts.some(p => {
+          const trimmed = p.trim().toLowerCase();
+          if (!trimmed.startsWith('expires=')) return false;
+          return new Date(trimmed.slice('expires='.length)) <= new Date();
+        });
+        if (isExpired) {
+          cookieJar.delete(name);
+        } else {
+          cookieJar.set(name, nameValue.slice(eqIndex + 1).trim());
+        }
       }
     },
     createElement: () => ({}),
@@ -65,7 +76,7 @@ it("adds secure cross-domain handoff parameters when redirecting to hosted sign-
     const previousDocument = globalThis.document;
     let redirectedUrl = "";
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: `${localRedirectUrl}/private-page?foo=bar`,
@@ -107,7 +118,7 @@ it("returns static app.urls.signIn for hosted flows", async ({ expect }) => {
 
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -138,7 +149,7 @@ it("returns static app.urls.signOut for hosted flows", async ({ expect }) => {
 
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -173,7 +184,7 @@ it("strips stale OAuth callback params from hosted current-page redirect URIs", 
     currentUrl.searchParams.set("message", "Known message");
     currentUrl.searchParams.set("details", "{}");
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentUrl.toString(),
@@ -284,7 +295,7 @@ it("does not await pending auth resolutions when post-callback redirect adds nes
 
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: `${localRedirectUrl}/callback-page`,
@@ -339,7 +350,7 @@ it("keeps cross-domain handoff working when top-level params are dropped before 
       .spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl")
       .mockResolvedValue(crossDomainAuthorizeRedirect);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: hostedAfterSignInCallbackUrl.toString(),
@@ -395,7 +406,7 @@ it("keeps cross-domain handoff working when after_auth_return_to is rewritten to
       .spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl")
       .mockResolvedValue(crossDomainAuthorizeRedirect);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: hostedAfterSignInCallbackUrl.toString(),
@@ -436,7 +447,7 @@ it("adds nested cross-domain auth params when redirecting signed-in users to hos
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
     let redirectedUrl = "";
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -474,7 +485,7 @@ it("adds nested cross-domain auth params for other cross-domain handler redirect
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
     let redirectedUrl = "";
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -515,7 +526,7 @@ it("starts nested cross-domain auth from the target domain", async ({ expect }) 
       codeChallenge: "nested-code-challenge",
     });
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -567,7 +578,7 @@ it("continues nested cross-domain auth on the source domain", async ({ expect })
       .mockResolvedValue(crossDomainRedirect);
     vi.spyOn(clientApp as any, "_getCurrentRefreshTokenIdIfSignedIn").mockResolvedValue(sourceRefreshTokenId);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentUrl.toString(),
@@ -611,7 +622,7 @@ it("rejects nested cross-domain auth when the source redirect URI is untrusted",
     const createCrossDomainAuthRedirectUrlSpy = vi.spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl");
     vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(false);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentUrl.toString(),
@@ -640,7 +651,7 @@ it("rejects nested cross-domain auth when the callback URL is untrusted", async 
     vi.spyOn(clientApp as any, "_getCurrentRefreshTokenIdIfSignedIn").mockResolvedValue(null);
     vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(false);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentHref,
@@ -671,7 +682,7 @@ it("rejects nested cross-domain auth when the source session does not match", as
     const createCrossDomainAuthRedirectUrlSpy = vi.spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl");
     vi.spyOn(clientApp as any, "_getCurrentRefreshTokenIdIfSignedIn").mockResolvedValue("different-source-session");
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentUrl.toString(),

--- a/apps/e2e/tests/js/cross-domain-auth.test.ts
+++ b/apps/e2e/tests/js/cross-domain-auth.test.ts
@@ -2,6 +2,23 @@ import { StackClientApp } from "@stackframe/js";
 import { afterEach, vi } from "vitest";
 import { it, localRedirectUrl } from "../helpers";
 
+function createMockDocument(): Document {
+  const cookieJar = new Map<string, string>();
+  return {
+    get cookie() {
+      return [...cookieJar.entries()].map(([k, v]) => `${k}=${v}`).join('; ');
+    },
+    set cookie(str: string) {
+      const [nameValue] = str.split(';');
+      const eqIndex = nameValue.indexOf('=');
+      if (eqIndex >= 0) {
+        cookieJar.set(nameValue.slice(0, eqIndex).trim(), nameValue.slice(eqIndex + 1).trim());
+      }
+    },
+    createElement: () => ({}),
+  } as any;
+}
+
 const withHostedDomainSuffix = async (callback: () => Promise<void>) => {
   const oldHostedHandlerDomainSuffix = process.env.NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX;
   const oldHostedHandlerUrlTemplate = process.env.NEXT_PUBLIC_STACK_HOSTED_HANDLER_URL_TEMPLATE;
@@ -178,7 +195,7 @@ it("only treats hosted OAuth callback URLs as Stack callbacks when the matching 
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: `${localRedirectUrl}/callback-page?code=oauth-code&state=oauth-state`,
@@ -221,7 +238,7 @@ it("does not await pending auth resolutions when post-callback redirect mints a 
     redirectBackUrl.searchParams.set("stack_cross_domain_auth", "1");
     redirectBackUrl.searchParams.set("stack_cross_domain_state", "state");
     redirectBackUrl.searchParams.set("stack_cross_domain_code_challenge", "challenge");
-    redirectBackUrl.searchParams.set("stack_cross_domain_after_callback_redirect_url", `${localRedirectUrl}/after`);
+    redirectBackUrl.searchParams.set("stack_cross_domain_after_callback_redirect_url", `https://${projectId}.example-stack-hosted.test/after`);
     currentUrl.searchParams.set("after_auth_return_to", redirectBackUrl.toString());
 
     const previousWindow = globalThis.window;
@@ -230,7 +247,7 @@ it("does not await pending auth resolutions when post-callback redirect mints a 
       .spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl")
       .mockResolvedValue(`https://${projectId}.example-stack-hosted.test/handler/final`);
 
-    globalThis.document = { cookie: "", createElement: () => ({}) } as any;
+    globalThis.document = createMockDocument();
     globalThis.window = {
       location: {
         href: currentUrl.toString(),

--- a/scripts/wait-for-dev-package-imports.ts
+++ b/scripts/wait-for-dev-package-imports.ts
@@ -26,6 +26,12 @@ import { setTimeout as sleep } from "timers/promises";
 // This probe waits only for the package imports that the backend-side generator
 // needs. It does not hide real runtime errors: we retry missing-module failures
 // while package builds warm up, and fail immediately for other import failures.
+//
+// In addition to workspace packages, the probe checks that the generated Prisma
+// client exists. When `turbo run dev` starts the backend, `codegen-prisma:watch`
+// (`prisma generate --watch`) performs an initial generation that briefly removes
+// and recreates `src/generated/prisma/`. If `codegen-docs` runs during that
+// window it fails with ERR_MODULE_NOT_FOUND for `@/generated/prisma/client`.
 const repoRoot = path.resolve(__dirname, "..");
 const backendDir = path.join(repoRoot, "apps/backend");
 const timeoutMs = 60_000;
@@ -35,6 +41,13 @@ const probeScript = `
 (async () => {
   await import('@stackframe/stack');
   await import('@stackframe/stack-shared/dist/utils/env');
+  const { existsSync, readdirSync } = await import('node:fs');
+  const { join } = await import('node:path');
+  const generatedDir = join(process.cwd(), 'src', 'generated', 'prisma');
+  if (!existsSync(generatedDir) || readdirSync(generatedDir).length === 0) {
+    const err = new Error('ERR_MODULE_NOT_FOUND: Generated Prisma client not yet available at ' + generatedDir);
+    throw err;
+  }
 })().then(
   () => undefined,
   (error) => {


### PR DESCRIPTION
Fix three test failures introduced by recent commits on dev:

- **projects.test.ts**: Add missing `allow_localhost` field to inline snapshot
- **cross-domain-auth.test.ts**: Replace plain-object document mock with proper cookie-jar mock (with expiry support) so `getAllCookiesClient()`'s internal `Cookies.set` doesn't overwrite test cookies
- **cross-domain-auth.test.ts**: Use cross-origin `afterCallbackRedirectUrl` so `planRedirectToHandler` correctly enters the cross-domain-authorize flow
- Replace all remaining plain-object document mocks with `createMockDocument()` for consistency

Link to Devin session: https://app.devin.ai/sessions/e0f695fe8704431ab9daad5a74662682
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Updated a project endpoint assertion to expect localhost config in current-project responses.
  * Added a stateful cookie simulation helper and converted cross-domain auth tests to use it, improving realism across redirects and nested flows.
* **Chores**
  * CI workflow adjusted to ensure required workspace packages are installed during emulator CLI builds.
  * Dev startup probe now verifies the generated client is present before proceeding.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1473?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->