### PR TITLE
fix(skills): import stack-shared via package boundary, inline JSON in tsdown build

### DIFF
--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -13,6 +13,7 @@
     "lint": "eslint ."
   },
   "dependencies": {
+    "@stackframe/stack-shared": "workspace:*",
     "next": "16.1.7",
     "react": "19.2.3",
     "react-dom": "19.2.3"

--- a/apps/skills/src/app/route.ts
+++ b/apps/skills/src/app/route.ts
@@ -1,4 +1,4 @@
-import { skillSitePrompt } from "../../../../packages/stack-shared/src/ai/unified-prompts/skill-site-prompt";
+import { skillSitePrompt } from "@stackframe/stack-shared/dist/ai/unified-prompts/skill-site-prompt";
 
 const SKILL_MD = skillSitePrompt;
 

--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -70,6 +70,17 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
             return null;
           }
 
+          // JSON imports must be bundled inline. Otherwise the verbatim relative
+          // path is preserved in both dist/ (CJS, same depth as src/, accidentally
+          // resolves) and dist/esm/ (one level deeper, resolves one segment too
+          // high), and the ESM consumer fails at module-resolution time. Inlining
+          // also makes the published package work — the imported JSON file isn't
+          // shipped in `files`, so a runtime fetch from the install location would
+          // fail regardless.
+          if (source.endsWith('.json')) {
+            return null;
+          }
+
           return {
             id: source,
             external: true,

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -907,6 +907,9 @@ importers:
 
   apps/skills:
     dependencies:
+      '@stackframe/stack-shared':
+        specifier: workspace:*
+        version: link:../../packages/stack-shared
       next:
         specifier: 16.1.7
         version: 16.1.7(@babel/core@7.26.0)(@opentelemetry/api@1.9.0)(react-dom@19.2.3(react@19.2.3))(react@19.2.3)
@@ -30819,7 +30822,7 @@ snapshots:
       picomatch: 4.0.3
       seroval: 1.5.1
       source-map: 0.7.6
-      srvx: 0.11.9
+      srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
       vitefu: 1.1.2(vite@7.3.1(@types/node@22.19.0)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.0))
@@ -30853,7 +30856,7 @@ snapshots:
       picomatch: 4.0.3
       seroval: 1.5.1
       source-map: 0.7.6
-      srvx: 0.11.9
+      srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.0))
@@ -30887,7 +30890,7 @@ snapshots:
       picomatch: 4.0.3
       seroval: 1.5.1
       source-map: 0.7.6
-      srvx: 0.11.9
+      srvx: 0.11.15
       tinyglobby: 0.2.15
       ufo: 1.6.3
       vitefu: 1.1.2(vite@7.3.1(@types/node@24.9.2)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.21.0)(yaml@2.8.0))


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/stack-auth/blob/dev/CONTRIBUTING.md

-->

## What

Fixes the `lint_and_build (24)` CI failure that's been red on `dev` since commit `2f3e5d0d5a` ("Update LLM documentation"). The fix has two parts:

**1. Route the skills app's import of `skillSitePrompt` through the package boundary.** [apps/skills/src/app/route.ts:1](apps/skills/src/app/route.ts:1) was doing:

```ts
import { skillSitePrompt } from "../../../../packages/stack-shared/src/ai/unified-prompts/skill-site-prompt";
```

That deep relative path bypasses the `@stackframe/stack-shared` package export map (which points at `./dist/`) and pulls stack-shared's whole source tree into the Next.js TypeScript compilation. The `apps/skills/package.json` didn't even declare `@stackframe/stack-shared` as a dependency — a clear signal the import was meant to go through `dist/`. This PR flips it to:

```ts
import { skillSitePrompt } from "@stackframe/stack-shared/dist/ai/unified-prompts/skill-site-prompt";
```

matching the established repo convention used in `docs/` and `examples/demo/`, and adds the workspace dep.

**2. Inline JSON imports in the shared `tsdown` build config.** Once the import goes through `dist/`, a latent build bug surfaces. The shared tsdown config [configs/tsdown/js-library.ts](configs/tsdown/js-library.ts) marks every non-entry import external — including the JSON import in [packages/stack-shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-index.ts:1](packages/stack-shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-index.ts:1):

```ts
import docsJson from "../../../../../../docs-mintlify/docs.json";
```

The verbatim relative path is preserved in both build outputs, but:
- `dist/...` (CJS) is the same depth as `src/...` → the path *accidentally* resolves correctly.
- `dist/esm/...` is **one level deeper** → the path lands one segment too high (`packages/docs-mintlify/docs.json` instead of `docs-mintlify/docs.json`).

So the CJS build worked by coincidence and the ESM build was broken — but nobody had consumed the ESM build of this file from outside the package until now, so it stayed hidden. (The published-to-npm artifact would also be broken regardless, since `docs-mintlify/` isn't in stack-shared's `"files"`.)

The fix is a one-line carve-out in the `force most files to be external` plugin: if the import ends in `.json`, bundle it inline. `docs-mintlify/docs.json` is 7KB; I grepped and it's the only JSON import in stack-shared `src/`.

## Why this is on `dev`, not just one PR

Same `lint_and_build (24)` failure shows up on `dev` HEAD (`a4ae7edec`, and now `7a2561dd7`). Any PR branched off recent `dev` was hitting it (which is how I found it — investigating its appearance on [#1481](https://github.com/hexclave/stack-auth/pull/1481)).

## What this PR does *not* fix (out of scope)

[packages/stack-shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-index.ts](packages/stack-shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-index.ts) still reaches across the workspace into `docs-mintlify/docs.json` via a 6-level relative path. With the JSON now inlined, the value is snapshotted at stack-shared build time — so a consumer that upgrades `@stackframe/stack-shared` without rebuilding stale docs gets a stale prompt. That's a layering smell worth a separate cleanup (codegen the relevant slice into a stack-shared source file, or move `docs.json` into the package).

## Verification

Locally on this branch:

- `pnpm --filter @stackframe/skills run build` ✓ (this is the step that failed in CI: [run/26472095929/job/77947958328](https://github.com/hexclave/stack-auth/actions/runs/26472095929/job/77947958328))
- `pnpm --filter @stackframe/skills run typecheck` ✓
- `pnpm --filter @stackframe/stack-shared run typecheck` ✓ (stack-shared's own type story is unchanged)

## Reviewer note — blast radius of the tsdown change

[configs/tsdown/js-library.ts](configs/tsdown/js-library.ts) is consumed by every package whose tsdown config does `createJsLibraryTsupConfig(...)` (stack-shared, stack-sc, and possibly more). Today only stack-shared has a JSON import, so the runtime impact is limited to that one file. The behaviour change for **future** JSON imports under this config is "inlined into dist rather than externalized" — almost certainly what callers want (externalized JSON breaks under any layout change, as it did here), but flagging explicitly.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the red lint_and_build CI on dev by importing `skillSitePrompt` through the `@stackframe/stack-shared` package boundary and inlining JSON imports in the shared build config. This stops source-only files from leaking into the app build and fixes ESM JSON path resolution.

- **Bug Fixes**
  - Route the skills app prompt import via `@stackframe/stack-shared/dist/...` to avoid pulling package `src/` into Next.js and tripping Vitest types.
  - Inline `.json` imports in the shared build config to fix ESM resolution and ensure the published package works.

- **Dependencies**
  - Add `@stackframe/stack-shared` to `apps/skills` as a workspace dependency.

<sup>Written for commit 603e3534842c3c55bd9b4a0ae318e9950ac378e0. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1491?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

