### PR TITLE
Fix docs overview setup prompt card

### DIFF
--- a/docs-mintlify/index.mdx
+++ b/docs-mintlify/index.mdx
@@ -5,6 +5,8 @@ sidebarTitle: "Overview"
 ---
 
 
+import { generatedSetupPromptText } from "/snippets/home-prompt-island.jsx";
+
 export const SectionLink = ({ href, children }) => (
   <a href={href} className="text-base font-semibold text-slate-900 no-underline hover:text-[#6b5df7] dark:text-white dark:hover:text-[#8b7cf9]">{children}</a>
 );
@@ -79,22 +81,14 @@ export const copyGeneratedSetupPrompt = async (event) => {
   </p>
 
   <h1 className="mt-3 text-4xl font-semibold tracking-tight text-zinc-900 sm:text-5xl dark:text-zinc-50">
-    Start with a single prompt.
+    Set up with one prompt.
   </h1>
   <p className="mt-3 max-w-3xl text-base leading-7 text-zinc-600 dark:text-zinc-300">
-    Set up Stack Auth by copying the prompt below into your favorite coding agent.
+    Copy the full Stack Auth setup prompt into your coding agent, or follow the manual instructions.
   </p>
 
-  <div className="relative mt-6">
-    <pre className="max-h-40 overflow-auto whitespace-pre-wrap rounded-2xl border border-[#cdd7f4] bg-white/75 px-4 py-3 pr-32 font-mono text-xs leading-6 text-zinc-700 backdrop-blur-sm sm:text-sm dark:border-[#33476d] dark:bg-black/20 dark:text-zinc-200"><code>{generatedSetupPromptText}</code></pre>
-    <button
-      type="button"
-      onClick={copyGeneratedSetupPrompt}
-      className="absolute right-2 top-2 inline-flex items-center justify-center rounded-lg border border-[#9fb5e4] bg-[#eaf1ff] px-3 py-1.5 text-xs font-semibold text-[#2a4272] transition-colors duration-150 hover:transition-none hover:bg-[#dde8ff] focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#f3f6ff] dark:border-[#3d5a91] dark:bg-[#12213d] dark:text-[#d5e6ff] dark:hover:bg-[#1a2e51] dark:focus-visible:ring-offset-[#0f1a2e]"
-    >
-      Copy prompt
-    </button>
-    <div className="pointer-events-none absolute inset-x-2 bottom-2 h-8 rounded-b-xl bg-gradient-to-t from-[#f4f7ff] to-transparent dark:from-[#0f1a2e]" />
+  <div className="mt-6 overflow-hidden rounded-2xl border border-[#cdd7f4] bg-white/75 backdrop-blur-sm dark:border-[#33476d] dark:bg-black/20">
+    <pre className="max-h-80 overflow-auto whitespace-pre-wrap px-4 py-3 font-mono text-xs leading-6 text-zinc-700 sm:text-sm dark:text-zinc-200"><code>{generatedSetupPromptText}</code></pre>
   </div>
   <p data-copy-prompt-error="true" hidden className="mt-2 text-xs font-medium text-red-700 dark:text-red-300" />
 
@@ -103,16 +97,15 @@ export const copyGeneratedSetupPrompt = async (event) => {
       href="/guides/getting-started/setup"
       className="inline-flex items-center justify-center rounded-xl bg-[#1e2f57] px-5 py-3 text-sm font-semibold !text-[#eef4ff] no-underline transition-colors duration-150 hover:transition-none hover:bg-[#253a6b] dark:bg-[#1e2f57] dark:hover:bg-[#253a6b] dark:!text-[#eef4ff]"
     >
-      View setup docs
+      View manual setup instructions
     </a>
-    <a
-      href="https://app.stack-auth.com"
-      target="_blank"
-      rel="noopener"
-      className="inline-flex items-center justify-center rounded-xl border border-[#9fb5e4] bg-white/60 px-5 py-3 text-sm font-semibold text-[#1f3764] no-underline transition-colors duration-150 hover:transition-none hover:bg-white/85 dark:border-[#3d5a91] dark:bg-transparent dark:text-[#d7e7ff] dark:hover:bg-white/10"
+    <button
+      type="button"
+      onClick={copyGeneratedSetupPrompt}
+      className="inline-flex items-center justify-center rounded-xl border border-[#9fb5e4] bg-white/60 px-5 py-3 text-sm font-semibold text-[#1f3764] transition-colors duration-150 hover:transition-none hover:bg-white/85 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-violet-500 focus-visible:ring-offset-2 focus-visible:ring-offset-[#f3f6ff] dark:border-[#3d5a91] dark:bg-transparent dark:text-[#d7e7ff] dark:hover:bg-white/10 dark:focus-visible:ring-offset-[#0f1a2e]"
     >
-      Go to dashboard
-    </a>
+      Copy prompt
+    </button>
   </div>
 </div>
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

Updates the docs overview setup prompt card to show the full prompt in a scrollable card and replaces the dashboard action with manual setup + copy prompt actions.

Validation:
- `pnpm --dir /home/ubuntu/repos/stack-auth --filter @stackframe/docs-mintlify lint`
- `pnpm --dir /home/ubuntu/repos/stack-auth --filter @stackframe/docs-mintlify typecheck`

Link to Devin session: https://app.devin.ai/sessions/5d2d891fff6a4357915366f6a3824c6c
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves the docs overview setup prompt card by showing the full prompt in a scrollable container and replacing the dashboard link with clearer "Copy prompt" and "View manual setup instructions" actions. This makes setup faster and more accessible.

- **New Features**
  - Renders `generatedSetupPromptText` in a bordered, scrollable card with increased max height.
  - Moves "Copy prompt" to the action row and adds focus-visible styles for better accessibility.

<sup>Written for commit 6630bbf36520e558949d171b002efecd51362027. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1484?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only UI copy and layout in `index.mdx`; no auth, API, or runtime product logic.
> 
> **Overview**
> The docs **Overview** hero card is reworked so readers see the **full** `generatedSetupPromptText` in a taller, scrollable preview (`max-h-80`) instead of a clipped block with an overlay **Copy prompt** control and bottom fade.
> 
> **Copy prompt** moves into the primary action row next to **View manual setup instructions** (renamed from “View setup docs”), with added `focus-visible` ring styles. The external **Go to dashboard** link is removed from this card. Headline and supporting copy are tightened to emphasize agent copy vs manual setup.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6630bbf36520e558949d171b002efecd51362027. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated the setup section layout and styling for improved clarity and navigation.
  * Reorganized call-to-action elements, including repositioning the copy prompt button and revising link text.
  * Enhanced the presentation of the setup prompt display.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1484?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->