### PR TITLE
Add captureWarning utility

### DIFF
--- a/packages/stack-shared/src/utils/errors.test.tsx
+++ b/packages/stack-shared/src/utils/errors.test.tsx
@@ -1,0 +1,50 @@
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { captureError, captureWarning, HexclaveAssertionError, registerErrorSink } from "./errors";
+
+describe("error capture", () => {
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("captures warnings in the same sinks as errors and logs them as warnings", () => {
+    const sink = vi.fn();
+    const warningSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const error = new Error("warning");
+
+    registerErrorSink(sink);
+    captureWarning("warning-location", error);
+
+    expect(warningSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Captured warning in warning-location:"),
+      expect.stringContaining("warning"),
+      "\x1b[0m",
+    );
+    expect(sink).toHaveBeenCalledWith("warning-location", error);
+  });
+
+  it("keeps captureError logging as an error", () => {
+    const errorSpy = vi.spyOn(console, "error").mockImplementation(() => {});
+    const warningSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    captureError("error-location", new Error("error"));
+
+    expect(errorSpy).toHaveBeenCalledWith(
+      expect.stringContaining("Captured error in error-location:"),
+      expect.stringContaining("error"),
+      "\x1b[0m",
+    );
+    expect(warningSpy).not.toHaveBeenCalled();
+  });
+
+  it("keeps custom capture extra args when capturing warnings", () => {
+    const sink = vi.fn();
+    vi.spyOn(console, "warn").mockImplementation(() => {});
+    const extraData = { projectId: "internal" };
+    const error = new HexclaveAssertionError("warning", extraData);
+
+    registerErrorSink(sink);
+    captureWarning("warning-location", error);
+
+    expect(sink).toHaveBeenCalledWith("warning-location", error, extraData);
+  });
+});

--- a/packages/stack-shared/src/utils/errors.tsx
+++ b/packages/stack-shared/src/utils/errors.tsx
@@ -95,26 +95,39 @@ export function errorToNiceString(error: unknown): string {
 
 
 const errorSinks = new Set<(location: string, error: unknown, ...extraArgs: unknown[]) => void>();
-export function registerErrorSink(sink: (location: string, error: unknown) => void): void {
+export function registerErrorSink(sink: (location: string, error: unknown, ...extraArgs: unknown[]) => void): void {
   if (errorSinks.has(sink)) {
     return;
   }
   errorSinks.add(sink);
 }
-registerErrorSink((location, error, ...extraArgs) => {
-  console.error(
-    `\x1b[41mCaptured error in ${location}:`,
+
+function getCaptureExtraArgs(error: unknown): unknown[] {
+  if (!error || (typeof error !== 'object' && typeof error !== 'function')) {
+    return [];
+  }
+  if (!("customCaptureExtraArgs" in error)) {
+    return [];
+  }
+  return Array.isArray(error.customCaptureExtraArgs) ? [...error.customCaptureExtraArgs] : [];
+}
+
+function captureToGlobalVar(location: string, error: unknown, extraArgs: unknown[]): void {
+  globalVar.stackCapturedErrors = globalVar.stackCapturedErrors ?? [];
+  globalVar.stackCapturedErrors.push({ location, error, extraArgs });
+}
+
+function logCapturedError(level: "error" | "warning", location: string, error: unknown, extraArgs: unknown[]): void {
+  const log = level === "error" ? console.error : console.warn;
+  log(
+    `${level === "error" ? "\x1b[41m" : "\x1b[43m"}Captured ${level} in ${location}:`,
     // HACK: Log a nicified version of the error to get around buggy Next.js pretty-printing
     // https://www.reddit.com/r/nextjs/comments/1gkxdqe/comment/m19kxgn/?utm_source=share&utm_medium=web3x&utm_name=web3xcss&utm_term=1&utm_content=share_button
     errorToNiceString(error),
     ...extraArgs,
     "\x1b[0m",
   );
-});
-registerErrorSink((location, error, ...extraArgs) => {
-  globalVar.stackCapturedErrors = globalVar.stackCapturedErrors ?? [];
-  globalVar.stackCapturedErrors.push({ location, error, extraArgs });
-});
+}
 
 /**
  * Captures an error and sends it to the error sinks (most notably, Sentry). Errors caught with captureError are
@@ -126,11 +139,22 @@ registerErrorSink((location, error, ...extraArgs) => {
  * Errors that bubble up to the top of runAsynchronously or a route handler are already captured with captureError.
  */
 export function captureError(location: string, error: unknown): void {
+  captureToErrorSinks("error", location, error);
+}
+
+export function captureWarning(location: string, error: unknown): void {
+  captureToErrorSinks("warning", location, error);
+}
+
+function captureToErrorSinks(level: "error" | "warning", location: string, error: unknown): void {
+  const extraArgs = getCaptureExtraArgs(error);
+  logCapturedError(level, location, error, extraArgs);
+  captureToGlobalVar(location, error, extraArgs);
   for (const sink of errorSinks) {
     sink(
       location,
       error,
-      ...error && (typeof error === 'object' || typeof error === 'function') && "customCaptureExtraArgs" in error && Array.isArray(error.customCaptureExtraArgs) ? (error.customCaptureExtraArgs as any[]) : [],
+      ...extraArgs,
     );
   }
 }

--- a/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
+++ b/packages/template/src/lib/stack-app/apps/implementations/session-replay.ts
@@ -1,4 +1,5 @@
 import { isBrowserLike } from "@stackframe/stack-shared/dist/utils/env";
+import { captureWarning } from "@stackframe/stack-shared/dist/utils/errors";
 import { runAsynchronously } from "@stackframe/stack-shared/dist/utils/promises";
 import { Result } from "@stackframe/stack-shared/dist/utils/results";
 
@@ -255,12 +256,15 @@ export class SessionRecorder {
       );
 
       if (res.status === "error") {
-        console.warn("SessionRecorder flush failed:", res.error);
+        captureWarning("session-recording-batch-flush-failed", res.error);
         return;
       }
 
       if (!res.data.ok) {
-        console.warn("SessionRecorder flush failed:", res.data.status, await res.data.text());
+        captureWarning("session-recording-batch-flush-failed", {
+          status: res.data.status,
+          body: await res.data.text(),
+        });
       }
     } finally {
       this._flushInProgress = false;


### PR DESCRIPTION
Added `captureWarning` alongside `captureError` and routed it through the same registered error sinks so Sentry capture continues to run.

Updated session replay batch/flush warnings to use `captureWarning`.

Validation:
- `pnpm -C /home/ubuntu/repos/stack-auth test run packages/stack-shared/src/utils/errors.test.tsx`
- `pnpm -C /home/ubuntu/repos/stack-auth --filter @stackframe/stack-shared lint`
- `pnpm -C /home/ubuntu/repos/stack-auth --filter @stackframe/template lint`
- `pnpm -C /home/ubuntu/repos/stack-auth --filter @stackframe/stack-shared typecheck`

Note: `pnpm -C /home/ubuntu/repos/stack-auth --filter @stackframe/template typecheck` is blocked locally by missing generated package outputs such as `@stackframe/stack-shared/dist/*` and `@stackframe/stack-ui`.

Link to Devin session: https://app.devin.ai/sessions/e962ee7735b94347bd4ceb5f796cda6e
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `captureWarning` to route warnings through the same sinks as `captureError`, so they reach Sentry and are stored consistently. Updates session replay to use `captureWarning` on batch/flush failures.

- **New Features**
  - Added `captureWarning(location, error)`; uses registered error sinks (e.g., Sentry) and preserves `customCaptureExtraArgs`.
  - Warnings log via `console.warn` and are saved in `globalVar.stackCapturedErrors` like errors.
  - `SessionRecorder` now calls `captureWarning` when batch/flush fails.
  - Added tests for warning capture behavior and logging.

<sup>Written for commit 20bf9b93fe73f19f777e965e86eab4164f73bdf4. Summary will update on new commits. <a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1505?utm_source=github">Review in cubic</a></sup>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced warning capture system to provide structured application warning reporting with custom argument support.
  * Enhanced error reporting for session replay batch operations using new warning capture mechanism.

* **Tests**
  * Added comprehensive test coverage for warning capture behavior, console output formatting, and error sink functionality.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1505?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->