### PR TITLE
fix: clearer error when changing email to one already used for auth

### DIFF
--- a/apps/backend/src/app/api/latest/users/crud.tsx
+++ b/apps/backend/src/app/api/latest/users/crud.tsx
@@ -254,7 +254,7 @@ async function checkAuthData(
     });
 
     if (existingChannelUsedForAuth) {
-      throw new KnownErrors.UserWithEmailAlreadyExists(data.primaryEmail);
+      throw new KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", data.primaryEmail);
     }
   }
 }

--- a/apps/dashboard/src/components/user-dialog.tsx
+++ b/apps/dashboard/src/components/user-dialog.tsx
@@ -134,6 +134,7 @@ export function UserDialog(props: {
         alert("Email already used for authentication. This email is already used for sign-in by another account. Please choose a different email address.");
         return 'prevent-close';
       }
+      throw error;
     }
   }
 

--- a/apps/dashboard/src/components/user-dialog.tsx
+++ b/apps/dashboard/src/components/user-dialog.tsx
@@ -2,7 +2,7 @@ import { useAdminApp } from "@/app/(main)/(protected)/projects/[projectId]/use-a
 import { ServerUser } from "@hexclave/next";
 import { KnownErrors } from "@hexclave/shared";
 import { countryCodeSchema, emailSchema, jsonStringOrEmptySchema, passwordSchema } from "@hexclave/shared/dist/schema-fields";
-import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button, Typography, useToast } from "@/components/ui";
+import { Accordion, AccordionContent, AccordionItem, AccordionTrigger, Button, Typography } from "@/components/ui";
 import * as yup from "yup";
 import { FormDialog } from "./form-dialog";
 import { CountryCodeField } from "./country-code-select";
@@ -22,7 +22,6 @@ export function UserDialog(props: {
   type: 'edit',
   user: ServerUser,
 })) {
-  const { toast } = useToast();
   const adminApp = useAdminApp();
   const project = adminApp.useProject();
 
@@ -128,11 +127,11 @@ export function UserDialog(props: {
       }
     } catch (error) {
       if (KnownErrors.UserWithEmailAlreadyExists.isInstance(error)) {
-        toast({
-          title: "Email already exists",
-          description: "Please choose a different email address",
-          variant: "destructive",
-        });
+        alert("Email already exists. Please choose a different email address.");
+        return 'prevent-close';
+      }
+      if (KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse.isInstance(error)) {
+        alert("Email already used for authentication. This email is already used for sign-in by another account. Please choose a different email address.");
         return 'prevent-close';
       }
     }

--- a/apps/e2e/tests/backend/endpoints/api/v1/users-primary-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users-primary-email.test.ts
@@ -433,6 +433,57 @@ describe("updating primary_email via users/me endpoint", () => {
       expect(updateResponse.body.primary_email).toBe(newMailbox.emailAddress);
       expect(updateResponse.body.primary_email_auth_enabled).toBe(true);
     });
+
+    it("should return a clear error when changing primary_email to an email already used for auth by another user", async ({ expect }) => {
+      // Create first user with email used for auth (via OTP sign-in)
+      const { userId: firstUserId } = await Auth.Otp.signIn();
+      const firstUserEmail = (await niceBackendFetch("/api/v1/users/me", {
+        accessType: "client",
+      })).body.primary_email;
+
+      // Create second user via server
+      const secondMailbox = createMailbox();
+      const createResponse = await niceBackendFetch("/api/v1/users", {
+        accessType: "server",
+        method: "POST",
+        body: {
+          primary_email: secondMailbox.emailAddress,
+          primary_email_auth_enabled: true,
+        },
+      });
+      expect(createResponse.status).toBe(201);
+      const secondUserId = createResponse.body.id;
+
+      // Try to change second user's primary_email to first user's email (with auth enabled)
+      const updateResponse = await niceBackendFetch(`/api/v1/users/${secondUserId}`, {
+        accessType: "server",
+        method: "PATCH",
+        body: {
+          primary_email: firstUserEmail,
+          primary_email_auth_enabled: true,
+        },
+      });
+
+      // Should get a clear error about the email being used for auth by another account
+      expect(updateResponse).toMatchInlineSnapshot(`
+        NiceResponse {
+          "status": 409,
+          "body": {
+            "code": "CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE",
+            "details": {
+              "contact_channel_value": "default-mailbox--<stripped UUID>@stack-generated.example.com",
+              "type": "email",
+              "would_work_if_email_was_verified": false,
+            },
+            "error": "This email \\"(default-mailbox--<stripped UUID>@stack-generated.example.com)\\" is already used for authentication by another account.",
+          },
+          "headers": Headers {
+            "x-stack-known-error": "CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE",
+            <some fields may have been hidden>,
+          },
+        }
+      `);
+    });
   });
 
   describe("edge cases", () => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/users-primary-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users-primary-email.test.ts
@@ -436,7 +436,7 @@ describe("updating primary_email via users/me endpoint", () => {
 
     it("should return a clear error when changing primary_email to an email already used for auth by another user", async ({ expect }) => {
       // Create first user with email used for auth (via OTP sign-in)
-      const { userId: firstUserId } = await Auth.Otp.signIn();
+      await Auth.Otp.signIn();
       const firstUserEmail = (await niceBackendFetch("/api/v1/users/me", {
         accessType: "client",
       })).body.primary_email;


### PR DESCRIPTION
## Summary

`checkAuthData` threw `UserWithEmailAlreadyExists` ("A user with email X already exists") when updating `primary_email` to one already used for auth by another account — misleading for email-change operations. Changed to `ContactChannelAlreadyUsedForAuthBySomeoneElse` ("This email is already used for authentication by another account"), which is already used in the contact channel CRUD path for the same scenario. Added E2E test.

Link to Devin session: https://app.devin.ai/sessions/25d0080447ec4257aecff7079cc09f5a
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Return a clear 409 error when changing a user's primary email to one already used for authentication by another account. The dashboard now blocks with a conflict alert, consistent with contact channel CRUD.

- **Bug Fixes**
  - Throw `KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse("email", value)` instead of `KnownErrors.UserWithEmailAlreadyExists` during `primary_email` updates.
  - Dashboard: use a blocking alert, handle `ContactChannelAlreadyUsedForAuthBySomeoneElse`, and re-throw unhandled errors.
  - Added an E2E test verifying 409 and `CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE`; removed an unused variable.

<sup>Written for commit a5f2ae8c3c2e243c037f20d2696a797e9f8342d3. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1569?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling when updating a user’s primary email to one already used for authentication by another account. The API now returns a structured HTTP 409 response with clear error details, and the dashboard shows the error via a blocking alert instead of a destructive toast.

* **Tests**
  * Added an end-to-end test covering the primary email auth-conflict scenario, including validation of the full error payload shape.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->