### PR TITLE
Add 6/5/26 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 ---
 
+## 6/5/26
+
+- Completed platform rebrand to Hexclave with native `@hexclave/*` packages and deprecated `@stackframe` scope.
+- CLI improvements: local dashboard in remote SSH and Codespaces, auto-update via npx re-exec, and ~154 MB bundle reduction.
+- Fixes for sign-out handling, nested cross-domain auth, subscription switching, and email preview theme blanking.
+- New Python & REST API setup docs, product prices clarified as decimal strings, and pnpm v11 upgrade.
+
 ## 5/29/26
  
 - Per-provider OAuth callback URLs with host-derived JWT issuer and redirect URIs.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,6 @@
 
 ## 6/5/26
 
-- Completed platform rebrand to Hexclave with native `@hexclave/*` packages and deprecated `@stackframe` scope.
 - CLI improvements: local dashboard in remote SSH and Codespaces, auto-update via npx re-exec, and ~154 MB bundle reduction.
 - Fixes for sign-out handling, nested cross-domain auth, subscription switching, and email preview theme blanking.
 - New Python & REST API setup docs, product prices clarified as decimal strings, and pnpm v11 upgrade.


### PR DESCRIPTION
## Summary\n\nWeekly changelog update covering commits since 5/29/26.

Link to Devin session: https://app.devin.ai/sessions/fd25862e52834a1a8a032c3dcc9722d7
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updates CHANGELOG.md with the 6/5/26 release notes: CLI improvements (local dashboard in remote SSH/Codespaces, npx re-exec auto‑update, ~154 MB smaller), fixes for sign-out, nested cross-domain auth, subscription switching, and email preview theme, clarified product prices as decimal strings, new Python & REST setup docs, and a `pnpm` v11 upgrade.

<sup>Written for commit 15832c0e76c8e2024291a3257e191f3cd15cf896. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1560?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only change to the changelog; no runtime or application code is modified.
> 
> **Overview**
> Adds a **6/5/26** section at the top of `CHANGELOG.md`, following the existing weekly release-note format.
> 
> The new bullets document CLI work (local dashboard over remote SSH/Codespaces, npx auto-update, ~154 MB bundle shrink), auth and billing fixes (sign-out, nested cross-domain auth, subscription switching, email preview themes), plus new Python/REST setup docs, decimal-string product prices, and a pnpm v11 upgrade.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 15832c0e76c8e2024291a3257e191f3cd15cf896. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->