### PR TITLE
Fix type error in verification-code-handler callbackUrl

### DIFF
--- a/apps/backend/src/route-handlers/verification-code-handler.tsx
+++ b/apps/backend/src/route-handlers/verification-code-handler.tsx
@@ -243,7 +243,7 @@ export function createVerificationCodeHandler<
       const tenancy = await getSoleTenancyFromProjectBranch(project.id, branchId);
 
       if (callbackUrl !== undefined && !validateRedirectUrl(callbackUrl, tenancy)) {
-        throw new KnownErrors.RedirectUrlNotWhitelisted(callbackUrl);
+        throw new KnownErrors.RedirectUrlNotWhitelisted(callbackUrl.toString());
       }
 
       const verificationCodePrisma = await globalPrismaClient.verificationCode.create({


### PR DESCRIPTION
## Summary\n\n`callbackUrl` is `string | URL` after the `!== undefined` narrowing, but `RedirectUrlNotWhitelisted` expects `string | undefined`. Added `.toString()` to convert before passing.

Link to Devin session: https://app.devin.ai/sessions/676b7f048a12437eb4ae924f920be321
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix type error in the verification code handler by converting `callbackUrl` (string | URL) to a string before throwing `RedirectUrlNotWhitelisted`. This matches the error’s expected type and avoids compile-time failures.

<sup>Written for commit 85d0cbf87da6d2989b4cc32b0be82e2d7053ed3e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1559?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved error message formatting for invalid redirect URLs during verification code generation, ensuring clearer feedback when URL validation fails.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->