### PR TITLE
[codex] Add docs markdown fetch instructions

### DIFF
--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt.ts
@@ -19,7 +19,13 @@ export function buildSkillSitePrompt(docsIndexPromptValue = docsIndexPrompt) {
 
     ## Docs
 
-    The full docs sidebar — generated from the live navigation. Fetch any of these directly:
+    The full docs sidebar — generated from the live navigation. Fetch any of these directly.
+
+    To retrieve docs as Markdown, use these endpoints:
+
+    - For discovery, fetch \`https://docs.hexclave.com/llms.txt\`.
+    - For a broad single-file docs bundle, fetch \`https://docs.hexclave.com/llms-full.txt\`.
+    - For a specific docs page, append \`.md\` to the canonical docs URL. For example, fetch \`https://docs.hexclave.com/guides/getting-started/setup.md\` for the Markdown version of \`https://docs.hexclave.com/guides/getting-started/setup\`.
 
     ${docsIndexPromptValue}
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt.ts
@@ -22,9 +22,6 @@ export function buildSkillSitePrompt(docsIndexPromptValue = docsIndexPrompt) {
     The full docs sidebar — generated from the live navigation. Fetch any of these directly.
 
     To retrieve docs as Markdown, use these endpoints:
-
-    - For discovery, fetch \`https://docs.hexclave.com/llms.txt\`.
-    - For a broad single-file docs bundle, fetch \`https://docs.hexclave.com/llms-full.txt\`.
     - For a specific docs page, append \`.md\` to the canonical docs URL. For example, fetch \`https://docs.hexclave.com/guides/getting-started/setup.md\` for the Markdown version of \`https://docs.hexclave.com/guides/getting-started/setup\`.
 
     ${docsIndexPromptValue}


### PR DESCRIPTION
## Summary

- Add Markdown-fetch instructions to the hosted `skill.hexclave.com` prompt docs section.
- Document `llms.txt`, `llms-full.txt`, and per-page `.md` URLs for agents fetching docs directly.

## Validation

- Verified live docs behavior with `curl`: `.md` page URLs return Markdown, and `llms.txt` / `llms-full.txt` are reachable.
- Ran `git diff --check`.
- `pnpm -C apps/skills typecheck` could not run because this worktree does not have `node_modules` installed (`tsc: command not found`).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the skill-site prompt to show how to fetch docs as Markdown by appending `.md` to any docs URL (e.g., `https://docs.hexclave.com/guides/getting-started/setup.md`). Remove outdated references to `https://docs.hexclave.com/llms.txt` and `https://docs.hexclave.com/llms-full.txt`.

<sup>Written for commit c5a43be748eb03ef757cb855ae9c6cdae44813c2. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1597?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation guidance with improved instructions and examples for retrieving documentation content.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->