### PR TITLE
fix(emails): remove 70-char limit on custom SMTP server password

### DIFF
--- a/packages/shared/src/schema-fields.ts
+++ b/packages/shared/src/schema-fields.ts
@@ -612,7 +612,15 @@ export const emailHostSchema = yupString().meta({ openapiField: { description: '
 export const emailPortSchema = yupNumber().min(0).max(65535).meta({ openapiField: { description: 'Email port. Needs to be specified when using type="standard"', exampleValue: 587 } });
 export const emailUsernameSchema = yupString().meta({ openapiField: { description: 'Email username. Needs to be specified when using type="standard"', exampleValue: 'smtp-email' } });
 export const emailSenderEmailSchema = emailSchema.meta({ openapiField: { description: 'Email sender email. Needs to be specified when using type="standard"', exampleValue: 'example@your-domain.com' } });
-export const emailPasswordSchema = passwordSchema.meta({ openapiField: { description: 'Email password. Needs to be specified when using type="standard"', exampleValue: 'your-email-password' } });
+/**
+ * Deliberately not based on passwordSchema — its 70-character limit only applies to user passwords (because of
+ * bcrypt), while SMTP providers may generate much longer credentials.
+ */
+export const emailPasswordSchema = yupString().meta({ openapiField: { description: 'Email password. Needs to be specified when using type="standard"', exampleValue: 'your-email-password' } });
+import.meta.vitest?.test("emailPasswordSchema permits passwords longer than 70 characters", async ({ expect }) => {
+  const longPassword = "a".repeat(144);
+  await expect(emailPasswordSchema.validate(longPassword)).resolves.toBe(longPassword);
+});
 // Project domain config
 export const handlerPathSchema = yupString().test('is-handler-path', 'Handler path must start with /', (value) => value?.startsWith('/')).meta({ openapiField: { description: 'Handler path. If you did not setup a custom handler path, it should be "/handler" by default. It needs to start with /', exampleValue: '/handler' } });
 // Project email theme config


### PR DESCRIPTION
## Problem

A user reported being unable to configure a custom SMTP server because the password field rejects anything over 70 characters

The cap came from `emailPasswordSchema` being derived from `passwordSchema` (`yupString().max(70)`). That limit exists for **user login passwords** — `hashPassword` uses bcrypt, which truncates input at 72 bytes — but SMTP credentials are never bcrypt-hashed, so the cap was inherited by accident.

## Fix

`emailPasswordSchema` is now a standalone `yupString()` with no length cap, with a comment explaining why it must not reuse `passwordSchema`. All three validation points reference this one schema (the `emails.server` config schema, the legacy projects CRUD, and the internal send-test-email endpoint), so the single change fixes every path. The dashboard form already used an uncapped `yup.string()` client-side.

Added an inline vitest regression test asserting a 144-character password validates — it fails against the old schema.

## Why uncapped rather than a higher cap

- A length cap on a credential field is exactly what caused this bug. Providers keep inventing longer secrets — SMTP servers using XOAUTH2 or JWT-style passwords can hand out 1–2KB tokens. Any number we pick is a guess about other people's credential formats, and we only find out it's wrong when a customer files a ticket like this one.
- It matches every comparable field in the schema file: `oauthClientSecretSchema`, `emailHostSchema`, `emailUsernameSchema` are all uncapped strings. Capping only the SMTP password would make it the odd one out.
- It isn't actually unbounded in practice: the value is never hashed (no bcrypt-style cost), it's stored in a jsonb config override column, and config override writes already hard-reject payloads over 5MB — so size policy is enforced at the layer that owns it.

User login password limits are untouched (`passwordSchema` / `userPasswordMutationSchema` still cap at 70).

## Verification

- All inline tests in `schema-fields.ts` pass, including the new regression test
- `lint` and `typecheck` clean on `@hexclave/shared`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Removed the 70‑character limit on custom SMTP server passwords so providers with long credentials (e.g., ZeptoMail’s 144‑char passwords) work. This decouples SMTP credential validation from user password rules.

- **Bug Fixes**
  - Made `emailPasswordSchema` a standalone `yupString()` with no length cap and wired it to all validation paths (`emails.server` config, legacy projects CRUD, send‑test‑email endpoint).
  - Added a regression test that validates a 144‑character password.
  - User login password limits remain unchanged in `passwordSchema` and related mutations.

<sup>Written for commit 3e5c921db5d0d697a87880222bba15530cb814ba. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1580?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Removed the 70-character limitation on passwords for email-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->