### PR TITLE
fix(dashboard): stop email Sent table from clipping its rows

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/grouped-email-table.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/grouped-email-table.tsx
@@ -268,6 +268,7 @@ export function GroupedEmailTable() {
       state={gridState}
       onChange={setGridState}
       fillHeight={false}
+      stickyTop={0}
       onRowClick={(row, _rowId, _event) => {
         if (row.sourceType === "draft" && row.sourceId) {
           router.push(`email-drafts/${row.sourceId}?stage=sent`);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/no-source/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/no-source/page-client.tsx
@@ -14,7 +14,11 @@ export default function PageClient() {
 
   return (
     <AppEnabledGuard appId="emails">
-      <PageLayout title="Sent: No Template/Draft">
+      {/* allowContentOverflow: SentEmailsView renders a `fillHeight={false}`
+          DataGrid inside an `overflow-hidden` DesignCard, which the default
+          `flex-1 min-h-0` clamp would shrink and clip at the bottom on tall
+          lists. Matches the main email-sent page. */}
+      <PageLayout title="Sent: No Template/Draft" allowContentOverflow>
         <SentEmailsView filterFn={filterFn} />
       </PageLayout>
     </AppEnabledGuard>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/page-client.tsx
@@ -172,6 +172,7 @@ function EmailSendDataTable() {
       isLoadingMore={gridData.isLoadingMore}
       onLoadMore={gridData.loadMore}
       fillHeight={false}
+      stickyTop={0}
       footer={false}
 
       onRowClick={(row) => {
@@ -189,6 +190,11 @@ export default function PageClient() {
       <PageLayout
         title="Sent"
         description="View email logs and domain reputation"
+        // The email log uses a `fillHeight={false}` DataGrid inside an
+        // `overflow-hidden` DesignCard. Without this, PageLayout's default
+        // `flex-1 min-h-0` clamp shrinks the card to the viewport height and
+        // the card clips the bottom rows. Let content grow + page scroll.
+        allowContentOverflow
       >
         <div data-walkthrough="emails-sent" className="flex flex-col lg:flex-row gap-6">
           {/* Left side: Email Log with toggle inside card */}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/email-sent/sent-emails-view.tsx
@@ -168,6 +168,7 @@ export function SentEmailsView({ filterFn, renderActions }: SentEmailsViewProps)
               state={gridState}
               onChange={setGridState}
               fillHeight={false}
+              stickyTop={0}
               onRowClick={(row) => {
                 router.push(`/projects/${projectId}/email-viewer/${row.id}`);
               }}


### PR DESCRIPTION
## Summary

The **Sent** email log (`/projects/:id/email-sent`) clipped its table rows. Two compounding layout bugs were at play: the first data row was cut off under the sticky header at rest, and the whole table could lose its bottom rows once the list exceeded the available height.

**Base:** `dev` → **Head:** `fix/email-sent-table-clipping`
**Scope:** 3 files, +8 lines — all in the `email-sent` route.

## Screenshots

| Before (first row clipped under header) | After (full table visible) |
|---|---|
| <!-- drag the BEFORE screenshot here --> | <!-- drag the AFTER screenshot here --> |

> In **Before**, the top row ("Template rendering failed… / Server Error") is sliced off under the column header. In **After**, every row renders fully.

## Root cause

Two separate issues, both stemming from the `DataGrid` living inside an `overflow-hidden` `DesignCard`:

1. **Bottom clipping.** `PageLayout` wraps page content in `flex-1 min-h-0` by default, clamping it to the viewport height. With the grid using `fillHeight={false}` (grows to natural height) inside the `overflow-hidden` card, the card got shrunk to the clamp and cut off the bottom rows whenever the table exceeded the available space.

2. **First-row clipping.** The `DataGrid`'s sticky header uses the global `--data-grid-sticky-top: 5rem` page offset (meant for tables placed directly on a page, to stick under the dashboard top bar). But here the grid is wrapped in an `overflow-hidden` `DesignCard`, which becomes the sticky scrolling boundary — shifting the header ~24px off its resting position **even with nothing scrolled**, so the rows' `clip-path: inset(24px 0 0 0)` sliced off the top of the first row.

## What changed

- **`page-client.tsx`** — `allowContentOverflow` on `PageLayout` (fixes #1: card now grows and the page scrolls) + `stickyTop={0}` on the list grid (fixes #2).
- **`grouped-email-table.tsx`** — `stickyTop={0}` on the grouped grid.
- **`sent-emails-view.tsx`** — `stickyTop={0}` on the no-source page's grid.

`stickyTop={0}` is the established escape hatch (the analytics tables page already uses it). Since the `overflow-hidden` card already trapped the sticky header, there was no working page-sticky behavior to regress.

## Verification

Confirmed live against the running dev server:
- `--data-grid-sticky-overlap` is now `0px` (`clip-path: inset(0px)`) at rest — first row fully visible.
- Simulated a tall table: the card grows to full content height and the **page scrolls** instead of clipping the bottom (`cardClipsContent: false`, `pageScrolls: true`).
- `@hexclave/dashboard` typecheck + lint pass.

## Notes for reviewers

- The same pattern (`DataGrid` inside an `overflow-hidden` `DesignCard`, no `stickyTop`) exists on the **webhooks** page and likely has the same first-row clip — out of scope here, flagging for a potential follow-up. A longer-term option is to bake this default into the shared `DataGrid`/`DesignCard` so card-wrapped grids handle it automatically.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes row clipping in the Sent email log table so the first row is visible and bottom rows aren’t cut off. The table now scrolls with the page and the header sticks correctly inside its card.

- **Bug Fixes**
  - Enabled `allowContentOverflow` on `PageLayout` for the main and no-source Sent email views so the card grows and the page scrolls instead of clipping.
  - Set `stickyTop={0}` on all Sent email `DataGrid`s (main, grouped, no-source) to remove the global offset that sliced the first row.

<sup>Written for commit 2631dcd57715ffae4127a264449ca11a13c0bc9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1556?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Email table headers now remain sticky at the top while scrolling across sent-email lists.
  * Page layouts updated to allow content overflow so tables can expand without being clipped, improving visibility of long email lists.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->