### PR TITLE
Fix bundled dashboard symlinks in stack-cli

### DIFF
--- a/packages/stack-cli/scripts/copy-runtime-assets.mjs
+++ b/packages/stack-cli/scripts/copy-runtime-assets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "child_process";
 import { chmodSync, cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync } from "fs";
-import { dirname, join, resolve } from "path";
+import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -48,8 +48,12 @@ function copyDashboardSymlinkTarget(src, dest) {
   cpSync(src, dest, { recursive: true, dereference: true, filter: shouldCopyDashboardFile });
 }
 
+function splitDashboardPath(root, path) {
+  return relative(root, path).split(/[\\/]+/);
+}
+
 function getDashboardDependencyName(pnpmRoot, path) {
-  const parts = path.slice(pnpmRoot.length + 1).split("/");
+  const parts = splitDashboardPath(pnpmRoot, path);
   const nodeModulesIndex = parts.lastIndexOf("node_modules");
   if (nodeModulesIndex < 0) {
     return undefined;
@@ -79,7 +83,8 @@ function copyDashboardHoistedDependencies(pnpmRoot, current = pnpmRoot) {
       continue;
     }
     const target = resolve(current, readlinkSync(path));
-    if (!path.includes("/node_modules/.pnpm/node_modules/")) {
+    const parts = splitDashboardPath(pnpmRoot, path);
+    if (parts[0] !== "node_modules" && existsSync(join(target, "package.json"))) {
       copyDashboardSymlinkTarget(target, join(dashboardDist, "node_modules", dependencyName));
     }
   }

--- a/packages/stack-cli/scripts/copy-runtime-assets.mjs
+++ b/packages/stack-cli/scripts/copy-runtime-assets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync, writeFileSync } from "fs";
-import { dirname, isAbsolute, join, resolve } from "path";
+import { chmodSync, cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync } from "fs";
+import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -17,7 +17,6 @@ const dashboardPublicSrc = join(dashboardRoot, "public");
 const distDir = join(packageRoot, "dist");
 const emulatorDist = join(distDir, "emulator");
 const dashboardDist = join(distDir, "dashboard");
-const dashboardSymlinksManifestPath = join(dashboardDist, "symlinks.json");
 
 function assertExists(path, message) {
   if (!existsSync(path)) {
@@ -40,29 +39,50 @@ function copyEmulatorAssets() {
   console.log(`Copied emulator assets into ${emulatorDist} (+ .env.development into ${distDir}).`);
 }
 
-function collectSymlinks(root, current = root) {
-  const symlinks = [];
+function shouldCopyDashboardFile(path) {
+  return existsSync(path);
+}
+
+function copyDashboardSymlinkTarget(src, dest) {
+  rmSync(dest, { recursive: true, force: true });
+  cpSync(src, dest, { recursive: true, dereference: true, filter: shouldCopyDashboardFile });
+}
+
+function getDashboardDependencyName(pnpmRoot, path) {
+  const parts = path.slice(pnpmRoot.length + 1).split("/");
+  const nodeModulesIndex = parts.lastIndexOf("node_modules");
+  if (nodeModulesIndex < 0) {
+    return undefined;
+  }
+  const dependencyParts = parts.slice(nodeModulesIndex + 1);
+  if (dependencyParts.length === 1) {
+    return dependencyParts[0];
+  }
+  if (dependencyParts.length === 2 && dependencyParts[0].startsWith("@")) {
+    return join(dependencyParts[0], dependencyParts[1]);
+  }
+  return undefined;
+}
+
+function copyDashboardHoistedDependencies(pnpmRoot, current = pnpmRoot) {
   for (const entry of readdirSync(current, { withFileTypes: true })) {
     const path = join(current, entry.name);
-    if (entry.isSymbolicLink()) {
-      if (!existsSync(path)) {
-        continue;
-      }
-      const target = readlinkSync(path);
-      if (isAbsolute(target)) {
-        throw new Error(`Dashboard standalone build contains a non-portable absolute symlink: ${path} -> ${target}`);
-      }
-      symlinks.push({
-        path: path.slice(root.length + 1),
-        target,
-      });
+    if (entry.isDirectory()) {
+      copyDashboardHoistedDependencies(pnpmRoot, path);
       continue;
     }
-    if (entry.isDirectory()) {
-      symlinks.push(...collectSymlinks(root, path));
+    if (!entry.isSymbolicLink() || !existsSync(path)) {
+      continue;
+    }
+    const dependencyName = getDashboardDependencyName(pnpmRoot, path);
+    if (dependencyName == null) {
+      continue;
+    }
+    const target = resolve(current, readlinkSync(path));
+    if (!path.includes("/node_modules/.pnpm/node_modules/")) {
+      copyDashboardSymlinkTarget(target, join(dashboardDist, "node_modules", dependencyName));
     }
   }
-  return symlinks;
 }
 
 function copyDashboardAssets() {
@@ -76,12 +96,12 @@ function copyDashboardAssets() {
   );
 
   rmSync(dashboardDist, { recursive: true, force: true });
-  cpSync(dashboardStandaloneSrc, dashboardDist, { recursive: true, verbatimSymlinks: true });
+  cpSync(dashboardStandaloneSrc, dashboardDist, { recursive: true, dereference: true, filter: shouldCopyDashboardFile });
   cpSync(dashboardStaticSrc, join(dashboardDist, "apps/dashboard/.next/static"), { recursive: true });
   if (existsSync(dashboardPublicSrc)) {
     cpSync(dashboardPublicSrc, join(dashboardDist, "apps/dashboard/public"), { recursive: true });
   }
-  writeFileSync(dashboardSymlinksManifestPath, `${JSON.stringify(collectSymlinks(dashboardDist), undefined, 2)}\n`);
+  copyDashboardHoistedDependencies(join(dashboardStandaloneSrc, "node_modules/.pnpm"));
 
   console.log(`Copied dashboard standalone runtime into ${dashboardDist}.`);
 }

--- a/packages/stack-cli/scripts/copy-runtime-assets.mjs
+++ b/packages/stack-cli/scripts/copy-runtime-assets.mjs
@@ -1,6 +1,6 @@
 #!/usr/bin/env node
 import { execFileSync } from "child_process";
-import { chmodSync, cpSync, existsSync, mkdirSync, rmSync } from "fs";
+import { chmodSync, cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -17,6 +17,7 @@ const dashboardPublicSrc = join(dashboardRoot, "public");
 const distDir = join(packageRoot, "dist");
 const emulatorDist = join(distDir, "emulator");
 const dashboardDist = join(distDir, "dashboard");
+const dashboardSymlinksManifestPath = join(dashboardDist, "symlinks.json");
 
 function assertExists(path, message) {
   if (!existsSync(path)) {
@@ -39,6 +40,27 @@ function copyEmulatorAssets() {
   console.log(`Copied emulator assets into ${emulatorDist} (+ .env.development into ${distDir}).`);
 }
 
+function collectSymlinks(root, current = root) {
+  const symlinks = [];
+  for (const entry of readdirSync(current, { withFileTypes: true })) {
+    const path = join(current, entry.name);
+    if (entry.isSymbolicLink()) {
+      if (!existsSync(path)) {
+        continue;
+      }
+      symlinks.push({
+        path: path.slice(root.length + 1),
+        target: readlinkSync(path),
+      });
+      continue;
+    }
+    if (entry.isDirectory()) {
+      symlinks.push(...collectSymlinks(root, path));
+    }
+  }
+  return symlinks;
+}
+
 function copyDashboardAssets() {
   assertExists(
     join(dashboardStandaloneSrc, "apps/dashboard/server.js"),
@@ -50,11 +72,12 @@ function copyDashboardAssets() {
   );
 
   rmSync(dashboardDist, { recursive: true, force: true });
-  cpSync(dashboardStandaloneSrc, dashboardDist, { recursive: true });
+  cpSync(dashboardStandaloneSrc, dashboardDist, { recursive: true, verbatimSymlinks: true });
   cpSync(dashboardStaticSrc, join(dashboardDist, "apps/dashboard/.next/static"), { recursive: true });
   if (existsSync(dashboardPublicSrc)) {
     cpSync(dashboardPublicSrc, join(dashboardDist, "apps/dashboard/public"), { recursive: true });
   }
+  writeFileSync(dashboardSymlinksManifestPath, `${JSON.stringify(collectSymlinks(dashboardDist), undefined, 2)}\n`);
 
   console.log(`Copied dashboard standalone runtime into ${dashboardDist}.`);
 }

--- a/packages/stack-cli/scripts/copy-runtime-assets.mjs
+++ b/packages/stack-cli/scripts/copy-runtime-assets.mjs
@@ -1,7 +1,7 @@
 #!/usr/bin/env node
 import { execFileSync } from "child_process";
 import { chmodSync, cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync, writeFileSync } from "fs";
-import { dirname, join, resolve } from "path";
+import { dirname, isAbsolute, join, resolve } from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
@@ -48,9 +48,13 @@ function collectSymlinks(root, current = root) {
       if (!existsSync(path)) {
         continue;
       }
+      const target = readlinkSync(path);
+      if (isAbsolute(target)) {
+        throw new Error(`Dashboard standalone build contains a non-portable absolute symlink: ${path} -> ${target}`);
+      }
       symlinks.push({
         path: path.slice(root.length + 1),
-        target: readlinkSync(path),
+        target,
       });
       continue;
     }

--- a/packages/stack-cli/src/commands/dev.ts
+++ b/packages/stack-cli/src/commands/dev.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from "child_process";
 import { Command } from "commander";
-import { chmodSync, closeSync, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, writeFileSync, writeSync } from "fs";
+import { chmodSync, closeSync, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync, writeSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { DEFAULT_API_URL, DEFAULT_PUBLISHABLE_CLIENT_KEY, resolveLoginConfig } from "../lib/auth.js";
@@ -31,6 +31,7 @@ const DASHBOARD_PORT = 26700;
 const DASHBOARD_START_TIMEOUT_MS = 60_000;
 const BUNDLED_DASHBOARD_DIR_NAME = "dashboard";
 const BUNDLED_DASHBOARD_SERVER_PATH = join("apps", "dashboard", "server.js");
+const BUNDLED_DASHBOARD_SYMLINKS_MANIFEST_PATH = "symlinks.json";
 const DASHBOARD_RUNTIME_DIR_NAME = "rde-dashboard-runtime";
 const SENTINEL_PREFIX = "STACK_ENV_VAR_SENTINEL_";
 const USE_INLINE_ENV_VARS_SENTINEL = "STACK_ENV_VAR_SENTINEL_USE_INLINE_ENV_VARS";
@@ -57,6 +58,11 @@ type ProgressLogger = {
 type DashboardSessionState = {
   session: SessionResponse,
   dashboardReachableSinceMs: number,
+};
+
+type DashboardSymlink = {
+  path: string,
+  target: string,
 };
 
 function wait(ms: number): Promise<void> {
@@ -213,12 +219,46 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
   }
 }
 
+function isDashboardSymlink(value: unknown): value is DashboardSymlink {
+  if (typeof value !== "object" || value == null) {
+    return false;
+  }
+  if (!("path" in value) || !("target" in value)) {
+    return false;
+  }
+  return typeof value.path === "string" && typeof value.target === "string";
+}
+
+function parseDashboardSymlinksManifest(content: string): DashboardSymlink[] {
+  const parsed: unknown = JSON.parse(content);
+  if (!Array.isArray(parsed) || !parsed.every(isDashboardSymlink)) {
+    throw new CliError("The bundled development-environment dashboard has an invalid symlink manifest.");
+  }
+  return parsed;
+}
+
+function restoreDashboardRuntimeSymlinks(root: string): void {
+  const manifestPath = join(root, BUNDLED_DASHBOARD_SYMLINKS_MANIFEST_PATH);
+  if (!existsSync(manifestPath)) {
+    throw new CliError("The bundled development-environment dashboard is missing its symlink manifest.");
+  }
+
+  const manifest = parseDashboardSymlinksManifest(readFileSync(manifestPath, "utf-8"));
+  for (const symlink of manifest) {
+    const path = join(root, symlink.path);
+    rmSync(path, { recursive: true, force: true });
+    mkdirSync(dirname(path), { recursive: true });
+    symlinkSync(symlink.target, path);
+  }
+}
+
 function prepareDashboardRuntime(env: NodeJS.ProcessEnv): string {
   assertBundledDashboardExists();
   const runtimeRoot = dashboardRuntimeRoot();
   mkdirSync(dirname(runtimeRoot), { recursive: true });
   rmSync(runtimeRoot, { recursive: true, force: true });
-  cpSync(bundledDashboardRoot(), runtimeRoot, { recursive: true });
+  cpSync(bundledDashboardRoot(), runtimeRoot, { recursive: true, verbatimSymlinks: true });
+  restoreDashboardRuntimeSymlinks(runtimeRoot);
   replaceDashboardRuntimeSentinels(runtimeRoot, env);
 
   const runtimeServerPath = join(runtimeRoot, BUNDLED_DASHBOARD_SERVER_PATH);

--- a/packages/stack-cli/src/commands/dev.ts
+++ b/packages/stack-cli/src/commands/dev.ts
@@ -218,7 +218,7 @@ function prepareDashboardRuntime(env: NodeJS.ProcessEnv): string {
   const runtimeRoot = dashboardRuntimeRoot();
   mkdirSync(dirname(runtimeRoot), { recursive: true });
   rmSync(runtimeRoot, { recursive: true, force: true });
-  cpSync(bundledDashboardRoot(), runtimeRoot, { recursive: true, verbatimSymlinks: true });
+  cpSync(bundledDashboardRoot(), runtimeRoot, { recursive: true });
   replaceDashboardRuntimeSentinels(runtimeRoot, env);
 
   const runtimeServerPath = join(runtimeRoot, BUNDLED_DASHBOARD_SERVER_PATH);

--- a/packages/stack-cli/src/commands/dev.ts
+++ b/packages/stack-cli/src/commands/dev.ts
@@ -1,6 +1,6 @@
 import { execFileSync, spawn } from "child_process";
 import { Command } from "commander";
-import { chmodSync, closeSync, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, symlinkSync, writeFileSync, writeSync } from "fs";
+import { chmodSync, closeSync, cpSync, existsSync, mkdirSync, openSync, readdirSync, readFileSync, rmSync, writeFileSync, writeSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
 import { DEFAULT_API_URL, DEFAULT_PUBLISHABLE_CLIENT_KEY, resolveLoginConfig } from "../lib/auth.js";
@@ -31,7 +31,6 @@ const DASHBOARD_PORT = 26700;
 const DASHBOARD_START_TIMEOUT_MS = 60_000;
 const BUNDLED_DASHBOARD_DIR_NAME = "dashboard";
 const BUNDLED_DASHBOARD_SERVER_PATH = join("apps", "dashboard", "server.js");
-const BUNDLED_DASHBOARD_SYMLINKS_MANIFEST_PATH = "symlinks.json";
 const DASHBOARD_RUNTIME_DIR_NAME = "rde-dashboard-runtime";
 const SENTINEL_PREFIX = "STACK_ENV_VAR_SENTINEL_";
 const USE_INLINE_ENV_VARS_SENTINEL = "STACK_ENV_VAR_SENTINEL_USE_INLINE_ENV_VARS";
@@ -58,11 +57,6 @@ type ProgressLogger = {
 type DashboardSessionState = {
   session: SessionResponse,
   dashboardReachableSinceMs: number,
-};
-
-type DashboardSymlink = {
-  path: string,
-  target: string,
 };
 
 function wait(ms: number): Promise<void> {
@@ -219,46 +213,12 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
   }
 }
 
-function isDashboardSymlink(value: unknown): value is DashboardSymlink {
-  if (typeof value !== "object" || value == null) {
-    return false;
-  }
-  if (!("path" in value) || !("target" in value)) {
-    return false;
-  }
-  return typeof value.path === "string" && typeof value.target === "string";
-}
-
-function parseDashboardSymlinksManifest(content: string): DashboardSymlink[] {
-  const parsed: unknown = JSON.parse(content);
-  if (!Array.isArray(parsed) || !parsed.every(isDashboardSymlink)) {
-    throw new CliError("The bundled development-environment dashboard has an invalid symlink manifest.");
-  }
-  return parsed;
-}
-
-function restoreDashboardRuntimeSymlinks(root: string): void {
-  const manifestPath = join(root, BUNDLED_DASHBOARD_SYMLINKS_MANIFEST_PATH);
-  if (!existsSync(manifestPath)) {
-    throw new CliError("The bundled development-environment dashboard is missing its symlink manifest.");
-  }
-
-  const manifest = parseDashboardSymlinksManifest(readFileSync(manifestPath, "utf-8"));
-  for (const symlink of manifest) {
-    const path = join(root, symlink.path);
-    rmSync(path, { recursive: true, force: true });
-    mkdirSync(dirname(path), { recursive: true });
-    symlinkSync(symlink.target, path);
-  }
-}
-
 function prepareDashboardRuntime(env: NodeJS.ProcessEnv): string {
   assertBundledDashboardExists();
   const runtimeRoot = dashboardRuntimeRoot();
   mkdirSync(dirname(runtimeRoot), { recursive: true });
   rmSync(runtimeRoot, { recursive: true, force: true });
   cpSync(bundledDashboardRoot(), runtimeRoot, { recursive: true, verbatimSymlinks: true });
-  restoreDashboardRuntimeSymlinks(runtimeRoot);
   replaceDashboardRuntimeSentinels(runtimeRoot, env);
 
   const runtimeServerPath = join(runtimeRoot, BUNDLED_DASHBOARD_SERVER_PATH);


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

Fixes the packaged development-environment dashboard failing to resolve `next` after Mintlify setup.

Changes:
- Copy the dashboard standalone runtime with symlink dereferencing so `npm pack` ships real files instead of broken pnpm symlinks.
- Hoist dereferenced dependencies used by Next.js and instrumentation into the packaged dashboard runtime.
- Keep runtime startup simpler by removing symlink manifest restoration.

Validation:
- Reproduced the packed dashboard module-resolution failure before the fix.
- `pnpm --dir /home/ubuntu/repos/stack-auth --filter=@stackframe/stack-cli build`
- Packed and extracted `@stackframe/stack-cli`; verified `dist/dashboard` contains `0` symlinks.
- Started extracted `dist/dashboard/apps/dashboard/server.js`; verified `Next.js 16.1.7` and `Ready`.
- `pnpm --dir /home/ubuntu/repos/stack-auth --filter=@stackframe/stack-cli lint`
- `pnpm --dir /home/ubuntu/repos/stack-auth --filter=@stackframe/stack-cli typecheck`

Link to Devin session: https://app.devin.ai/sessions/13728b5ccea44f23b2d300c79ffc2440
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard packaging now preserves symlinks during bundling and runtime; hoisted dependency targets are detected and included so linked dependencies remain resolvable.

* **Bug Fixes**
  * Resolved issues where symbolic links could be lost or broken during asset copying by validating and dereferencing hoisted links for a more reliable dev experience.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1485?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->