### PR TITLE
fix: handle ENOENT race and misleading progress log in CLI dashboard restart

### DIFF
--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -240,7 +240,14 @@ function hasErrnoCode(error: unknown, code: string): boolean {
 }
 
 function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv): void {
-  for (const entry of readdirSync(root, { withFileTypes: true })) {
+  let entries: ReturnType<typeof readdirSync>;
+  try {
+    entries = readdirSync(root, { withFileTypes: true });
+  } catch (error) {
+    if (hasErrnoCode(error, "ENOENT")) return;
+    throw error;
+  }
+  for (const entry of entries) {
     const path = join(root, entry.name);
     if (entry.isDirectory()) {
       try {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -235,6 +235,10 @@ function replaceSentinels(content: string, env: NodeJS.ProcessEnv): string {
   });
 }
 
+function hasErrnoCode(error: unknown, code: string): boolean {
+  return error instanceof Error && "code" in error && error.code === code;
+}
+
 function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv): void {
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const path = join(root, entry.name);
@@ -242,7 +246,7 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
       try {
         replaceDashboardRuntimeSentinels(path, env);
       } catch (error) {
-        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        if (hasErrnoCode(error, "ENOENT")) continue;
         throw error;
       }
       continue;
@@ -259,7 +263,7 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
     try {
       buffer = readFileSync(path);
     } catch (error) {
-      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      if (hasErrnoCode(error, "ENOENT")) continue;
       throw error;
     }
     if (!buffer.includes("STACK_ENV_VAR_SENTINEL")) {

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -269,7 +269,12 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
     if (!buffer.includes("STACK_ENV_VAR_SENTINEL")) {
       continue;
     }
-    writeFileSync(path, replaceSentinels(buffer.toString("utf-8"), env));
+    try {
+      writeFileSync(path, replaceSentinels(buffer.toString("utf-8"), env));
+    } catch (error) {
+      if (hasErrnoCode(error, "ENOENT")) continue;
+      throw error;
+    }
   }
 }
 

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -68,7 +68,7 @@ const REQUIRED_DASHBOARD_RUNTIME_ENV_VARS = new Set([
 ]);
 
 type ProgressLogger = {
-  stop: (finalMessage?: string) => void,
+  stop: (showDone?: boolean) => void,
 };
 
 type DashboardSessionState = {
@@ -162,8 +162,8 @@ function startProgressLog(message: string): ProgressLogger {
   if (!process.stderr.isTTY) {
     logDev(`${message}...`);
     return {
-      stop(finalMessage?: string) {
-        if (finalMessage != null) {
+      stop(showDone?: boolean) {
+        if (showDone) {
           logDev(`${message}... done!`);
         }
       },
@@ -181,12 +181,12 @@ function startProgressLog(message: string): ProgressLogger {
   timer.unref();
 
   return {
-    stop(finalMessage?: string) {
+    stop(showDone?: boolean) {
       if (stopped) return;
       stopped = true;
       clearInterval(timer);
       process.stderr.write("\r\x1b[2K");
-      if (finalMessage != null) {
+      if (showDone) {
         logDev(`${message}... done!`);
       }
     },
@@ -239,7 +239,12 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
   for (const entry of readdirSync(root, { withFileTypes: true })) {
     const path = join(root, entry.name);
     if (entry.isDirectory()) {
-      replaceDashboardRuntimeSentinels(path, env);
+      try {
+        replaceDashboardRuntimeSentinels(path, env);
+      } catch (error) {
+        if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+        throw error;
+      }
       continue;
     }
     if (!entry.isFile()) {
@@ -518,7 +523,7 @@ async function startDashboardIfNeeded(options: { apiBaseUrl: string, secret: str
     const startedAt = performance.now();
     while (performance.now() - startedAt < DASHBOARD_START_TIMEOUT_MS) {
       if (await isDashboardReachable(url, options.secret)) {
-        progress.stop(`Started Hexclave dashboard`);
+        progress.stop(true);
         return;
       }
       await wait(500);

--- a/packages/cli/src/commands/dev.ts
+++ b/packages/cli/src/commands/dev.ts
@@ -162,8 +162,10 @@ function startProgressLog(message: string): ProgressLogger {
   if (!process.stderr.isTTY) {
     logDev(`${message}...`);
     return {
-      stop() {
-        logDev(`${message}... done!`);
+      stop(finalMessage?: string) {
+        if (finalMessage != null) {
+          logDev(`${message}... done!`);
+        }
       },
     };
   }
@@ -179,12 +181,14 @@ function startProgressLog(message: string): ProgressLogger {
   timer.unref();
 
   return {
-    stop() {
+    stop(finalMessage?: string) {
       if (stopped) return;
       stopped = true;
       clearInterval(timer);
       process.stderr.write("\r\x1b[2K");
-      logDev(`${message}... done!`);
+      if (finalMessage != null) {
+        logDev(`${message}... done!`);
+      }
     },
   };
 }
@@ -242,7 +246,17 @@ function replaceDashboardRuntimeSentinels(root: string, env: NodeJS.ProcessEnv):
       continue;
     }
 
-    const buffer = readFileSync(path);
+    // During a version-upgrade restart, the old dashboard process may still be
+    // shutting down and can delete or move files via cached absolute paths. Guard
+    // against the resulting TOCTOU race (readdirSync sees the entry, but the
+    // file is gone by the time we read it).
+    let buffer: Buffer;
+    try {
+      buffer = readFileSync(path);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code === "ENOENT") continue;
+      throw error;
+    }
     if (!buffer.includes("STACK_ENV_VAR_SENTINEL")) {
       continue;
     }
@@ -414,7 +428,15 @@ export async function killLocalDashboard(url: string, port: number): Promise<voi
   // the listener is up, so an unreachable port reliably means it's gone.
   const startedAt = performance.now();
   while (performance.now() - startedAt < DASHBOARD_STOP_TIMEOUT_MS) {
-    if (!(await isDashboardReachable(url))) return;
+    if (!(await isDashboardReachable(url))) {
+      // Port is released, but the process may still be alive doing final I/O
+      // (flushing caches, writing traces). Give it a brief grace period so its
+      // file operations don't race with the new runtime directory being set up.
+      if (processExists(pid)) {
+        await wait(500);
+      }
+      return;
+    }
     await wait(200);
   }
 


### PR DESCRIPTION
## Summary

Fixes a crash during CLI version-upgrade restarts (`1.0.10 → 1.0.11`) where `replaceDashboardRuntimeSentinels` throws ENOENT because the dying old dashboard process can delete files between `readdirSync` and `readFileSync`.

Three targeted fixes:

1. **ENOENT guard** in `replaceDashboardRuntimeSentinels` — catches and skips files/dirs that vanish (TOCTOU race), using a runtime-checked `hasErrnoCode` helper instead of unsafe `as` casts
2. **Grace period** in `killLocalDashboard` — after port is released, waits 500ms if the pid is still alive so its final I/O settles before the new runtime dir is created
3. **Progress log** — `stop(showDone?: boolean)` replaces the misleading `stop(finalMessage?: string)` API where the string was silently discarded

Link to Devin session: https://app.devin.ai/sessions/456fbdf12ebc477f84fd2bebb40c4aca
Requested by: @Developing-Gamer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Updated development dashboard progress output so the “... done!” message appears only when the operation truly completes successfully.
  * Hardened bundled dashboard runtime sentinel replacement to better tolerate restart/upgrade race conditions during directory traversal and file updates.
  * Improved local dashboard shutdown by allowing an extra brief wait for pending I/O when the original process is still present after the port becomes unreachable.
  * Refined dashboard startup reachability handling for more consistent completion behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->