### PR TITLE
Make demo dev resilient to dashboard build failures

### DIFF
--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "typecheck": "tsc --noEmit",
     "clean": "rimraf .next && rimraf node_modules",
-    "dev": "NEXT_PUBLIC_HEXCLAVE_LOCAL_DASHBOARD_PORT=${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}42 pnpm -w run cli -- dev --config-file=./hexclave.config.ts -- pnpm --dir examples/demo run dev:inner",
+    "dev": "NEXT_PUBLIC_HEXCLAVE_LOCAL_DASHBOARD_PORT=${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}42 node scripts/dev-with-retry.mjs",
     "dev:inner": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}03",
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}03",

--- a/examples/demo/scripts/dev-with-retry.mjs
+++ b/examples/demo/scripts/dev-with-retry.mjs
@@ -1,0 +1,119 @@
+#!/usr/bin/env node
+
+// Resilient wrapper for the demo dev command.
+//
+// The demo dev flow runs `pnpm -w run cli`, which internally builds the CLI
+// package (and its dependency, dashboard build:rde-standalone). If that build
+// fails, this process would normally exit, and because the root dev script uses
+// `concurrently -k`, the entire dev server would die.
+//
+// This wrapper catches non-zero exits and watches for file changes in the
+// dashboard and packages directories before retrying, so a transient build
+// failure doesn't tear down the whole dev server.
+
+import { spawn } from "node:child_process";
+import { watch } from "node:fs";
+import { join, resolve } from "node:path";
+import { setTimeout as sleep } from "node:timers/promises";
+
+const scriptDir = import.meta.dirname;
+const demoRoot = resolve(scriptDir, "..");
+const repoRoot = resolve(demoRoot, "../..");
+
+const LOG_PREFIX = "[Hexclave dev-retry] ";
+const RETRY_DEBOUNCE_MS = 2_000;
+
+function log(message) {
+  console.error(`${LOG_PREFIX}${message}`);
+}
+
+function runCliDev() {
+  return new Promise((resolvePromise, reject) => {
+    const child = spawn("pnpm", [
+      "-w", "run", "cli", "--",
+      "dev",
+      "--config-file=./hexclave.config.ts",
+      "--",
+      "pnpm", "--dir", "examples/demo", "run", "dev:inner",
+    ], {
+      stdio: "inherit",
+      env: process.env,
+    });
+
+    let signalled = false;
+
+    const forwardSigint = () => { signalled = true; child.kill("SIGINT"); };
+    const forwardSigterm = () => { signalled = true; child.kill("SIGTERM"); };
+    process.on("SIGINT", forwardSigint);
+    process.on("SIGTERM", forwardSigterm);
+
+    child.on("close", (code) => {
+      process.off("SIGINT", forwardSigint);
+      process.off("SIGTERM", forwardSigterm);
+      resolvePromise({ code: code ?? 1, signalled });
+    });
+    child.on("error", (err) => {
+      process.off("SIGINT", forwardSigint);
+      process.off("SIGTERM", forwardSigterm);
+      reject(err);
+    });
+  });
+}
+
+function waitForFileChanges() {
+  return new Promise((resolvePromise) => {
+    const watchDirs = [
+      join(repoRoot, "apps", "dashboard"),
+      join(repoRoot, "packages"),
+    ];
+    const watchers = [];
+    let resolved = false;
+
+    const done = () => {
+      if (resolved) return;
+      resolved = true;
+      for (const w of watchers) {
+        try { w.close(); } catch { /* ignore */ }
+      }
+      resolvePromise();
+    };
+
+    for (const dir of watchDirs) {
+      try {
+        const w = watch(dir, { recursive: true }, done);
+        w.on("error", () => { /* ignore watch errors */ });
+        watchers.push(w);
+      } catch {
+        // directory might not exist yet
+      }
+    }
+
+    // Fallback: if no watchers could be set up, resolve after a timeout so we
+    // don't block forever.
+    if (watchers.length === 0) {
+      log("Could not set up file watchers. Will retry after a delay.");
+      setTimeout(done, 10_000);
+    }
+  });
+}
+
+async function main() {
+  // eslint-disable-next-line @typescript-eslint/no-unnecessary-condition
+  while (true) {
+    const { code, signalled } = await runCliDev();
+
+    if (signalled || code === 0) {
+      process.exit(code);
+    }
+
+    log(`Dev command exited with code ${code}. Watching for file changes before retrying...`);
+    await waitForFileChanges();
+    log(`Change detected. Retrying in ${RETRY_DEBOUNCE_MS / 1000}s...`);
+    await sleep(RETRY_DEBOUNCE_MS);
+  }
+}
+
+main().catch((err) => {
+  console.error(err);
+  process.exit(1);
+});


### PR DESCRIPTION
## Summary

The demo dev calls `pnpm -w run cli` → `turbo run build --filter=@hexclave/cli` → `@hexclave/dashboard#build:rde-standalone`. If the dashboard build fails, the demo process exits and `concurrently -k` tears down the entire dev server.

Adds `examples/demo/scripts/dev-with-retry.mjs`: on non-zero exit, watches `apps/dashboard` and `packages` via `fs.watch` for changes, debounces, and retries — so a build failure no longer kills `pnpm run dev`.

Link to Devin session: https://app.devin.ai/sessions/f40bde30fa16400ca54f61c7cbd15938
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make the demo dev server resilient to `@hexclave/dashboard` build failures. Instead of tearing down on a failed CLI/dashboard build, it now waits for changes and retries.

- **Bug Fixes**
  - Add `examples/demo/scripts/dev-with-retry.mjs` to wrap `pnpm -w run cli` and retry on non-zero exit.
  - Watch `apps/dashboard` and `packages` with `fs.watch`, then retry after a 2s debounce.
  - Update `examples/demo/package.json` `dev` script to run the wrapper (`node scripts/dev-with-retry.mjs`).
  - Forward SIGINT/SIGTERM so manual stops still work; exit immediately on success.

<sup>Written for commit c8cf28f654ca8136984e88e048232c3704b99610. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1542?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dev-only script change in the example app; no production runtime, auth, or data paths affected.
> 
> **Overview**
> **Demo `dev` no longer exits on a failed CLI/dashboard build**, so root `concurrently -k` dev is less likely to shut everything down after a transient `@hexclave/dashboard` build error.
> 
> The `examples/demo` **`dev` script** now runs **`node scripts/dev-with-retry.mjs`** instead of calling `pnpm -w run cli` directly (same env for `NEXT_PUBLIC_HEXCLAVE_LOCAL_DASHBOARD_PORT`).
> 
> **New wrapper** `examples/demo/scripts/dev-with-retry.mjs` spawns the same `pnpm -w run cli -- dev ... dev:inner` flow. On **non-zero exit** it watches **`apps/dashboard`** and **`packages`** with `fs.watch`, debounces **2s**, and retries in a loop. **SIGINT/SIGTERM** are forwarded and still exit; **success (code 0)** exits normally. If watchers cannot be set up, it falls back to a **10s** delay before retry.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c8cf28f654ca8136984e88e048232c3704b99610. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Enhanced demo development workflow with automatic retry and recovery functionality. The development server now intelligently monitors for file changes across core packages and dashboard modules, automatically restarting when encountering transient failures. Features graceful shutdown handling and configurable retry debounce intervals to optimize the development experience.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->