### PR TITLE
fix(skill): TanStack Start setup passes projectId from import.meta.env

### DIFF
--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -219,15 +219,32 @@ function createInternalApp(apiBaseUrl: string, anonymousRefreshToken?: string) {
 
 function envVarsForProject(project: RemoteDevelopmentEnvironmentProject): Record<string, string> {
   return {
+    // Hexclave rebrand: inject both the new HEXCLAVE_-prefixed names and the legacy STACK_-prefixed
+    // names so apps on either naming convention pick them up. Each is emitted with every framework
+    // prefix family (plain for backends/SSR, NEXT_PUBLIC_ for Next.js, VITE_ for Vite/TanStack Start,
+    // EXPO_PUBLIC_ for Expo) since each framework's browser bundle only sees its own prefix.
+    HEXCLAVE_PROJECT_ID: project.projectId,
+    NEXT_PUBLIC_HEXCLAVE_PROJECT_ID: project.projectId,
+    VITE_HEXCLAVE_PROJECT_ID: project.projectId,
+    EXPO_PUBLIC_HEXCLAVE_PROJECT_ID: project.projectId,
     STACK_PROJECT_ID: project.projectId,
     NEXT_PUBLIC_STACK_PROJECT_ID: project.projectId,
     VITE_STACK_PROJECT_ID: project.projectId,
     EXPO_PUBLIC_STACK_PROJECT_ID: project.projectId,
+    HEXCLAVE_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
+    NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
+    VITE_HEXCLAVE_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
+    EXPO_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
     STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
     NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
     VITE_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
     EXPO_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
+    HEXCLAVE_SECRET_SERVER_KEY: project.secretServerKey,
     STACK_SECRET_SERVER_KEY: project.secretServerKey,
+    HEXCLAVE_API_URL: project.apiBaseUrl,
+    NEXT_PUBLIC_HEXCLAVE_API_URL: project.apiBaseUrl,
+    VITE_HEXCLAVE_API_URL: project.apiBaseUrl,
+    EXPO_PUBLIC_HEXCLAVE_API_URL: project.apiBaseUrl,
     STACK_API_URL: project.apiBaseUrl,
     NEXT_PUBLIC_STACK_API_URL: project.apiBaseUrl,
     VITE_STACK_API_URL: project.apiBaseUrl,

--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -219,10 +219,8 @@ function createInternalApp(apiBaseUrl: string, anonymousRefreshToken?: string) {
 
 function envVarsForProject(project: RemoteDevelopmentEnvironmentProject): Record<string, string> {
   return {
-    // Hexclave rebrand: inject both the new HEXCLAVE_-prefixed names and the legacy STACK_-prefixed
-    // names so apps on either naming convention pick them up. Each is emitted with every framework
-    // prefix family (plain for backends/SSR, NEXT_PUBLIC_ for Next.js, VITE_ for Vite/TanStack Start,
-    // EXPO_PUBLIC_ for Expo) since each framework's browser bundle only sees its own prefix.
+    // Emit both HEXCLAVE_ and legacy STACK_ names, across every framework prefix (plain, NEXT_PUBLIC_,
+    // VITE_, EXPO_PUBLIC_), since each framework's browser only sees its own prefix.
     HEXCLAVE_PROJECT_ID: project.projectId,
     NEXT_PUBLIC_HEXCLAVE_PROJECT_ID: project.projectId,
     VITE_HEXCLAVE_PROJECT_ID: project.projectId,

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
@@ -650,18 +650,42 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
         ${isMaybeFrontend ? deindent`
           In a frontend where you cannot keep a secret key safe, you would use the \`HexclaveClientApp\` constructor:
 
-          \`\`\`ts src/hexclave/client.ts
-          import { HexclaveClientApp } from "${packageName}";
+          ${isDefinitelyTanstackStart ? deindent`
+            \`\`\`ts src/hexclave/client.ts
+            import { HexclaveClientApp } from "${packageName}";
 
-          export const hexclaveClientApp = new HexclaveClientApp({
-            tokenStore: "cookie", // "nextjs-cookie" for Next.js, "cookie" for other web frontends, null for backend environments
-            urls: {
-              default: {
-                type: "hosted",
-              }
-            },
-          });
-          \`\`\`
+            export const hexclaveClientApp = new HexclaveClientApp({
+              tokenStore: "cookie",
+              // Vite (and therefore TanStack Start) only exposes \`VITE_\`-prefixed variables to the
+              // browser, and the SDK's automatic project ID detection reads \`process.env\`, which is
+              // undefined in the browser. Pass the project ID explicitly from \`import.meta.env\`:
+              projectId: import.meta.env.VITE_HEXCLAVE_PROJECT_ID,
+              urls: {
+                default: {
+                  type: "hosted",
+                }
+              },
+            });
+            \`\`\`
+          ` : deindent`
+            \`\`\`ts src/hexclave/client.ts
+            import { HexclaveClientApp } from "${packageName}";
+
+            export const hexclaveClientApp = new HexclaveClientApp({
+              tokenStore: "cookie", // "nextjs-cookie" for Next.js, "cookie" for other web frontends, null for backend environments
+              urls: {
+                default: {
+                  type: "hosted",
+                }
+              },
+            });
+            \`\`\`
+          `}
+          ${isAiPrompt ? deindent`
+            <Note>
+              For Vite-based frameworks such as TanStack Start, \`process.env\` is not available in the browser, so the SDK cannot auto-detect your project ID. Pass it explicitly with \`projectId: import.meta.env.VITE_HEXCLAVE_PROJECT_ID\` and make sure the variable is set with the \`VITE_\` prefix.
+            </Note>
+          ` : ""}
         ` : ""}
 
         ${isMaybeBackend ? deindent`
@@ -762,15 +786,20 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
             ${isAiPrompt ? `${deindent`
               Some projects have the \`requirePublishableClientKey\` config option enabled. In that case, a publishable client key will also be necessary. However, this is extremely uncommon; for most projects this is not true, so don't ask the user for one unless you have confirmation that the publishable client key is required. If it's not required, the project ID is the only environment variable required to use Hexclave on a client.
             `}\n\n` : ""}\`\`\`.env .env.local
-            HEXCLAVE_PROJECT_ID=<your-project-id>
+            ${isDefinitelyTanstackStart ? "VITE_HEXCLAVE_PROJECT_ID" : "HEXCLAVE_PROJECT_ID"}=<your-project-id>
             \`\`\`
+            ${isAiPrompt ? deindent`
 
+              <Note>
+                For Vite-based frameworks such as TanStack Start, name the variable \`VITE_HEXCLAVE_PROJECT_ID\` (only \`VITE_\`-prefixed variables reach the browser) and pass it explicitly to the constructor, since the SDK's auto-detection reads \`process.env\`, which isn't available in the browser.
+              </Note>
+            ` : ""}
             Alternatively, you can also just set the project ID in the \`hexclave/client.ts\` file:
 
             \`\`\`ts src/hexclave/client.ts
             export const hexclaveClientApp = new HexclaveClientApp({
               // ...
-              projectId: "your-project-id",
+              projectId: ${isDefinitelyTanstackStart ? "import.meta.env.VITE_HEXCLAVE_PROJECT_ID" : `"your-project-id"`},
             });
             \`\`\`
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
@@ -598,14 +598,6 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
     nodejs: "@hexclave/js",
     bun: "@hexclave/js",
   }[mainType];
-  // The browser-visible env var that holds the project ID differs by bundler: Next.js inlines
-  // `process.env.NEXT_PUBLIC_*`, Vite (incl. TanStack Start) only exposes `import.meta.env.VITE_*`,
-  // and everything else falls back to plain `process.env.HEXCLAVE_PROJECT_ID`.
-  const projectIdEnvExpr = isDefinitelyNextjs
-    ? "process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID"
-    : isDefinitelyTanstackStart
-      ? "import.meta.env.VITE_HEXCLAVE_PROJECT_ID"
-      : "process.env.HEXCLAVE_PROJECT_ID";
 
   return deindent`
     ## ${typeLabel ? `${typeLabel} SDK Setup Instructions` : "SDK Setup Instructions"}
@@ -663,10 +655,11 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
 
           export const hexclaveClientApp = new HexclaveClientApp({
             tokenStore: "cookie", // "nextjs-cookie" for Next.js, "cookie" for other web frontends, null for backend environments
-            // Your Hexclave project ID. For Vite-based frameworks like TanStack Start, pass it in
-            // explicitly via \`import.meta.env.VITE_HEXCLAVE_PROJECT_ID\` (the browser has no \`process.env\`).
-            // For Next.js, use \`process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID\` — it's read automatically, so you can omit this line.
-            projectId: ${projectIdEnvExpr},
+            // Your Hexclave project ID. In Next.js this is read automatically from
+            // \`process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID\`. In other frameworks, pass it in manually —
+            // e.g. in Vite-based frameworks like TanStack Start use \`import.meta.env.VITE_HEXCLAVE_PROJECT_ID\`,
+            // and otherwise however your framework exposes environment variables to the browser.
+            projectId: process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID,
             urls: {
               default: {
                 type: "hosted",

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
@@ -598,6 +598,11 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
     nodejs: "@hexclave/js",
     bun: "@hexclave/js",
   }[mainType];
+  // The browser-visible env var that holds the project ID differs by bundler: Next.js inlines
+  // `process.env.NEXT_PUBLIC_*`, while Vite (incl. TanStack Start) only exposes `import.meta.env.VITE_*`.
+  const projectIdEnvExpr = isDefinitelyNextjs
+    ? "process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID"
+    : "import.meta.env.VITE_HEXCLAVE_PROJECT_ID";
 
   return deindent`
     ## ${typeLabel ? `${typeLabel} SDK Setup Instructions` : "SDK Setup Instructions"}
@@ -650,42 +655,22 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
         ${isMaybeFrontend ? deindent`
           In a frontend where you cannot keep a secret key safe, you would use the \`HexclaveClientApp\` constructor:
 
-          ${isDefinitelyTanstackStart ? deindent`
-            \`\`\`ts src/hexclave/client.ts
-            import { HexclaveClientApp } from "${packageName}";
+          \`\`\`ts src/hexclave/client.ts
+          import { HexclaveClientApp } from "${packageName}";
 
-            export const hexclaveClientApp = new HexclaveClientApp({
-              tokenStore: "cookie",
-              // Vite (and therefore TanStack Start) only exposes \`VITE_\`-prefixed variables to the
-              // browser, and the SDK's automatic project ID detection reads \`process.env\`, which is
-              // undefined in the browser. Pass the project ID explicitly from \`import.meta.env\`:
-              projectId: import.meta.env.VITE_HEXCLAVE_PROJECT_ID,
-              urls: {
-                default: {
-                  type: "hosted",
-                }
-              },
-            });
-            \`\`\`
-          ` : deindent`
-            \`\`\`ts src/hexclave/client.ts
-            import { HexclaveClientApp } from "${packageName}";
-
-            export const hexclaveClientApp = new HexclaveClientApp({
-              tokenStore: "cookie", // "nextjs-cookie" for Next.js, "cookie" for other web frontends, null for backend environments
-              urls: {
-                default: {
-                  type: "hosted",
-                }
-              },
-            });
-            \`\`\`
-          `}
-          ${isAiPrompt ? deindent`
-            <Note>
-              For Vite-based frameworks such as TanStack Start, \`process.env\` is not available in the browser, so the SDK cannot auto-detect your project ID. Pass it explicitly with \`projectId: import.meta.env.VITE_HEXCLAVE_PROJECT_ID\` and make sure the variable is set with the \`VITE_\` prefix.
-            </Note>
-          ` : ""}
+          export const hexclaveClientApp = new HexclaveClientApp({
+            tokenStore: "cookie", // "nextjs-cookie" for Next.js, "cookie" for other web frontends, null for backend environments
+            // Your Hexclave project ID. For Vite-based frameworks like TanStack Start, pass it in
+            // explicitly via \`import.meta.env.VITE_HEXCLAVE_PROJECT_ID\` (the browser has no \`process.env\`).
+            // For Next.js, use \`process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID\` — it's read automatically, so you can omit this line.
+            projectId: ${projectIdEnvExpr},
+            urls: {
+              default: {
+                type: "hosted",
+              }
+            },
+          });
+          \`\`\`
         ` : ""}
 
         ${isMaybeBackend ? deindent`
@@ -788,18 +773,13 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
             `}\n\n` : ""}\`\`\`.env .env.local
             ${isDefinitelyTanstackStart ? "VITE_HEXCLAVE_PROJECT_ID" : "HEXCLAVE_PROJECT_ID"}=<your-project-id>
             \`\`\`
-            ${isAiPrompt ? deindent`
 
-              <Note>
-                For Vite-based frameworks such as TanStack Start, name the variable \`VITE_HEXCLAVE_PROJECT_ID\` (only \`VITE_\`-prefixed variables reach the browser) and pass it explicitly to the constructor, since the SDK's auto-detection reads \`process.env\`, which isn't available in the browser.
-              </Note>
-            ` : ""}
             Alternatively, you can also just set the project ID in the \`hexclave/client.ts\` file:
 
             \`\`\`ts src/hexclave/client.ts
             export const hexclaveClientApp = new HexclaveClientApp({
               // ...
-              projectId: ${isDefinitelyTanstackStart ? "import.meta.env.VITE_HEXCLAVE_PROJECT_ID" : `"your-project-id"`},
+              projectId: "your-project-id",
             });
             \`\`\`
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/ai-setup-prompt.ts
@@ -599,10 +599,13 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
     bun: "@hexclave/js",
   }[mainType];
   // The browser-visible env var that holds the project ID differs by bundler: Next.js inlines
-  // `process.env.NEXT_PUBLIC_*`, while Vite (incl. TanStack Start) only exposes `import.meta.env.VITE_*`.
+  // `process.env.NEXT_PUBLIC_*`, Vite (incl. TanStack Start) only exposes `import.meta.env.VITE_*`,
+  // and everything else falls back to plain `process.env.HEXCLAVE_PROJECT_ID`.
   const projectIdEnvExpr = isDefinitelyNextjs
     ? "process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID"
-    : "import.meta.env.VITE_HEXCLAVE_PROJECT_ID";
+    : isDefinitelyTanstackStart
+      ? "import.meta.env.VITE_HEXCLAVE_PROJECT_ID"
+      : "process.env.HEXCLAVE_PROJECT_ID";
 
   return deindent`
     ## ${typeLabel ? `${typeLabel} SDK Setup Instructions` : "SDK Setup Instructions"}
@@ -771,7 +774,7 @@ export function getSdkSetupPrompt(mainType: "ai-prompt" | "nextjs" | "react" | "
             ${isAiPrompt ? `${deindent`
               Some projects have the \`requirePublishableClientKey\` config option enabled. In that case, a publishable client key will also be necessary. However, this is extremely uncommon; for most projects this is not true, so don't ask the user for one unless you have confirmation that the publishable client key is required. If it's not required, the project ID is the only environment variable required to use Hexclave on a client.
             `}\n\n` : ""}\`\`\`.env .env.local
-            ${isDefinitelyTanstackStart ? "VITE_HEXCLAVE_PROJECT_ID" : "HEXCLAVE_PROJECT_ID"}=<your-project-id>
+            HEXCLAVE_PROJECT_ID=<your-project-id>
             \`\`\`
 
             Alternatively, you can also just set the project ID in the \`hexclave/client.ts\` file:


### PR DESCRIPTION
## Problem

The `skill.hexclave.com` setup instructions for **TanStack Start** told users to rely on the SDK's automatic project ID detection. That never works in a TanStack Start (Vite) app:

- The SDK's env resolution (`packages/*/src/lib/env.ts`) is **`process.env`-only**, guarded by `typeof process !== "undefined"`.
- In a Vite browser bundle `process` is undefined, so `getDefaultProjectId()` falls through to its `throwErr` → `HexclaveClientApp` throws *"you haven't provided a project ID."*
- Vite only exposes `VITE_`-prefixed vars to the browser via `import.meta.env`, which the SDK never reads.

We can't simply teach the SDK to read `import.meta.env`: `env.ts` is shared across `@hexclave/{js,next,react,tanstack-start}`, all of which emit CommonJS, and tsdown compiles `import.meta` → `{}` in the CJS output. So `import.meta.env` belongs in the **user's** Vite/ESM app code, not the compiled SDK.

## Fix

**`packages/shared/.../ai-setup-prompt.ts`** (source of skill.hexclave.com):
- The `HexclaveClientApp` example now always shows a `projectId`, with a comment explaining the per-framework value. The value is framework-correct via a small `projectIdEnvExpr` helper:
  - Vite / TanStack Start (and react/js) → `import.meta.env.VITE_HEXCLAVE_PROJECT_ID`
  - Next.js → `process.env.NEXT_PUBLIC_HEXCLAVE_PROJECT_ID` (read automatically)
- Cloud "Frontend" instructions use `VITE_HEXCLAVE_PROJECT_ID` on the TanStack Start tab (only `VITE_`-prefixed vars reach the browser).

**`apps/dashboard/.../remote-development-environment/manager.ts`** (`hexclave dev` RDE):
- `envVarsForProject()` now injects `HEXCLAVE_*`-prefixed vars alongside the legacy `STACK_*` ones, across all prefix families (plain, `NEXT_PUBLIC_`, `VITE_`, `EXPO_PUBLIC_`), plus `HEXCLAVE_SECRET_SERVER_KEY`. This makes the recommended local-dev path supply a browser-visible `VITE_HEXCLAVE_PROJECT_ID`, matching the new docs.

## Verification

- Rendered `getSdkSetupPrompt()` for `tanstack-start`, `nextjs`, `react`, `js`, and `ai-prompt`; the `projectId` value is correct on each.
- `@hexclave/shared`: typecheck ✅, lint ✅. `@hexclave/dashboard`: lint ✅.

## Notes

- Legacy `STACK_*` env vars are kept alongside the new `HEXCLAVE_*` ones for backward compat during the rename.
- The mintlify guide (`docs-mintlify/.../setup.mdx`) is generated from this same prompt via `scripts/generate-setup-prompt-docs.ts`; the `llms-full.txt` route reads the source directly. Re-run the generator if/when publishing the mintlify guide.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apps now expose both new Hexclave-prefixed and legacy STACK-prefixed environment variables, including framework-specific variants for Next.js, Vite and Expo for improved compatibility.

* **Documentation**
  * Updated SDK/setup snippets and guidance showing how to read the project ID in different front-end targets (Next.js automatic vs. Vite/others requiring explicit import).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->