### PR TITLE
dashboard: show stale tag on RDE project cards

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,12 @@
 
 ---
 
+## 5/29/26
+
+- Per-provider OAuth callback URLs with host-derived JWT issuer and redirect URIs.
+- New LLM metadata endpoints for documentation discovery.
+- Fixes for SSO dialog tab switching, client retry handling, and legacy cookie mixing.
+
 ## 5/22/26
 
 - Faster ClickHouse analytics for project metrics and previews.

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
@@ -123,7 +123,7 @@ function ProjectsListPage() {
         const response = await fetch("/api/remote-development-environment/active-projects");
         if (!response.ok) return;
         const body = await response.json() as { project_ids?: unknown };
-        if (cancelled || !Array.isArray(body.project_ids)) return;
+        if (cancelled || !Array.isArray(body.project_ids) || !body.project_ids.every((id: unknown) => typeof id === "string")) return;
         setActiveProjectIds(new Set(body.project_ids as string[]));
       } catch {
         // best-effort; don't surface errors for this

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
@@ -106,6 +106,7 @@ function ProjectsListPage() {
   const [projectDailySignups, setProjectDailySignups] = useState<Map<string, { date: string, activity: number }[]>>(new Map());
   const [loadingProjectMetrics, setLoadingProjectMetrics] = useState(true);
   const [projectMetricsError, setProjectMetricsError] = useState(false);
+  const [activeProjectIds, setActiveProjectIds] = useState<Set<string> | null>(null);
   const router = useRouter();
 
   useEffect(() => {
@@ -113,6 +114,30 @@ function ProjectsListPage() {
       router.push('/new-project');
     }
   }, [isLocalEmulator, isRemoteDevelopmentEnvironment, router, rawProjects]);
+
+  useEffect(() => {
+    if (!isRemoteDevelopmentEnvironment) return;
+    let cancelled = false;
+    const poll = async () => {
+      try {
+        const response = await fetch("/api/remote-development-environment/active-projects");
+        if (!response.ok) return;
+        const body = await response.json() as { project_ids?: unknown };
+        if (cancelled || !Array.isArray(body.project_ids)) return;
+        setActiveProjectIds(new Set(body.project_ids as string[]));
+      } catch {
+        // best-effort; don't surface errors for this
+      }
+    };
+    runAsynchronously(poll);
+    const interval = setInterval(() => {
+      runAsynchronously(poll);
+    }, 10_000);
+    return () => {
+      cancelled = true;
+      clearInterval(interval);
+    };
+  }, [isRemoteDevelopmentEnvironment]);
 
   useEffect(() => {
     let cancelled = false;
@@ -536,12 +561,17 @@ function ProjectsListPage() {
                   ? `/projects/${encodeURIComponent(project.id)}`
                   : `/new-project?project_id=${encodeURIComponent(project.id)}`;
 
+                const isStale = isRemoteDevelopmentEnvironment
+                  && activeProjectIds != null
+                  && !activeProjectIds.has(project.id);
+
                 return (
                   <ProjectCard
                     key={project.id}
                     project={project}
                     href={projectHref}
                     showIncompleteBadge={!loadingProjectStatuses && onboardingStatus !== "completed"}
+                    showStaleBadge={isStale}
                     totalUsers={projectTotalUsers.get(project.id)}
                     dailySignups={projectDailySignups.get(project.id)}
                     metricsLoading={loadingProjectMetrics}

--- a/apps/dashboard/src/app/api/remote-development-environment/active-projects/route.ts
+++ b/apps/dashboard/src/app/api/remote-development-environment/active-projects/route.ts
@@ -1,0 +1,13 @@
+import { NextRequest, NextResponse } from "next/server";
+import { getActiveRemoteDevelopmentEnvironmentProjectIds } from "@/lib/remote-development-environment/manager";
+import { assertRemoteDevelopmentEnvironmentBrowserRequest } from "@/lib/remote-development-environment/security";
+
+export const runtime = "nodejs";
+
+export async function GET(req: NextRequest) {
+  const securityResponse = assertRemoteDevelopmentEnvironmentBrowserRequest(req);
+  if (securityResponse != null) return securityResponse;
+
+  const activeProjectIds = getActiveRemoteDevelopmentEnvironmentProjectIds();
+  return NextResponse.json({ project_ids: [...activeProjectIds] });
+}

--- a/apps/dashboard/src/components/project-card.tsx
+++ b/apps/dashboard/src/components/project-card.tsx
@@ -12,6 +12,7 @@ export function ProjectCard(props: {
   project: AdminProject,
   href?: string,
   showIncompleteBadge?: boolean,
+  showStaleBadge?: boolean,
   totalUsers?: number,
   dailySignups?: { date: string, activity: number }[],
   metricsLoading?: boolean,
@@ -39,6 +40,8 @@ export function ProjectCard(props: {
               </h3>
               {props.showIncompleteBadge ? (
                 <DesignBadge label="Setup incomplete" color="orange" size="sm" />
+              ) : props.showStaleBadge ? (
+                <DesignBadge label="Stale" color="red" size="sm" />
               ) : (
                 <span className="shrink-0 text-[10px] text-muted-foreground/80 whitespace-nowrap">
                   {createdAt}

--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -609,6 +609,20 @@ export function getRemoteDevelopmentEnvironmentHealth(): {
   };
 }
 
+export function getActiveRemoteDevelopmentEnvironmentProjectIds(): Set<string> {
+  assertRemoteDevelopmentEnvironmentEnabled();
+  const state = getGlobals();
+  const rdeState = readRemoteDevelopmentEnvironmentState();
+  const activeProjectIds = new Set<string>();
+  for (const session of state.sessions.values()) {
+    const project = rdeState.projectsByConfigPath[session.configFilePath];
+    if (project != null) {
+      activeProjectIds.add(project.projectId);
+    }
+  }
+  return activeProjectIds;
+}
+
 export async function applyRemoteDevelopmentEnvironmentConfigUpdate(options: {
   sessionId?: string,
   projectId?: string,

--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -614,7 +614,9 @@ export function getActiveRemoteDevelopmentEnvironmentProjectIds(): Set<string> {
   const state = getGlobals();
   const rdeState = readRemoteDevelopmentEnvironmentState();
   const activeProjectIds = new Set<string>();
+  const now = performance.now();
   for (const session of state.sessions.values()) {
+    if (now - session.lastHeartbeatMs > SESSION_TTL_MS) continue;
     const project = rdeState.projectsByConfigPath[session.configFilePath];
     if (project != null) {
       activeProjectIds.add(project.projectId);


### PR DESCRIPTION
## Summary

Shows a red "Stale" badge on project cards in the RDE dashboard projects page when no active CLI session (`stack dev`) is connected to that project.

- `getActiveRemoteDevelopmentEnvironmentProjectIds()` in manager.ts cross-references in-memory sessions with `projectsByConfigPath` to return active project IDs
- New browser-facing endpoint `GET /api/remote-development-environment/active-projects` (uses `assertRemoteDevelopmentEnvironmentBrowserRequest`)
- Projects page polls every 10s; `ProjectCard` gets `showStaleBadge` prop rendering `<DesignBadge label="Stale" color="red" size="sm" />`

Link to Devin session: https://app.devin.ai/sessions/91c5e9fb467d4fb292c08491507c629f
Requested by: @mantrakp04

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows a red “Stale” badge on RDE project cards when no active CLI session (stack dev) is connected. Adds polling to keep card status up to date.

- **New Features**
  - Added GET /api/remote-development-environment/active-projects (browser-guarded) to return active project IDs.
  - Projects page polls every 10s and marks cards as stale when a project ID isn’t active.
  - Introduced getActiveRemoteDevelopmentEnvironmentProjectIds(); `ProjectCard` accepts `showStaleBadge` and renders a red “Stale” badge.

- **Bug Fixes**
  - Ignore expired CLI sessions via TTL when computing active project IDs.
  - Validate each `project_ids` element from the API before updating state.

<sup>Written for commit abade90070b472671ad6fa55c1c1f74861ff5d3c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1552?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Projects unused in remote development environments now display a "Stale" badge and are detected via periodic background checks
  * Added per-provider OAuth callback URLs with dynamic host-derived issuer/redirect handling
  * Introduced new LLM metadata endpoints for documentation discovery

* **Bug Fixes**
  * Fixed SSO dialog tab switching, client retry handling, and legacy cookie mixing issues
<!-- end of auto-generated comment: release notes by coderabbit.ai -->