### PR TITLE
fix(hexclave): rename leftover @stackframe/stack-shared imports in template providers

### DIFF
--- a/packages/template/src/providers/stack-context.tsx
+++ b/packages/template/src/providers/stack-context.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { createGlobal } from "@stackframe/stack-shared/dist/utils/globals";
+import { createGlobal } from "@hexclave/shared/dist/utils/globals";
 import type { StackClientApp } from "../lib/stack-app/apps/interfaces/client-app";
 
 type StackContextValue = {

--- a/packages/template/src/providers/translation-provider-client.tsx
+++ b/packages/template/src/providers/translation-provider-client.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React from "react";
-import { createGlobal } from "@stackframe/stack-shared/dist/utils/globals";
+import { createGlobal } from "@hexclave/shared/dist/utils/globals";
 
 type TranslationContextValue = {
   quetzalKeys: Map<string, string>,


### PR DESCRIPTION
## Why the build fails on `origin/dev`

The `Lint & build` workflow fails at the **Build** step, in `@hexclave/lovable-react-18-example`'s `vite build`:

```
[vite]: Rollup failed to resolve import "@stackframe/stack-shared/dist/utils/globals"
from ".../packages/react/dist/esm/providers/stack-context.js".
```

(failing run: [job 78596906597](https://github.com/hexclave/stack-auth/actions/runs/26665187298/job/78596906597))

### Root cause

PR 3 (`feat(hexclave): PR 3 — native @hexclave/* source rename + delete dual-publish wiring`, #1482) renamed `@stackframe/stack-shared` → `@hexclave/shared` and **deleted the dual-publish wiring**, so `@stackframe/stack-shared` is no longer a resolvable package.

Two `packages/template/src` provider files were missed in that rename:

- `packages/template/src/providers/stack-context.tsx`
- `packages/template/src/providers/translation-provider-client.tsx`

`packages/react` ships only `package.json`; its `src`/`dist` are **generated** from `packages/template/src` by `generate-sdks`, which copies import specifiers verbatim. So the stale `@stackframe/stack-shared` import propagated into `packages/react/dist`.

The `@hexclave/react` build itself **succeeds** because tsdown/rolldown externalizes the import (it never has to resolve it). The failure only surfaces downstream, when `lovable-react-18-example` bundles `@hexclave/react` with Vite/Rollup and tries to actually resolve `@stackframe/stack-shared` — a package that no longer exists.

## Fix

Point both imports at the renamed package, matching the convention already used by sibling files (e.g. `stack-provider-client.tsx`, `common.ts`):

```diff
-import { createGlobal } from "@stackframe/stack-shared/dist/utils/globals";
+import { createGlobal } from "@hexclave/shared/dist/utils/globals";
```

## Verification

Reproduced and confirmed the fix locally:

1. Edited the two template files.
2. `pnpm -w run generate-sdks` → generated `packages/react/src` now imports `@hexclave/shared/dist/utils/globals`.
3. `pnpm --filter @hexclave/react run build` → `dist/esm/providers/stack-context.js` now imports `@hexclave/shared` ✔
4. `pnpm --filter @hexclave/lovable-react-18-example run build` → **`✓ built`** (previously failed at this exact step).


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Rename leftover imports from `@stackframe/stack-shared` to `@hexclave/shared` in the template providers to fix downstream build failures. This unblocks Vite/Rollup consumers (e.g., `@hexclave/lovable-react-18-example`) by resolving `createGlobal` from the correct package.

<sup>Written for commit 15901edb2bc4c104ccba1917b18cdf17b7c569ff. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1525?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal module dependencies across provider configurations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/hexclave/stack-auth/pull/1525?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->