### PR TITLE
Publish src folder alongside dist in all packages

### DIFF
--- a/packages/dashboard-ui-components/package.json
+++ b/packages/dashboard-ui-components/package.json
@@ -17,6 +17,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/js/package.json
+++ b/packages/js/package.json
@@ -46,6 +46,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -54,6 +54,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/stack-cli/package.json
+++ b/packages/stack-cli/package.json
@@ -20,6 +20,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/stack-sc/package.json
+++ b/packages/stack-sc/package.json
@@ -43,6 +43,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/stack-shared/package.json
+++ b/packages/stack-shared/package.json
@@ -13,6 +13,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/stack-ui/package.json
+++ b/packages/stack-ui/package.json
@@ -15,6 +15,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/stack/package.json
+++ b/packages/stack/package.json
@@ -54,6 +54,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/tanstack-start/package.json
+++ b/packages/tanstack-start/package.json
@@ -65,6 +65,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/template/package-template.json
+++ b/packages/template/package-template.json
@@ -97,6 +97,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/template/package.json
+++ b/packages/template/package.json
@@ -70,6 +70,7 @@
   "files": [
     "README.md",
     "dist",
+    "src",
     "CHANGELOG.md",
     "LICENSE"
   ],


### PR DESCRIPTION
## Summary

Adds `"src"` to the `files` array in all published packages so coding agents can inspect source alongside `dist` when debugging.

Link to Devin session: https://app.devin.ai/sessions/faa0a3454498463fa8b2928695cbd162
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish `src` alongside `dist` for all published packages to include source files in the published tarballs. This makes debugging easier for consumers and tooling by allowing direct source inspection.

<sup>Written for commit d1af929444133d24ee88fa8ef3d9c516b0ac0357. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1545?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated package distribution configuration across all packages to include source code files in published versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->