### PR TITLE
Fix/npm-pkg-shared-backend

### DIFF
--- a/packages/shared-backend/package.json
+++ b/packages/shared-backend/package.json
@@ -1,19 +1,39 @@
 {
   "name": "@hexclave/shared-backend",
   "version": "1.0.17",
-  "private": true,
-  "type": "module",
-  "main": "./src/index.ts",
-  "types": "./src/index.ts",
+  "repository": "https://github.com/hexclave/hexclave",
+  "main": "./dist/index.js",
+  "types": "./dist/index.d.ts",
   "exports": {
-    ".": "./src/index.ts",
-    "./config-agent": "./src/config-agent.ts"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "require": {
+        "default": "./dist/index.js"
+      },
+      "default": "./dist/esm/index.js"
+    },
+    "./config-agent": {
+      "types": "./dist/config-agent.d.ts",
+      "require": {
+        "default": "./dist/config-agent.js"
+      },
+      "default": "./dist/esm/config-agent.js"
+    }
   },
   "scripts": {
+    "build": "rimraf dist && tsdown",
+    "clean": "rimraf dist && rimraf node_modules",
+    "dev": "tsdown --watch",
     "lint": "eslint --ext .tsx,.ts .",
     "typecheck": "tsc --noEmit",
     "test": "vitest run"
   },
+  "files": [
+    "dist",
+    "src",
+    "CHANGELOG.md",
+    "LICENSE"
+  ],
   "dependencies": {
     "@anthropic-ai/claude-agent-sdk": "^0.2.73",
     "@hexclave/shared": "workspace:*",

--- a/packages/shared-backend/package.json
+++ b/packages/shared-backend/package.json
@@ -30,7 +30,7 @@
   },
   "files": [
     "dist",
-    "src",
+    "!dist/**/*.test.*",
     "CHANGELOG.md",
     "LICENSE"
   ],

--- a/packages/shared-backend/src/index.ts
+++ b/packages/shared-backend/src/index.ts
@@ -330,11 +330,7 @@ function getRelativeImportSpecifiers(content: string): string[] {
   const importPattern = /\bimport\b(?:[^'"]*?\bfrom\s*)?["'](\.{1,2}\/[^"']+)["']/g;
   let match: RegExpExecArray | null;
   while ((match = importPattern.exec(content)) !== null) {
-    const specifier = match[1];
-    if (specifier == null) {
-      throw new Error("Import specifier regex matched without a capture group.");
-    }
-    specifiers.push(specifier);
+    specifiers.push(match[1]);
   }
   return specifiers;
 }

--- a/packages/shared-backend/tsdown.config.ts
+++ b/packages/shared-backend/tsdown.config.ts
@@ -1,0 +1,3 @@
+import createJsLibraryTsupConfig from '../../configs/tsdown/js-library.ts';
+
+export default createJsLibraryTsupConfig({});


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/stack-auth/stack-auth/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prepares `@hexclave/shared-backend` for npm publishing with a proper build, dual ESM/CJS exports, and bundled types. Also simplifies an import parsing helper for safer matching.

- New Features
  - Configure build with `tsdown`; output CJS/ESM and `.d.ts` to `dist/` and `dist/esm/`.
  - Add export map for `.` and `./config-agent` with `require` and `default` entries plus types.
  - Update publish settings: set `main`/`types` to built files, include only `dist`, exclude tests, and add `build`, `dev`, `clean` scripts.
  - Add repository field and `tsdown.config.ts`.

- Bug Fixes
  - Simplified import specifier parsing in `src/index.ts` to push matches directly and remove unnecessary error throwing.

<sup>Written for commit 9f18bc019ae452099b719241dd0d4051cad92d09. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1598?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Chores**
  * Transitioned package to distribute pre-compiled artifacts from the build directory
  * Added build and development tooling scripts for package maintenance
  * Implemented conditional module exports for improved CommonJS and ESM compatibility

<!-- end of auto-generated comment: release notes by coderabbit.ai -->