### PR TITLE
fix(payments): don't call $replica() inside a transaction in getLatestRow

### DIFF
--- a/apps/backend/src/lib/payments/customer-data.ts
+++ b/apps/backend/src/lib/payments/customer-data.ts
@@ -44,7 +44,17 @@ async function getLatestRow<T>(
     ORDER BY "__all_rows"."rowsortkey" DESC NULLS LAST, "__all_rows"."rowidentifier" DESC
     LIMIT 1
   `;
-  const replicaClient = '$replica' in prisma ? (prisma as any).$replica() : prisma;
+  // `$replica` exists on transaction clients too, but calling it throws
+  // "Cannot use $replica inside of a transaction". Fall back to `prisma`
+  // (which is `tx` in that case) when that happens.
+  let replicaClient = prisma;
+  if ('$replica' in prisma) {
+    try {
+      replicaClient = (prisma as any).$replica();
+    } catch {
+      replicaClient = prisma;
+    }
+  }
   const rows = await replicaClient.$queryRaw`${Prisma.raw(sql)}` as any[];
   if (rows.length === 0) return null;
   return rows[0].rowdata as T;

--- a/apps/backend/src/lib/payments/customer-data.ts
+++ b/apps/backend/src/lib/payments/customer-data.ts
@@ -51,7 +51,10 @@ async function getLatestRow<T>(
   if ('$replica' in prisma) {
     try {
       replicaClient = (prisma as any).$replica();
-    } catch {
+    } catch (e) {
+      if (!(e instanceof Error) || !e.message.includes('Cannot use $replica inside of a transaction')) {
+        throw e;
+      }
       replicaClient = prisma;
     }
   }


### PR DESCRIPTION
## Summary

`getLatestRow` (in `apps/backend/src/lib/payments/customer-data.ts`) decides whether to route a read to the replica with:

```ts
const replicaClient = '$replica' in prisma ? (prisma as any).$replica() : prisma;
```

This was added in #1467 to route read-only raw Prisma queries to the read replica, with the explicit rule that **queries inside transactions should stay on the primary**.

However, a Prisma transaction client (`tx`, as passed by `retryTransaction`) also has `$replica` defined as a property — it just throws when *called*:

```
Error: Cannot use $replica inside of a transaction
    at Proxy.$replica (...)
```

Since `getLatestRow` is called from `getItemQuantityForCustomer` / `getOwnedProductsForCustomer` / etc., which are in turn called from inside `retryTransaction(prisma, async (tx) => { ... })` (e.g. the `update-quantity` route handler at `apps/backend/src/app/api/latest/payments/items/[customer_type]/[customer_id]/[item_id]/update-quantity/route.ts`), every such call throws and the request fails with a 500:

```
Captured error in route-handler: Error: Cannot use $replica inside of a transaction
  at Proxy.$replica (...)
  at ... _transactionWithCallback (@prisma/client/runtime/client.js)
[ERR] POST .../payments/items/team/{teamId}/analytics_events/update-quantity?allow_negative=false: Something went wrong.
```

This is hit in practice by the `external-db-sync` sequencer/poller backfill flow, which calls `tryDecreaseQuantity` for `analytics_events` items.

## Fix

Wrap `.$replica()` in a try/catch and fall back to the passed-in client (the transaction client `tx`) if it throws. This keeps #1467's intent (transactional reads stay on primary) while fixing the regression for raw queries issued via `getLatestRow` from within a transaction.

## Test plan

- [ ] Existing payments e2e tests should continue to pass
- [ ] `POST /api/v1/payments/items/team/{teamId}/{itemId}/update-quantity` from inside a transaction (e.g. via the external-db-sync sequencer touching `analytics_events`) should no longer 500 with `Cannot use $replica inside of a transaction`