### PR TITLE
cli: include project path in dashboard URL log

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -616,7 +616,7 @@ async function heartbeatUntilStopped(sessionState: DashboardSessionState, option
         secret: options.secret,
       });
       sessionState.dashboardReachableSinceMs = performance.now();
-      logDev(`Hexclave dashboard running at ${dashboardUrl(options.port)}`);
+      logDev(`Hexclave dashboard running at ${dashboardUrl(options.port)}/projects/${encodeURIComponent(sessionState.session.project_id)}`);
       continue;
     } finally {
       clearInterval(abortOnStop);
@@ -632,7 +632,7 @@ async function heartbeatUntilStopped(sessionState: DashboardSessionState, option
         secret: options.secret,
       });
       sessionState.dashboardReachableSinceMs = performance.now();
-      logDev(`Hexclave dashboard running at ${dashboardUrl(options.port)}`);
+      logDev(`Hexclave dashboard running at ${dashboardUrl(options.port)}/projects/${encodeURIComponent(sessionState.session.project_id)}`);
     }
   }
 }
@@ -691,7 +691,7 @@ export function registerDevCommand(program: Command) {
         }),
         dashboardReachableSinceMs: performance.now(),
       };
-      logDev(`Hexclave dashboard running at ${localDashboardUrl}`);
+      logDev(`Hexclave dashboard running at ${localDashboardUrl}/projects/${encodeURIComponent(sessionState.session.project_id)}`);
       maybeOpenOnboardingPage(sessionState.session, port);
 
       let stopped = false;


### PR DESCRIPTION
## Summary\n\nThe `[Hexclave] Hexclave dashboard running at ...` log now appends `/projects/<project_id>` so the printed URL links directly to the project page instead of the dashboard root. Applies to all 3 `logDev` call sites (initial startup + both heartbeat-restart paths).

Link to Devin session: https://app.devin.ai/sessions/91c5e9fb467d4fb292c08491507c629f
Requested by: @mantrakp04

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the CLI to log a direct link to the active project in the Hexclave dashboard. The “Hexclave dashboard running at …” message now appends `/projects/<project_id>` on startup and after heartbeat restarts, so the URL opens the project page instead of the dashboard root.

<sup>Written for commit df8955524d785c1ff0da20a44070d6de47708742. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1551?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * CLI dev command running status messages now display your project-specific dashboard URL, enabling quick direct access to your project without additional navigation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->