### PR TITLE
Fix stale e2e CLI + RDE config tests (emulator removal & hexclave rename)

### DIFF
--- a/apps/dashboard/src/lib/remote-development-environment/config-file.test.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/config-file.test.ts
@@ -24,7 +24,7 @@ afterEach(() => {
 describe("remote development environment config file", () => {
   it("loads config exports wrapped in defineStackConfig", async () => {
     const configPath = writeTempConfig(`
-      import { defineStackConfig } from "@stackframe/stack-shared/config";
+      import { defineStackConfig } from "@hexclave/shared/config";
 
       export const config = defineStackConfig({
         auth: {
@@ -49,7 +49,7 @@ describe("remote development environment config file", () => {
 
   it("loads config exports wrapped in defineHexclaveConfig", async () => {
     const configPath = writeTempConfig(`
-      import { defineHexclaveConfig } from "@stackframe/stack-shared/config";
+      import { defineHexclaveConfig } from "@hexclave/shared/config";
 
       export const config = defineHexclaveConfig({
         auth: {
@@ -182,7 +182,7 @@ describe("remote development environment config file", () => {
     });
 
     expect(readFileSync(configPath, "utf-8")).toMatchInlineSnapshot(`
-      "import type { StackConfig } from "@stackframe/js";
+      "import type { StackConfig } from "@hexclave/js";
 
       export const config: StackConfig = {
         "auth": {

--- a/apps/e2e/tests/general/cli.test.ts
+++ b/apps/e2e/tests/general/cli.test.ts
@@ -10,7 +10,6 @@ import { it, niceFetch, STACK_BACKEND_BASE_URL, STACK_INTERNAL_PROJECT_CLIENT_KE
 const isLocalEmulator = process.env.NEXT_PUBLIC_STACK_IS_LOCAL_EMULATOR === "true";
 
 const CLI_BIN = path.resolve("packages/stack-cli/dist/index.js");
-const CLI_SRC_BIN = path.resolve("packages/stack-cli/src/index.ts");
 
 function extractConfigObjectString(content: string): string {
   const configMatch = content.match(/export const config:\s*StackConfig\s*=\s*(.+);\s*$/s);
@@ -375,7 +374,7 @@ describe("Stack CLI", () => {
         },
       );
       expect(exitCode).toBe(1);
-      expect(stderr).toContain("Local emulator publishable client key not found");
+      expect(stderr).toContain("Development environment publishable client key not found");
     } finally {
       fs.rmSync(fakeEmulatorHome, { recursive: true });
     }
@@ -401,7 +400,7 @@ describe("Stack CLI", () => {
         },
       );
       expect(exitCode).toBe(1);
-      expect(stderr).toContain("Cannot reach local emulator");
+      expect(stderr).toContain("Cannot reach development environment");
     } finally {
       fs.rmSync(fakeEmulatorHome, { recursive: true });
     }
@@ -666,75 +665,6 @@ describe("Stack CLI", () => {
     ]);
     expect(exitCode).toBe(0);
     expect(stdout).toContain("STACK AUTH SETUP INSTRUCTIONS");
-  });
-});
-
-// Emulator CLI tests — no backend required, just validates help/arg parsing
-describe("Stack CLI — Emulator", () => {
-  function runCliBare(
-    args: string[],
-  ): Promise<{ stdout: string, stderr: string, exitCode: number | null }> {
-    return new Promise((resolve) => {
-      execFile("node", [CLI_BIN, ...args], {
-        env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", CI: "1" },
-        timeout: 15_000,
-      }, (error, stdout, stderr) => {
-        resolve({
-          stdout: stdout.toString(),
-          stderr: stderr.toString(),
-          exitCode: error ? (error as any).code ?? 1 : 0,
-        });
-      });
-    });
-  }
-
-  function runCliBareFromSource(
-    args: string[],
-  ): Promise<{ stdout: string, stderr: string, exitCode: number | null }> {
-    return new Promise((resolve) => {
-      execFile("node", ["--import", "tsx", CLI_SRC_BIN, ...args], {
-        env: { PATH: process.env.PATH ?? "", HOME: process.env.HOME ?? "", CI: "1" },
-        timeout: 15_000,
-      }, (error, stdout, stderr) => {
-        resolve({
-          stdout: stdout.toString(),
-          stderr: stderr.toString(),
-          exitCode: error ? (error as any).code ?? 1 : 0,
-        });
-      });
-    });
-  }
-
-  it("emulator help shows subcommands", async ({ expect }) => {
-    const { stdout, exitCode } = await runCliBare(["emulator", "--help"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("pull");
-    expect(stdout).toContain("start");
-    expect(stdout).toContain("stop");
-    expect(stdout).toContain("reset");
-    expect(stdout).toContain("status");
-    expect(stdout).toContain("list-releases");
-  });
-
-  it("emulator pull help shows options", async ({ expect }) => {
-    const { stdout, exitCode } = await runCliBare(["emulator", "pull", "--help"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("--arch");
-    expect(stdout).toContain("--branch");
-    expect(stdout).toContain("--tag");
-    expect(stdout).toContain("--repo");
-  });
-
-  it("emulator pull rejects invalid arch values", async ({ expect }) => {
-    const { stderr, exitCode } = await runCliBareFromSource(["emulator", "pull", "--arch", "sparc"]);
-    expect(exitCode).toBe(1);
-    expect(stderr).toContain("Invalid architecture: sparc. Expected arm64 or amd64.");
-  });
-
-  it("emulator list-releases help shows repo option", async ({ expect }) => {
-    const { stdout, exitCode } = await runCliBare(["emulator", "list-releases", "--help"]);
-    expect(exitCode).toBe(0);
-    expect(stdout).toContain("--repo");
   });
 });
 


### PR DESCRIPTION
## What

Fixes the 9 failing tests in the E2E (Local Emulator) job — 2 test files, both stale after recent refactors that renamed source but missed the tests.

### `apps/e2e/tests/general/cli.test.ts` (6 failures)
The `stack emulator` command was removed in #1522 (which also reworded its auth errors from "local emulator" → "development environment"), but the e2e tests were never updated:
- Updated two error-string assertions:
  - `"Local emulator publishable client key not found"` → `"Development environment publishable client key not found"`
  - `"Cannot reach local emulator"` → `"Cannot reach development environment"`
- Removed the dead `"Stack CLI — Emulator"` describe block (4 tests for the deleted `emulator pull/start/stop/list-releases` subcommands) and the now-unused `CLI_SRC_BIN` const.

### `apps/dashboard/src/lib/remote-development-environment/config-file.test.ts` (3 failures)
Leftover `@stackframe/*` names from the `@hexclave` rename:
- Fixture imports `@stackframe/stack-shared/config` → `@hexclave/shared/config` (the `defineStackConfig` / `defineHexclaveConfig` cases were failing with `Cannot find module`).
- Rendered-config snapshot type import `@stackframe/js` → `@hexclave/js`.

## Verification
- `config-file.test.ts`: **7 passed**.
- `cli.test.ts` against a live local backend: **69 passed / 4 skipped / 0 failed** (the 4 skips are environment-gated `it.runIf`/`it.skip`, not failures).
- Reproduced both CLI error paths against the built CLI binary to confirm the new strings match exactly.
- `lint` ✓ and `typecheck` ✓ for `@hexclave/e2e-tests` and `@hexclave/dashboard`.

Only test files are changed — no production code.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes 9 failing E2E tests by updating CLI error messages and RDE config test imports after the emulator command removal and the `@hexclave` rename. Removes obsolete emulator CLI tests; no production code changed.

- **Bug Fixes**
  - CLI: updated two error-string assertions to use “Development environment …” wording.
  - CLI: removed the obsolete “Stack CLI — Emulator” test block and the unused `CLI_SRC_BIN`.
  - Dashboard RDE config tests: replaced `@stackframe/stack-shared/config` with `@hexclave/shared/config`.
  - Snapshot import: `@stackframe/js` → `@hexclave/js`.

<sup>Written for commit a887d7209bce24f4f8b7670e027c49625f30865d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/stack-auth/pull/1528?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated error messages to use "development environment" terminology instead of "emulator" references.

* **Tests**
  * Adjusted test assertions and imports for consistency with updated terminology.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->