### PR TITLE
Fix onboarding shared OAuth provider persistence

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
@@ -2,7 +2,9 @@
 
 import type { ButtonHTMLAttributes, ReactNode } from "react";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { cleanup, render, waitFor } from "@testing-library/react";
+import { cleanup, fireEvent, render, screen, waitFor } from "@testing-library/react";
+
+const mockUpdateConfig = vi.hoisted(() => vi.fn(async () => true));
 
 vi.mock("@/components/design-components", () => ({
   DesignCard: ({ children }: { children: ReactNode }) => <div>{children}</div>,
@@ -82,7 +84,7 @@ vi.mock("@/lib/env", () => ({
 }));
 
 vi.mock("@/lib/config-update", () => ({
-  useUpdateConfig: () => vi.fn(async () => true),
+  useUpdateConfig: () => mockUpdateConfig,
 }));
 
 vi.mock("@stackframe/stack", () => ({
@@ -91,7 +93,8 @@ vi.mock("@stackframe/stack", () => ({
 }));
 
 vi.mock("@stackframe/stack-shared/dist/utils/oauth", () => ({
-  allProviders: [],
+  allProviders: ["google", "github", "microsoft", "spotify"],
+  sharedProviders: ["google", "github", "microsoft", "spotify"],
 }));
 
 vi.mock("@stackframe/stack-shared/dist/utils/promises", () => ({
@@ -142,6 +145,7 @@ import { ALL_APPS } from "@stackframe/stack-shared/dist/apps/apps-config";
 
 afterEach(() => {
   cleanup();
+  mockUpdateConfig.mockClear();
 });
 
 describe("ProjectOnboardingWizard", () => {
@@ -225,5 +229,85 @@ describe("ProjectOnboardingWizard", () => {
       expect(setStatus).toHaveBeenCalledWith("welcome");
     });
     expect(onComplete).not.toHaveBeenCalled();
+  });
+
+  it("persists shared OAuth providers selected during onboarding before completing", async () => {
+    const setStatus = vi.fn(async () => {});
+    const clearOnboardingState = vi.fn(async () => {});
+    const onComplete = vi.fn();
+    const app = {
+      setupPayments: vi.fn(async () => ({ url: "https://example.com" })),
+      useEmailThemes: () => [],
+      useStripeAccountInfo: () => null,
+    };
+    const project = {
+      id: "proj_123",
+      config: {
+        credentialEnabled: true,
+        magicLinkEnabled: false,
+        passkeyEnabled: false,
+        oauthProviders: [],
+      },
+      useConfig: () => ({
+        apps: {
+          installed: {
+            authentication: { enabled: true },
+            emails: { enabled: true },
+            payments: { enabled: false },
+          },
+        },
+        domains: {
+          trustedDomains: {},
+        },
+        emails: {
+          selectedThemeId: "default",
+          server: {},
+        },
+      }),
+      app,
+    };
+
+    render(
+      <ProjectOnboardingWizard
+        project={project as never}
+        status="welcome"
+        onboardingState={{
+          selected_config_choice: "create-new",
+          selected_apps: ["authentication", "emails"],
+          selected_sign_in_methods: ["credential", "google"],
+          selected_email_theme_id: "default",
+          selected_payments_country: "US",
+        }}
+        mode={null}
+        setMode={vi.fn()}
+        setStatus={setStatus}
+        setOnboardingState={vi.fn(async () => {})}
+        clearOnboardingState={clearOnboardingState}
+        onComplete={onComplete}
+      />,
+    );
+
+    fireEvent.click(screen.getByRole("button", { name: "Get Started" }));
+
+    await waitFor(() => {
+      expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
+    });
+    expect(mockUpdateConfig).toHaveBeenNthCalledWith(2, {
+      adminApp: app,
+      configUpdate: {
+        "auth.oauth.providers.google": {
+          type: "google",
+          isShared: true,
+          allowSignIn: true,
+          allowConnectedAccounts: true,
+        },
+        "auth.oauth.providers.github": null,
+        "auth.oauth.providers.microsoft": null,
+      },
+      pushable: false,
+    });
+    expect(setStatus).toHaveBeenCalledWith("completed");
+    expect(clearOnboardingState).toHaveBeenCalled();
+    expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
@@ -291,23 +291,23 @@ describe("ProjectOnboardingWizard", () => {
 
     await waitFor(() => {
       expect(mockUpdateConfig).toHaveBeenCalledTimes(2);
-    });
-    expect(mockUpdateConfig).toHaveBeenNthCalledWith(2, {
-      adminApp: app,
-      configUpdate: {
-        "auth.oauth.providers.google": {
-          type: "google",
-          isShared: true,
-          allowSignIn: true,
-          allowConnectedAccounts: true,
+      expect(mockUpdateConfig).toHaveBeenNthCalledWith(2, {
+        adminApp: app,
+        configUpdate: {
+          "auth.oauth.providers.google": {
+            type: "google",
+            isShared: true,
+            allowSignIn: true,
+            allowConnectedAccounts: true,
+          },
+          "auth.oauth.providers.github": null,
+          "auth.oauth.providers.microsoft": null,
         },
-        "auth.oauth.providers.github": null,
-        "auth.oauth.providers.microsoft": null,
-      },
-      pushable: false,
+        pushable: false,
+      });
+      expect(setStatus).toHaveBeenCalledWith("completed");
+      expect(clearOnboardingState).toHaveBeenCalled();
+      expect(onComplete).toHaveBeenCalled();
     });
-    expect(setStatus).toHaveBeenCalledWith("completed");
-    expect(clearOnboardingState).toHaveBeenCalled();
-    expect(onComplete).toHaveBeenCalled();
   });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -33,7 +33,6 @@ import { AdminOwnedProject, AuthPage } from "@stackframe/stack";
 import { type AppId } from "@stackframe/stack-shared/dist/apps/apps-config";
 import { type EnvironmentConfigOverrideOverride } from "@stackframe/stack-shared/dist/config/schema";
 import { projectOnboardingStatusValues, type ProjectOnboardingStatus } from "@stackframe/stack-shared/dist/schema-fields";
-import { allProviders } from "@stackframe/stack-shared/dist/utils/oauth";
 import { runAsynchronouslyWithAlert } from "@stackframe/stack-shared/dist/utils/promises";
 import { useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -61,6 +60,7 @@ import {
   PRIMARY_APP_IDS,
   type ProjectOnboardingState,
   REQUIRED_APP_IDS,
+  SHARED_OAUTH_SIGN_IN_METHODS,
   SIGN_IN_METHODS,
   type SignInMethod,
 } from "./shared";
@@ -236,8 +236,8 @@ export function ProjectOnboardingWizard(props: {
         credentialEnabled: signInMethods.has("credential"),
         magicLinkEnabled: signInMethods.has("magicLink"),
         passkeyEnabled: signInMethods.has("passkey"),
-        oauthProviders: (allProviders as readonly string[])
-          .filter((providerId) => signInMethods.has(providerId as SignInMethod))
+        oauthProviders: SHARED_OAUTH_SIGN_IN_METHODS
+          .filter((providerId) => signInMethods.has(providerId))
           .map((providerId) => ({ id: providerId, type: "shared" as const })),
       },
     };
@@ -319,26 +319,16 @@ export function ProjectOnboardingWizard(props: {
   }, [completeConfig.emails.selectedThemeId, isDevelopmentEnvironment, selectedApps, selectedEmailThemeId, signInMethods]);
 
   const buildEnvironmentOAuthConfigUpdate = useCallback(() => {
-    return {
-      "auth.oauth.providers.google": signInMethods.has("google") ? {
-        type: "google",
+    const configUpdate: EnvironmentConfigOverrideOverride = {};
+    for (const providerId of SHARED_OAUTH_SIGN_IN_METHODS) {
+      configUpdate[`auth.oauth.providers.${providerId}`] = signInMethods.has(providerId) ? {
+        type: providerId,
         isShared: true,
         allowSignIn: true,
         allowConnectedAccounts: true,
-      } : null,
-      "auth.oauth.providers.github": signInMethods.has("github") ? {
-        type: "github",
-        isShared: true,
-        allowSignIn: true,
-        allowConnectedAccounts: true,
-      } : null,
-      "auth.oauth.providers.microsoft": signInMethods.has("microsoft") ? {
-        type: "microsoft",
-        isShared: true,
-        allowSignIn: true,
-        allowConnectedAccounts: true,
-      } : null,
-    };
+      } : null;
+    }
+    return configUpdate;
   }, [signInMethods]);
 
   const finalizeOnboarding = useCallback(async () => {

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/shared.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/shared.ts
@@ -2,6 +2,7 @@ import { stackAppInternalsSymbol } from "@/lib/stack-app-internals";
 import { AdminOwnedProject } from "@stackframe/stack";
 import { ALL_APPS, type AppId } from "@stackframe/stack-shared/dist/apps/apps-config";
 import { projectOnboardingStatusValues, type ProjectOnboardingStatus } from "@stackframe/stack-shared/dist/schema-fields";
+import { sharedProviders } from "@stackframe/stack-shared/dist/utils/oauth";
 import { stringCompare } from "@stackframe/stack-shared/dist/utils/strings";
 
 const PROJECT_ONBOARDING_STATUSES = projectOnboardingStatusValues;
@@ -23,7 +24,10 @@ export const REQUIRED_APP_IDS: AppId[] = ["authentication", "emails"];
 export const PRIMARY_APP_IDS: AppId[] = ["authentication", "emails", "payments", "analytics"];
 export const ALL_APP_IDS = Object.keys(ALL_APPS) as AppId[];
 export const ONBOARDING_APP_IDS = ALL_APP_IDS.filter((appId) => ALL_APPS[appId].stage !== "alpha");
-export const OAUTH_SIGN_IN_METHODS: SignInMethod[] = ["google", "github", "microsoft"];
+export const OAUTH_SIGN_IN_METHODS = ["google", "github", "microsoft"] satisfies SignInMethod[];
+export const SHARED_OAUTH_SIGN_IN_METHODS = sharedProviders.filter((provider): provider is (typeof sharedProviders)[number] & SignInMethod => {
+  return OAUTH_SIGN_IN_METHODS.some((method) => method === provider);
+});
 
 export type ProjectOnboardingState = {
   selected_config_choice: OnboardingConfigChoice,


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

Fixes Google/GitHub/Microsoft shared OAuth providers selected during new-project onboarding not being persisted into the project environment config.

- Reuses the shared-provider list for onboarding OAuth preview and config updates
- Writes environment OAuth config only for onboarding methods that can use shared keys
- Adds a regression test that completes onboarding with Google selected and asserts the provider config update is saved before completion

Validation:
- `pnpm test run apps/dashboard/src/app/'(main)'/'(protected)'/'(outside-dashboard)'/new-project/page-client-parts/project-onboarding-wizard.test.tsx`
- `pnpm lint --fix`
- `pnpm --filter @stackframe/dashboard typecheck`

Note: full `pnpm typecheck` currently fails in `@stackframe/backend` because generated Prisma artifacts are missing (`@/generated/prisma/client`), while dashboard typecheck passes.

Link to Devin session: https://app.devin.ai/sessions/fe87aa598a524ab0822341324c03d90c
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth provider handling during project onboarding so shared authentication methods are reliably persisted.

* **Refactor**
  * Onboarding now derives shared OAuth options from a consolidated source, streamlining how provider selections are assembled and saved.

* **Tests**
  * Added tests verifying shared OAuth provider selections are preserved and onboarding completion behavior triggers as expected.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1477?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->