### PR TITLE
Fix skills app CI typecheck

### DIFF
--- a/apps/skills/tsconfig.json
+++ b/apps/skills/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es2020",
+    "target": "es2021",
     "lib": [
       "dom",
       "dom.iterable",

--- a/apps/skills/tsconfig.json
+++ b/apps/skills/tsconfig.json
@@ -4,7 +4,8 @@
     "lib": [
       "dom",
       "dom.iterable",
-      "esnext"
+      "es2021",
+      "es2022.error"
     ],
     "allowJs": true,
     "strict": true,
@@ -17,6 +18,9 @@
     "jsx": "react-jsx",
     "incremental": true,
     "noErrorTruncation": true,
+    "types": [
+      "vitest/importMeta"
+    ],
     "plugins": [
       {
         "name": "next"


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

Fixes the `apps/skills` TypeScript config so the app can typecheck shared source files with inline Vitest tests and without pulling in newer weak-symbol library types.

Validated locally:
- `pnpm -C apps/skills typecheck`
- `pnpm -C apps/skills lint`
- `pnpm -C apps/skills build`
- `pnpm build --filter=@stackframe/skills`

Link to Devin session: https://app.devin.ai/sessions/0c5ec4011c754d42b1fb16ec8974588e
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI typechecking for the `apps/skills` app by aligning the TypeScript target/libs to ES2021 and enabling inline `vitest` test types. Prevents newer weak-symbol lib types from leaking and keeps shared sources typechecking reliably.

- **Bug Fixes**
  - Set `target` to `es2021` and replace `lib` `esnext` with `es2021` + `es2022.error`.
  - Add `types: ["vitest/importMeta"]` for inline `vitest` tests.

<sup>Written for commit 01a4c977c0b696fbdd26e1ec931c46e60f453f59. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1490?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Updated TypeScript compilation settings to target newer JavaScript features, adjust supported library definitions, and include test type definitions for better test-time type checking.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1490?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->