### PR TITLE
Fix SSO provider dialog closing when switching pill toggle tabs

### DIFF
--- a/packages/dashboard-ui-components/src/components/pill-toggle.tsx
+++ b/packages/dashboard-ui-components/src/components/pill-toggle.tsx
@@ -97,6 +97,7 @@ export function DesignPillToggle({
 
         const pill = (
           <button
+            type="button"
             key={option.id}
             onClick={() => handleClick(option.id)}
             disabled={loadingOptionId !== null}


### PR DESCRIPTION
Add `type="button"` to `DesignPillToggle` buttons to prevent them from submitting forms. Without this, buttons inside `<form>` default to `type="submit"`, causing the SSO provider settings dialog to close when switching from Custom back to Shared tab.

Link to Devin session: https://app.devin.ai/sessions/e479ec357e3843719b9b642327c25ab5
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the SSO provider settings dialog closing when switching between Custom and Shared tabs. Sets `type="button"` on `DesignPillToggle` buttons so clicks don't submit the surrounding form.

<sup>Written for commit c7a040feb699759e591df82010ecba6507237c38. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1515?utm_source=github">Review in cubic</a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed pill toggle components to prevent unintended form submissions when used within forms.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1515?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->