### PR TITLE
Add 5/29/26 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ## 5/29/26
 
-- Hexclave rebrand goes live: native @hexclave/* packages, updated branding, and backward-compatible migration layer.
 - Per-provider OAuth callback URLs with host-derived JWT issuer and redirect URIs.
 - New LLM metadata endpoints for documentation discovery.
 - Fixes for SSO dialog tab switching, client retry handling, and legacy cookie mixing.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## 5/29/26
+
+- Hexclave rebrand goes live: native @hexclave/* packages, updated branding, and backward-compatible migration layer.
+- Per-provider OAuth callback URLs with host-derived JWT issuer and redirect URIs.
+- New LLM metadata endpoints for documentation discovery.
+- Fixes for SSO dialog tab switching, client retry handling, and legacy cookie mixing.
+
 ## 5/22/26
 
 - Faster ClickHouse analytics for project metrics and previews.


### PR DESCRIPTION
## Summary\n\nAdds the weekly changelog entry for 5/29/26, summarizing that week's commits on `main`.

Link to Devin session: https://app.devin.ai/sessions/73ccfdffd1574df28b85958d17eb0496
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds the 5/29/26 changelog entry. It covers per-provider OAuth callback URLs with host-derived JWT issuer and redirect URIs, new LLM metadata endpoints for documentation discovery, and fixes for SSO dialog tab switching, client retry handling, and legacy cookie mixing.

<sup>Written for commit 9e34039f2321d4bf0834dfb01abbb4bd4c5e660a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1548?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to CHANGELOG.md with no runtime or code impact.
> 
> **Overview**
> Adds a **5/29/26** section at the top of `CHANGELOG.md` documenting that week’s shipped work.
> 
> The new bullets cover **per-provider OAuth callback URLs** with host-derived JWT issuer and redirect URIs, **LLM metadata endpoints** for documentation discovery, and **fixes** for SSO dialog tab switching, client retry handling, and legacy cookie mixing.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9e34039f2321d4bf0834dfb01abbb4bd4c5e660a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->