### PR TITLE
Remove redundant clean + reinstall from npm-publish workflow

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -36,12 +36,6 @@ jobs:
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
 
-      - name: Clean
-        run: pnpm run clean
-
-      - name: Install dependencies (after clean)
-        run: pnpm install --frozen-lockfile
-
       - name: Build packages
         run: pnpm build:packages
 


### PR DESCRIPTION
## Summary

The `npm-publish.yaml` workflow ran `install → clean → install`. The `clean` deletes all `node_modules` but not `~/.cache/puppeteer/`, so the second install's puppeteer postinstall finds an existing (potentially incomplete) cache folder and hard-errors instead of re-downloading. Other workflows only install once and don't hit this.

Removes the `clean` and second `install` steps — not needed for `build:packages` + `publish`.

Link to Devin session: https://app.devin.ai/sessions/c45a3d8227da42f599fa967f29f9954a
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Remove redundant clean and second install in `npm-publish.yaml` to prevent `puppeteer` postinstall cache errors and speed up the publish job. The workflow now installs once before `pnpm build:packages` and publish.

- **Bug Fixes**
  - Avoids failures caused by `pnpm run clean` removing `node_modules` but leaving `~/.cache/puppeteer/`, which broke the second install.

<sup>Written for commit d0c038771bff073d63e65906334c5a0daac2c785. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1540?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only workflow simplification with no application or publish logic changes beyond step order.
> 
> **Overview**
> The **Publish npm packages** workflow no longer runs `pnpm run clean` or a second `pnpm install --frozen-lockfile` between install and build.
> 
> The publish job now follows a single **install → build:packages → publish** path, matching other workflows and avoiding a failure mode where cleaning `node_modules` while leaving Puppeteer’s cache intact could break the follow-up install’s postinstall step.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0c038771bff073d63e65906334c5a0daac2c785. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

This pull request contains only internal infrastructure changes with no impact to end-user functionality. No user-visible updates to document.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->