### PR TITLE
Add captureWarning and use it for flush failures

### DIFF
--- a/apps/backend/src/polyfills.tsx
+++ b/apps/backend/src/polyfills.tsx
@@ -32,7 +32,12 @@ export function ensurePolyfilled() {
   }
 
   registerErrorSink(sentryErrorSink);
-  registerWarningSink(sentryErrorSink);
+  registerWarningSink((location, error) => {
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning");
+      sentryErrorSink(location, error);
+    });
+  });
 
   if ("addEventListener" in globalThis) {
     globalThis.addEventListener("unhandledrejection", (event) => {

--- a/apps/backend/src/polyfills.tsx
+++ b/apps/backend/src/polyfills.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { getEnvVariable, getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
-import { captureError, registerErrorSink } from "@stackframe/stack-shared/dist/utils/errors";
+import { captureError, registerErrorSink, registerWarningSink } from "@stackframe/stack-shared/dist/utils/errors";
 import * as util from "util";
 import { runAsynchronouslyAndWaitUntil } from "./utils/background-tasks";
 
@@ -32,6 +32,7 @@ export function ensurePolyfilled() {
   }
 
   registerErrorSink(sentryErrorSink);
+  registerWarningSink(sentryErrorSink);
 
   if ("addEventListener" in globalThis) {
     globalThis.addEventListener("unhandledrejection", (event) => {

--- a/apps/dashboard/src/polyfills.tsx
+++ b/apps/dashboard/src/polyfills.tsx
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/nextjs";
 import { getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
-import { captureError, registerErrorSink } from "@stackframe/stack-shared/dist/utils/errors";
+import { captureError, registerErrorSink, registerWarningSink } from "@stackframe/stack-shared/dist/utils/errors";
 import * as util from "util";
 import { getPublicEnvVar } from "./lib/env";
 
@@ -25,6 +25,7 @@ export function ensurePolyfilled() {
   }
 
   registerErrorSink(sentryErrorSink);
+  registerWarningSink(sentryErrorSink);
 
   if ("addEventListener" in globalThis) {
     globalThis.addEventListener("unhandledrejection", (event) => {

--- a/apps/dashboard/src/polyfills.tsx
+++ b/apps/dashboard/src/polyfills.tsx
@@ -25,7 +25,12 @@ export function ensurePolyfilled() {
   }
 
   registerErrorSink(sentryErrorSink);
-  registerWarningSink(sentryErrorSink);
+  registerWarningSink((location, error) => {
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning");
+      sentryErrorSink(location, error);
+    });
+  });
 
   if ("addEventListener" in globalThis) {
     globalThis.addEventListener("unhandledrejection", (event) => {

--- a/packages/stack-cli/src/lib/sentry.ts
+++ b/packages/stack-cli/src/lib/sentry.ts
@@ -1,6 +1,6 @@
 import * as Sentry from "@sentry/node";
 import { getEnvVariable, getNodeEnvironment } from "@stackframe/stack-shared/dist/utils/env";
-import { registerErrorSink } from "@stackframe/stack-shared/dist/utils/errors";
+import { registerErrorSink, registerWarningSink } from "@stackframe/stack-shared/dist/utils/errors";
 import { ignoreUnhandledRejection } from "@stackframe/stack-shared/dist/utils/promises";
 import { sentryBaseConfig } from "@stackframe/stack-shared/dist/utils/sentry";
 import { nicify } from "@stackframe/stack-shared/dist/utils/strings";
@@ -89,8 +89,10 @@ export function initSentry() {
     },
   });
 
-  registerErrorSink((location, error) => {
+  const sentrySink = (location: string, error: unknown) => {
     Sentry.captureException(error, { extra: { location } });
     ignoreUnhandledRejection(Sentry.flush(2000));
-  });
+  };
+  registerErrorSink(sentrySink);
+  registerWarningSink(sentrySink);
 }

--- a/packages/stack-cli/src/lib/sentry.ts
+++ b/packages/stack-cli/src/lib/sentry.ts
@@ -94,5 +94,10 @@ export function initSentry() {
     ignoreUnhandledRejection(Sentry.flush(2000));
   };
   registerErrorSink(sentrySink);
-  registerWarningSink(sentrySink);
+  registerWarningSink((location, error) => {
+    Sentry.withScope((scope) => {
+      scope.setLevel("warning");
+      sentrySink(location, error);
+    });
+  });
 }

--- a/packages/stack-shared/src/utils/errors.tsx
+++ b/packages/stack-shared/src/utils/errors.tsx
@@ -94,7 +94,9 @@ export function errorToNiceString(error: unknown): string {
 }
 
 
-const errorSinks = new Set<(location: string, error: unknown, ...extraArgs: unknown[]) => void>();
+type ErrorOrWarningSink = (location: string, error: unknown, ...extraArgs: unknown[]) => void;
+
+const errorSinks = new Set<ErrorOrWarningSink>();
 export function registerErrorSink(sink: (location: string, error: unknown) => void): void {
   if (errorSinks.has(sink)) {
     return;
@@ -116,6 +118,30 @@ registerErrorSink((location, error, ...extraArgs) => {
   globalVar.stackCapturedErrors.push({ location, error, extraArgs });
 });
 
+const warningSinks = new Set<ErrorOrWarningSink>();
+export function registerWarningSink(sink: (location: string, error: unknown) => void): void {
+  if (warningSinks.has(sink)) {
+    return;
+  }
+  warningSinks.add(sink);
+}
+registerWarningSink((location, error, ...extraArgs) => {
+  console.warn(
+    `\x1b[43mCaptured warning in ${location}:`,
+    errorToNiceString(error),
+    ...extraArgs,
+    "\x1b[0m",
+  );
+});
+registerWarningSink((location, error, ...extraArgs) => {
+  globalVar.stackCapturedWarnings = globalVar.stackCapturedWarnings ?? [];
+  globalVar.stackCapturedWarnings.push({ location, error, extraArgs });
+});
+
+function getCustomCaptureExtraArgs(error: unknown): unknown[] {
+  return error && (typeof error === 'object' || typeof error === 'function') && "customCaptureExtraArgs" in error && Array.isArray(error.customCaptureExtraArgs) ? (error.customCaptureExtraArgs as unknown[]) : [];
+}
+
 /**
  * Captures an error and sends it to the error sinks (most notably, Sentry). Errors caught with captureError are
  * supposed to be seen by an engineer, so they should be actionable and important.
@@ -127,11 +153,19 @@ registerErrorSink((location, error, ...extraArgs) => {
  */
 export function captureError(location: string, error: unknown): void {
   for (const sink of errorSinks) {
-    sink(
-      location,
-      error,
-      ...error && (typeof error === 'object' || typeof error === 'function') && "customCaptureExtraArgs" in error && Array.isArray(error.customCaptureExtraArgs) ? (error.customCaptureExtraArgs as any[]) : [],
-    );
+    sink(location, error, ...getCustomCaptureExtraArgs(error));
+  }
+}
+
+/**
+ * Like captureError, but uses console.warn instead of console.error. Still reports to Sentry.
+ *
+ * Use this for issues that are worth tracking but are not hard errors — e.g. expected
+ * transient failures like network flush retries.
+ */
+export function captureWarning(location: string, error: unknown): void {
+  for (const sink of warningSinks) {
+    sink(location, error, ...getCustomCaptureExtraArgs(error));
   }
 }
 

--- a/packages/template/src/lib/stack-app/apps/implementations/event-tracker.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/event-tracker.ts
@@ -1,4 +1,5 @@
 import { isBrowserLike } from "@stackframe/stack-shared/dist/utils/env";
+import { captureWarning } from "@stackframe/stack-shared/dist/utils/errors";
 import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
 import { generateUuid } from "./session-replay";
@@ -284,12 +285,12 @@ export class EventTracker {
     );
 
     if (res.status === "error") {
-      console.warn("EventTracker flush failed:", res.error);
+      captureWarning("EventTracker.flush()", res.error);
       return;
     }
 
     if (!res.data.ok) {
-      console.warn("EventTracker flush failed:", res.data.status, await res.data.text());
+      captureWarning("EventTracker.flush()", new Error(`EventTracker flush failed: ${res.data.status} ${await res.data.text()}`));
     }
   }
 

--- a/packages/template/src/lib/stack-app/apps/implementations/event-tracker.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/event-tracker.ts
@@ -290,7 +290,8 @@ export class EventTracker {
     }
 
     if (!res.data.ok) {
-      captureWarning("EventTracker.flush()", new Error(`EventTracker flush failed: ${res.data.status} ${await res.data.text()}`));
+      const body = await res.data.text().catch(() => "<unable to read response body>");
+      captureWarning("EventTracker.flush()", new Error(`EventTracker flush failed: ${res.data.status} ${body}`));
     }
   }
 

--- a/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
@@ -261,7 +261,8 @@ export class SessionRecorder {
       }
 
       if (!res.data.ok) {
-        captureWarning("SessionRecorder.flush()", new Error(`SessionRecorder flush failed: ${res.data.status} ${await res.data.text()}`));
+        const body = await res.data.text().catch(() => "<unable to read response body>");
+        captureWarning("SessionRecorder.flush()", new Error(`SessionRecorder flush failed: ${res.data.status} ${body}`));
       }
     } finally {
       this._flushInProgress = false;

--- a/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
@@ -1,4 +1,5 @@
 import { isBrowserLike } from "@stackframe/stack-shared/dist/utils/env";
+import { captureWarning } from "@stackframe/stack-shared/dist/utils/errors";
 import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
 
@@ -255,12 +256,12 @@ export class SessionRecorder {
       );
 
       if (res.status === "error") {
-        console.warn("SessionRecorder flush failed:", res.error);
+        captureWarning("SessionRecorder.flush()", res.error);
         return;
       }
 
       if (!res.data.ok) {
-        console.warn("SessionRecorder flush failed:", res.data.status, await res.data.text());
+        captureWarning("SessionRecorder.flush()", new Error(`SessionRecorder flush failed: ${res.data.status} ${await res.data.text()}`));
       }
     } finally {
       this._flushInProgress = false;


### PR DESCRIPTION
Adds `captureWarning` — mirrors `captureError` but logs via `console.warn` instead of `console.error`. Still reports to Sentry via warning sinks.

Replaces bare `console.warn` calls in `SessionRecorder.flush()` and `EventTracker.flush()` with `captureWarning` so these transient failures are tracked in Sentry.

Link to Devin session: https://app.devin.ai/sessions/c4cb3300c1a14966999c67a63f2ab666
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `captureWarning` for non-critical issues. Warnings use `console.warn`, report to Sentry with level "warning", and are now used for session replay and event tracker flush failures with safer response handling.

- New Features
  - Added `captureWarning` and `registerWarningSink` in `@stackframe/stack-shared`; forwards custom extra args and logs via `console.warn`.
  - Wired warning sinks to Sentry in apps/backend, apps/dashboard, and `packages/stack-cli`, setting Sentry level to `warning`.
  - Replaced `console.warn` in `SessionRecorder.flush()` and `EventTracker.flush()` with `captureWarning`; include status and response body, and handle `text()` failures gracefully.

<sup>Written for commit ee3e822b174f28dea74c0c8adf98a4ee8f94d19d. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1504?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Capture and report warnings to Sentry alongside errors, improving visibility into non-fatal issues across services.
  * Core runtime now registers a warning sink so warnings propagate through the same reporting pipeline as errors.
  * Event tracking and session replay components now use the new warning-capture mechanism instead of console logs for transport/response failures.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1504?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->