### PR TITLE
Dev tool dashboard bug fix

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
@@ -349,7 +349,6 @@ function PageClientInner() {
                   value={projectName}
                   onChange={(event) => setProjectName(event.target.value)}
                   placeholder="My Project"
-                  required
                 />
               </div>
 

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
@@ -76,6 +76,7 @@ function PageClientInner() {
   const [projectOnboardingStates, setProjectOnboardingStates] = useState<Map<string, ProjectOnboardingState | null>>(new Map());
   const [loadingStatuses, setLoadingStatuses] = useState(true);
   const [projectName, setProjectName] = useState(displayNameFromSearch ?? "");
+  const hasProjectName = projectName.trim().length > 0;
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [creatingTeam, setCreatingTeam] = useState(false);
   const [creatingProject, setCreatingProject] = useState(false);
@@ -348,6 +349,7 @@ function PageClientInner() {
                   value={projectName}
                   onChange={(event) => setProjectName(event.target.value)}
                   placeholder="My Project"
+                  required
                 />
               </div>
 
@@ -376,6 +378,7 @@ function PageClientInner() {
               </DesignButton>
               <DesignButton
                 className="rounded-xl"
+                disabled={!hasProjectName || creatingProject}
                 loading={creatingProject}
                 onClick={() => {
                   if (!beginPendingAction(creatingProjectRef, setCreatingProject)) {

--- a/packages/stack-shared/src/utils/urls.tsx
+++ b/packages/stack-shared/src/utils/urls.tsx
@@ -219,6 +219,7 @@ export function isLocalhost(urlOrString: string | URL) {
   if (!url) return false;
   if (url.hostname === "localhost" || url.hostname.endsWith(".localhost")) return true;
   if (url.hostname.match(/^127\.\d+\.\d+\.\d+$/)) return true;
+  if (url.hostname === "[::1]" || url.hostname === "::1") return true;
   return false;
 }
 import.meta.vitest?.test("isLocalhost", ({ expect }) => {
@@ -228,6 +229,7 @@ import.meta.vitest?.test("isLocalhost", ({ expect }) => {
   expect(isLocalhost("http://sub.localhost")).toBe(true);
   expect(isLocalhost("http://127.0.0.1")).toBe(true);
   expect(isLocalhost("http://127.1.2.3")).toBe(true);
+  expect(isLocalhost("http://[::1]")).toBe(true);
 
   // Test with non-localhost URLs
   expect(isLocalhost("https://example.com")).toBe(false);

--- a/packages/template/src/dev-tool/dev-tool-core.ts
+++ b/packages/template/src/dev-tool/dev-tool-core.ts
@@ -2183,11 +2183,10 @@ function createPanel(
   }
 
   const tabs = getTabsForApp(app);
-  if (!tabs.some((tab) => tab.id === state.get().activeTab)) {
-    state.update({ activeTab: DEFAULT_STATE.activeTab });
-  }
+  const storedActiveTab = state.get().activeTab;
+  const activeTab = tabs.some((tab) => tab.id === storedActiveTab) ? storedActiveTab : DEFAULT_STATE.activeTab;
 
-  applyPanelMode(state.get().activeTab);
+  applyPanelMode(activeTab);
 
   const inner = h('div', { className: 'sdt-panel-inner' });
 
@@ -2203,7 +2202,7 @@ function createPanel(
 
   const trailingControls = h('div', { className: 'sdt-tabbar-actions' }, docsLink, closeBtn);
 
-  const tabBar = createTabBar(tabs, state.get().activeTab, (id) => {
+  const tabBar = createTabBar(tabs, activeTab, (id) => {
     state.update({ activeTab: id as TabId });
     applyPanelMode(id as TabId, { animate: true });
     showTab(id as TabId);
@@ -2277,7 +2276,7 @@ function createPanel(
     pane.classList.add('sdt-tab-pane-active');
   }
 
-  showTab(state.get().activeTab);
+  showTab(activeTab);
 
   function addResizeHandle(edge: 'top' | 'left' | 'top-left') {
     const handle = h('div', { className: `sdt-resize-handle sdt-resize-${edge}` });
@@ -2378,7 +2377,6 @@ export function createDevTool(app: StackClientApp<true>): () => void {
 
   function openPanel() {
     if (panel) return;
-    state.update({ activeTab: 'overview' });
     panel = createPanel(app, state, logStore, closePanelAndPersistClosed);
     wrapper.appendChild(panel.element);
   }

--- a/packages/template/src/dev-tool/dev-tool-core.ts
+++ b/packages/template/src/dev-tool/dev-tool-core.ts
@@ -4,6 +4,7 @@ import type { RequestLogEntry } from "@stackframe/stack-shared/dist/interface/cl
 import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
 import { isLocalhost } from "@stackframe/stack-shared/dist/utils/urls";
 import type { StackClientApp } from "../lib/stack-app";
+import { envVars } from "../lib/env";
 import { getBaseUrl } from "../lib/stack-app/apps/implementations/common";
 import type { HandlerUrlOptions, HandlerUrls, HandlerUrlTarget } from "../lib/stack-app/common";
 import { stackAppInternalsSymbol } from "../lib/stack-app/common";
@@ -201,6 +202,17 @@ function nextId() {
 function resolveApiBaseUrl(app: StackClientApp<true>): string {
   const opts = app[stackAppInternalsSymbol].getConstructorOptions();
   return getBaseUrl(opts.baseUrl);
+}
+
+function shouldShowDashboardTab(app: StackClientApp<true>): boolean {
+  return envVars.NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR === "true" && isLocalhost(resolveApiBaseUrl(app));
+}
+
+function getTabsForApp(app: StackClientApp<true>): { id: TabId; label: string; icon: string }[] {
+  if (shouldShowDashboardTab(app)) {
+    return TABS;
+  }
+  return TABS.filter((tab) => tab.id !== 'dashboard');
 }
 
 function deriveDashboardBaseUrl(apiBaseUrl: string): string {
@@ -2170,6 +2182,11 @@ function createPanel(
     panel.style.height = state.get().panelHeight + 'px';
   }
 
+  const tabs = getTabsForApp(app);
+  if (!tabs.some((tab) => tab.id === state.get().activeTab)) {
+    state.update({ activeTab: DEFAULT_STATE.activeTab });
+  }
+
   applyPanelMode(state.get().activeTab);
 
   const inner = h('div', { className: 'sdt-panel-inner' });
@@ -2186,7 +2203,7 @@ function createPanel(
 
   const trailingControls = h('div', { className: 'sdt-tabbar-actions' }, docsLink, closeBtn);
 
-  const tabBar = createTabBar(TABS, state.get().activeTab, (id) => {
+  const tabBar = createTabBar(tabs, state.get().activeTab, (id) => {
     state.update({ activeTab: id as TabId });
     applyPanelMode(id as TabId, { animate: true });
     showTab(id as TabId);


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes Dev Tool Dashboard tab visibility (only in local emulator, now including IPv6 localhost) and prevents creating projects without a valid name.

- **Bug Fixes**
  - Dev Tool: show Dashboard tab only when `NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR` is "true" and API base URL resolves to localhost (includes IPv6 `::1`); filter tabs and reset active tab if invalid.
  - New project modal: require a trimmed, non-empty name and disable Create when empty or while creating.

<sup>Written for commit d2a0f67a79beb775227ce2f0fd4026da0f5e48a0. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1486?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Dashboard tab visibility is now conditional based on local emulator environment.

* **Bug Fixes**
  * Project creation form now disables Create for empty/whitespace names.
  * Persisted tab selection is validated and preserved; invalid saved tabs fall back to a safe default and the panel no longer force-resets the active tab on open.
  * Localhost detection now correctly recognizes IPv6 loopback addresses.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1486?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->