### PR TITLE
Fix Microsoft OAuth callback by passing scope in token exchange

### DIFF
--- a/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/oauth/callback/[provider_id]/route.tsx
@@ -168,6 +168,7 @@ const handler = createSmartRouteHandler({
         callbackResult = await providerObj.getCallback({
           codeVerifier: innerCodeVerifier,
           state: innerState,
+          extraScope: providerScope,
           callbackParams: {
             ...query,
             ...body,

--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -386,6 +386,7 @@ export abstract class OAuthBaseProvider {
     callbackParams: CallbackParamsType,
     codeVerifier: string,
     state: string,
+    extraScope?: string,
   }): Promise<{ userInfo: OAuthUserInfo, tokenSet: TokenSet }> {
     let tokenSet;
     const callbackParams = { ...options.callbackParams };
@@ -410,11 +411,17 @@ export abstract class OAuthBaseProvider {
       },
     ] as const;
 
+    const callbackExtras = {
+      exchangeBody: {
+        scope: mergeScopeStrings(this.scope, options.extraScope ?? ""),
+      },
+    };
+
     try {
       if (this.openid) {
-        tokenSet = await this.oauthClient.callback(...params);
+        tokenSet = await this.oauthClient.callback(...params, callbackExtras);
       } else {
-        tokenSet = await this.oauthClient.oauthCallback(...params);
+        tokenSet = await this.oauthClient.oauthCallback(...params, callbackExtras);
       }
     } catch (error: any) {
       if (error?.error === "invalid_grant" || error?.error?.error === "invalid_grant") {


### PR DESCRIPTION
Microsoft's v2.0 token endpoint requires a `scope` parameter in the authorization code exchange request (AADSTS70011). The `openid-client` library doesn't include it automatically since it's optional per RFC 6749.

Pass scope via `exchangeBody` in the callback extras for all providers, and forward the provider-specific extra scope from the outer OAuth info.

Link to Devin session: https://app.devin.ai/sessions/3cdf9182be7c47289d52f66de534c384
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Include scope in the token exchange for OAuth callbacks to satisfy Microsoft v2.0 and prevent AADSTS70011. Applied generically across providers using `openid-client`’s `exchangeBody` extras.

- **Bug Fixes**
  - Send merged scope via `exchangeBody.scope` to `callback`/`oauthCallback` in `openid-client`.
  - Forward provider-specific `extraScope` from the route to the base provider.

<sup>Written for commit ab1efa2b28394c62d9f2f0f66422406ffa79be4a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1509?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Authentication**
  * Improved OAuth scope parameter handling during provider authentication callbacks to better align with OAuth provider requirements and enhance authentication compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1509?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->