### PR TITLE
Increase SMTP password max length from 70 to 256

### DIFF
--- a/packages/shared/src/schema-fields.ts
+++ b/packages/shared/src/schema-fields.ts
@@ -612,7 +612,10 @@ export const emailHostSchema = yupString().meta({ openapiField: { description: '
 export const emailPortSchema = yupNumber().min(0).max(65535).meta({ openapiField: { description: 'Email port. Needs to be specified when using type="standard"', exampleValue: 587 } });
 export const emailUsernameSchema = yupString().meta({ openapiField: { description: 'Email username. Needs to be specified when using type="standard"', exampleValue: 'smtp-email' } });
 export const emailSenderEmailSchema = emailSchema.meta({ openapiField: { description: 'Email sender email. Needs to be specified when using type="standard"', exampleValue: 'example@your-domain.com' } });
-export const emailPasswordSchema = passwordSchema.meta({ openapiField: { description: 'Email password. Needs to be specified when using type="standard"', exampleValue: 'your-email-password' } });
+// SMTP credentials are stored encrypted (not bcrypt-hashed like user passwords), so they don't
+// need the 70-char bcrypt limit from passwordSchema. Some providers (e.g. ZeptoMail) generate
+// passwords well over 100 chars.
+export const emailPasswordSchema = yupString().max(256).meta({ openapiField: { description: 'Email password. Needs to be specified when using type="standard"', exampleValue: 'your-email-password' } });
 // Project domain config
 export const handlerPathSchema = yupString().test('is-handler-path', 'Handler path must start with /', (value) => value?.startsWith('/')).meta({ openapiField: { description: 'Handler path. If you did not setup a custom handler path, it should be "/handler" by default. It needs to start with /', exampleValue: '/handler' } });
 // Project email theme config


### PR DESCRIPTION
## Summary

`emailPasswordSchema` inherited `.max(70)` from `passwordSchema`, which exists for bcrypt's 72-byte truncation limit. SMTP credentials are stored encrypted (not bcrypt-hashed), so the limit doesn't apply. Raised to 256.

Link to Devin session: https://app.devin.ai/sessions/5a9f5e3c28d7429393493bf699110813
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Raised SMTP password max length from 70 to 256 by replacing `emailPasswordSchema` inheritance from `passwordSchema` with `yupString().max(256)`. This supports long provider-generated credentials and removes the bcrypt limit that only applies to user passwords.

<sup>Written for commit 1ffede2e10b2ec8b7a2ad53fbe427cd49246bc86. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1579?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Increased the maximum character limit for SMTP email passwords from 70 to 256 characters, allowing longer credential values that were previously rejected during validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->