### PR TITLE
Fix dev CI build failures

### DIFF
--- a/apps/dashboard/src/instrumentation-node.ts
+++ b/apps/dashboard/src/instrumentation-node.ts
@@ -1,9 +1,9 @@
 import "server-only";
 
-import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { getEnvBoolean } from "@hexclave/shared/dist/utils/env";
 
 export async function startRemoteDevelopmentEnvironmentLifecycleIfNeeded(): Promise<void> {
-  if (getEnvVariable("NEXT_PUBLIC_STACK_IS_REMOTE_DEVELOPMENT_ENVIRONMENT", "") !== "true") {
+  if (!getEnvBoolean("NEXT_PUBLIC_STACK_IS_REMOTE_DEVELOPMENT_ENVIRONMENT")) {
     return;
   }
 

--- a/apps/dashboard/src/instrumentation-node.ts
+++ b/apps/dashboard/src/instrumentation-node.ts
@@ -1,0 +1,12 @@
+import "server-only";
+
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+
+export async function startRemoteDevelopmentEnvironmentLifecycleIfNeeded(): Promise<void> {
+  if (getEnvVariable("NEXT_PUBLIC_STACK_IS_REMOTE_DEVELOPMENT_ENVIRONMENT", "") !== "true") {
+    return;
+  }
+
+  const { startRemoteDevelopmentEnvironmentLifecycle } = await import("./lib/remote-development-environment/manager");
+  startRemoteDevelopmentEnvironmentLifecycle();
+}

--- a/apps/dashboard/src/instrumentation.ts
+++ b/apps/dashboard/src/instrumentation.ts
@@ -31,8 +31,10 @@ export async function register(): Promise<void> {
       let nicified;
       try {
         nicified = nicify(error, { maxDepth: 8 });
-      } catch (e) {
-        nicified = `Error occurred during nicification: ${e}`;
+      } catch (nicifyError: unknown) {
+        // Only nicify errors are converted to metadata; the original event still reports.
+        const nicifyErrorMessage = nicifyError instanceof Error ? nicifyError.message : String(nicifyError);
+        nicified = `Error occurred during nicification: ${nicifyErrorMessage}`;
       }
       if (error instanceof Error) {
         event.extra = {

--- a/apps/dashboard/src/instrumentation.ts
+++ b/apps/dashboard/src/instrumentation.ts
@@ -1,58 +1,50 @@
 import * as Sentry from "@sentry/nextjs";
-import { getEnvBoolean, getEnvVariable, getNextRuntime, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
+import { getEnvBoolean, getEnvVariable, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
 import { sentryBaseConfig } from "@hexclave/shared/dist/utils/sentry";
 import { nicify } from "@hexclave/shared/dist/utils/strings";
 import "./polyfills";
 
-async function startRemoteDevelopmentEnvironmentLifecycleIfNeeded(): Promise<void> {
-  if (getNextRuntime() !== "nodejs" || getEnvVariable("NEXT_PUBLIC_STACK_IS_REMOTE_DEVELOPMENT_ENVIRONMENT", "") !== "true") {
+export async function register(): Promise<void> {
+  if (process.env.NEXT_RUNTIME !== "nodejs" && process.env.NEXT_RUNTIME !== "edge") {
     return;
   }
 
-  const { startRemoteDevelopmentEnvironmentLifecycle } = await import("./lib/remote-development-environment/manager");
-  startRemoteDevelopmentEnvironmentLifecycle();
-}
-
-export async function register() {
-  if (getNextRuntime() === "nodejs") {
+  if (process.env.NEXT_RUNTIME === "nodejs") {
     if (getEnvBoolean("NEXT_PUBLIC_STACK_IS_REMOTE_DEVELOPMENT_ENVIRONMENT")) {
       globalThis.process.title = `Hexclave — Development Server (port ${getEnvVariable("PORT", "?")})`;
     } else {
       globalThis.process.title = `stack-dashboard:${getEnvVariable("NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX", "81")} (node/nextjs)`;
     }
+    const { startRemoteDevelopmentEnvironmentLifecycleIfNeeded } = await import("./instrumentation-node");
     await startRemoteDevelopmentEnvironmentLifecycleIfNeeded();
   }
 
-  if (getNextRuntime() === "nodejs" || getNextRuntime() === "edge") {
-    Sentry.init({
-      ...sentryBaseConfig,
+  Sentry.init({
+    ...sentryBaseConfig,
 
-      dsn: getEnvVariable("NEXT_PUBLIC_SENTRY_DSN", ""),
+    dsn: getEnvVariable("NEXT_PUBLIC_SENTRY_DSN", ""),
 
-      enabled: getNodeEnvironment() !== "development" && !getEnvVariable("CI", ""),
+    enabled: getNodeEnvironment() !== "development" && !getEnvVariable("CI", ""),
 
-      // Add exception metadata to the event
-      beforeSend(event, hint) {
-        const error = hint.originalException;
-        let nicified;
-        try {
-          nicified = nicify(error, { maxDepth: 8 });
-        } catch (e) {
-          nicified = `Error occurred during nicification: ${e}`;
-        }
-        if (error instanceof Error) {
-          event.extra = {
-            ...event.extra,
-            cause: error.cause,
-            errorProps: {
-              ...error,
-            },
-            nicifiedError: nicified,
-          };
-        }
-        return event;
-      },
-    });
-
-  }
+    beforeSend(event, hint) {
+      const error = hint.originalException;
+      let nicified;
+      try {
+        nicified = nicify(error, { maxDepth: 8 });
+      } catch (e) {
+        nicified = `Error occurred during nicification: ${e}`;
+      }
+      if (error instanceof Error) {
+        event.extra = {
+          ...event.extra,
+          cause: error.cause,
+          errorProps: {
+            ...error,
+          },
+          nicifiedError: nicified,
+        };
+      }
+      return event;
+    },
+  });
 }

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -2,9 +2,10 @@ import { StackServerApp } from '@hexclave/next';
 import "server-only";
 
 const placeholderPrefix = "#";
+const replaceMePlaceholder = "REPLACE_ME";
 
 function envOrUndefined(value: string | undefined): string | undefined {
-  if (value == null || value === "" || value.startsWith(placeholderPrefix)) {
+  if (value == null || value === "" || value === replaceMePlaceholder || value.startsWith(placeholderPrefix)) {
     return undefined;
   }
   return value;

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -1,13 +1,22 @@
 import { StackServerApp } from '@hexclave/next';
 import "server-only";
 
+const placeholderPrefix = "#";
+
+function envOrUndefined(value: string | undefined): string | undefined {
+  if (value == null || value === "" || value.startsWith(placeholderPrefix)) {
+    return undefined;
+  }
+  return value;
+}
+
 // Explicitly configure Stack Auth for docs app
 export const stackServerApp = new StackServerApp({
   tokenStore: "nextjs-cookie",
-  projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID || process.env.NEXT_PUBLIC_STACK_PROJECT_ID || "internal",
-  publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY || process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
-  secretServerKey: process.env.HEXCLAVE_SECRET_SERVER_KEY || process.env.STACK_SECRET_SERVER_KEY,
-  baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL || process.env.NEXT_PUBLIC_STACK_API_URL,
+  projectId: envOrUndefined(process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID) ?? envOrUndefined(process.env.NEXT_PUBLIC_STACK_PROJECT_ID) ?? "internal",
+  publishableClientKey: envOrUndefined(process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY) ?? envOrUndefined(process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY),
+  secretServerKey: envOrUndefined(process.env.HEXCLAVE_SECRET_SERVER_KEY) ?? envOrUndefined(process.env.STACK_SECRET_SERVER_KEY) ?? "this-secret-server-key-is-for-local-development-only",
+  baseUrl: envOrUndefined(process.env.NEXT_PUBLIC_HEXCLAVE_API_URL) ?? envOrUndefined(process.env.NEXT_PUBLIC_STACK_API_URL),
   analytics: {
     replays: {
       enabled: true,

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -5,10 +5,11 @@ const placeholderPrefix = "#";
 const replaceMePlaceholder = "REPLACE_ME";
 
 function envOrUndefined(value: string | undefined): string | undefined {
-  if (value == null || value === "" || value === replaceMePlaceholder || value.startsWith(placeholderPrefix)) {
+  const normalized = value?.trim();
+  if (normalized == null || normalized === "" || normalized.replace(/^["']|["']$/g, "") === replaceMePlaceholder || normalized.startsWith(placeholderPrefix)) {
     return undefined;
   }
-  return value;
+  return normalized;
 }
 
 // Explicitly configure Stack Auth for docs app

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -5,8 +5,8 @@ const placeholderPrefix = "#";
 const replaceMePlaceholder = "REPLACE_ME";
 
 function envOrUndefined(value: string | undefined): string | undefined {
-  const normalized = value?.trim();
-  if (normalized == null || normalized === "" || normalized.replace(/^["']|["']$/g, "") === replaceMePlaceholder || normalized.startsWith(placeholderPrefix)) {
+  const normalized = value?.trim().replace(/^["']|["']$/g, "");
+  if (normalized == null || normalized === "" || normalized === replaceMePlaceholder || normalized.startsWith(placeholderPrefix)) {
     return undefined;
   }
   return normalized;

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -4,10 +4,10 @@ import "server-only";
 // Explicitly configure Stack Auth for docs app
 export const stackServerApp = new StackServerApp({
   tokenStore: "nextjs-cookie",
-  projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID ?? process.env.NEXT_PUBLIC_STACK_PROJECT_ID,
-  publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY ?? process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
-  secretServerKey: process.env.HEXCLAVE_SECRET_SERVER_KEY ?? process.env.STACK_SECRET_SERVER_KEY,
-  baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL ?? process.env.NEXT_PUBLIC_STACK_API_URL,
+  projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID || process.env.NEXT_PUBLIC_STACK_PROJECT_ID || "internal",
+  publishableClientKey: process.env.NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY || process.env.NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY,
+  secretServerKey: process.env.HEXCLAVE_SECRET_SERVER_KEY || process.env.STACK_SECRET_SERVER_KEY,
+  baseUrl: process.env.NEXT_PUBLIC_HEXCLAVE_API_URL || process.env.NEXT_PUBLIC_STACK_API_URL,
   analytics: {
     replays: {
       enabled: true,

--- a/docs/src/stack.ts
+++ b/docs/src/stack.ts
@@ -6,7 +6,7 @@ const replaceMePlaceholder = "REPLACE_ME";
 
 function envOrUndefined(value: string | undefined): string | undefined {
   const normalized = value?.trim().replace(/^["']|["']$/g, "");
-  if (normalized == null || normalized === "" || normalized === replaceMePlaceholder || normalized.startsWith(placeholderPrefix)) {
+  if (normalized == null || normalized === "" || normalized === replaceMePlaceholder || normalized.startsWith(placeholderPrefix) || normalized.startsWith("$(")) {
     return undefined;
   }
   return normalized;

--- a/packages/template/src/providers/stack-context.tsx
+++ b/packages/template/src/providers/stack-context.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { createGlobal } from "@stackframe/stack-shared/dist/utils/globals";
+import { createGlobal } from "@hexclave/shared/dist/utils/globals";
 import type { StackClientApp } from "../lib/stack-app/apps/interfaces/client-app";
 
 type StackContextValue = {

--- a/packages/template/src/providers/translation-provider-client.tsx
+++ b/packages/template/src/providers/translation-provider-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { createGlobal } from "@stackframe/stack-shared/dist/utils/globals";
+import { createGlobal } from "@hexclave/shared/dist/utils/globals";
 
 type TranslationContextValue = {
   quetzalKeys: Map<string, string>,


### PR DESCRIPTION
Fixes dev CI build failures by:

- Updating generated SDK template imports to use `@hexclave/shared`.
- Keeping dashboard development-environment startup in a Node-only instrumentation module.
- Treating docs placeholder env values as unset so `stack-docs` can build.

Validation:
- `pnpm --filter @hexclave/dashboard lint --max-warnings=0`
- `pnpm --filter @hexclave/dashboard build`
- `pnpm --filter @hexclave/docs lint --max-warnings=0`
- `pnpm --filter @hexclave/docs typecheck`
- `pnpm --filter @hexclave/docs build`
- `pnpm --filter @hexclave/example-tanstack-start-demo build`
- `pnpm --filter @stackframe/template lint --max-warnings=0`

Link to Devin session: https://app.devin.ai/sessions/57d3ec52f91f4c32a035a9c157d68edf
Requested by: @N2D4