### PR TITLE
[codex] fix clickmap wildcard origin launch

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts
@@ -31,4 +31,9 @@ describe("clickmap origin options", () => {
     expect(normalizeClickmapOrigin("https://app.dev.stack-auth.com/dashboard")).toMatchInlineSnapshot(`"https://app.dev.stack-auth.com"`);
     expect(normalizeClickmapOrigin("javascript:alert(1)")).toMatchInlineSnapshot(`null`);
   });
+
+  it("rejects wildcard origins to prevent percent-encoded URLs", () => {
+    expect(normalizeClickmapOrigin("https://**.example.com")).toMatchInlineSnapshot(`null`);
+    expect(normalizeClickmapOrigin("https://*.stack-auth.com")).toMatchInlineSnapshot(`null`);
+  });
 });

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { getClickmapOriginOptions, normalizeClickmapOrigin } from "./clickmap-origins";
+
+describe("clickmap origin options", () => {
+  it("keeps wildcard domains out of launchable origins", () => {
+    const options = getClickmapOriginOptions({
+      wildcard: { baseUrl: "https://**.stack-auth.com" },
+      concrete: { baseUrl: "https://app.stack-auth.com/path?x=1" },
+      duplicate: { baseUrl: "https://app.stack-auth.com/other" },
+    });
+
+    expect(options).toMatchInlineSnapshot(`
+      {
+        "origins": [
+          {
+            "id": "duplicate",
+            "origin": "https://app.stack-auth.com",
+          },
+        ],
+        "wildcardDomains": [
+          {
+            "baseUrl": "https://**.stack-auth.com",
+            "id": "wildcard",
+          },
+        ],
+      }
+    `);
+  });
+
+  it("normalizes only HTTP(S) origins", () => {
+    expect(normalizeClickmapOrigin("https://app.dev.stack-auth.com/dashboard")).toMatchInlineSnapshot(`"https://app.dev.stack-auth.com"`);
+    expect(normalizeClickmapOrigin("javascript:alert(1)")).toMatchInlineSnapshot(`null`);
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.ts
@@ -1,0 +1,69 @@
+export type ClickmapOrigin = {
+  id: string,
+  origin: string,
+};
+
+export type ClickmapWildcardDomain = {
+  id: string,
+  baseUrl: string,
+};
+
+export function normalizeClickmapOrigin(baseUrl: string): string | null {
+  let url: URL;
+  try {
+    url = new URL(baseUrl);
+  } catch {
+    return null;
+  }
+
+  if (url.protocol !== "https:" && url.protocol !== "http:") {
+    return null;
+  }
+
+  return url.origin;
+}
+
+function isWildcardDomain(baseUrl: string): boolean {
+  return baseUrl.includes("*");
+}
+
+function compareStrings(a: string, b: string): number {
+  if (a < b) {
+    return -1;
+  }
+  if (a > b) {
+    return 1;
+  }
+  return 0;
+}
+
+export function getClickmapOriginOptions(trustedDomains: Record<string, { baseUrl?: string | null }>): {
+  origins: ClickmapOrigin[],
+  wildcardDomains: ClickmapWildcardDomain[],
+} {
+  const byOrigin = new Map<string, ClickmapOrigin>();
+  const wildcardDomains: ClickmapWildcardDomain[] = [];
+
+  for (const id in trustedDomains) {
+    const domain = trustedDomains[id];
+    if (domain.baseUrl == null) {
+      continue;
+    }
+
+    if (isWildcardDomain(domain.baseUrl)) {
+      wildcardDomains.push({ id, baseUrl: domain.baseUrl });
+      continue;
+    }
+
+    const origin = normalizeClickmapOrigin(domain.baseUrl);
+    if (origin == null) {
+      continue;
+    }
+    byOrigin.set(origin, { id, origin });
+  }
+
+  return {
+    origins: Array.from(byOrigin.values()).sort((a, b) => compareStrings(a.origin, b.origin)),
+    wildcardDomains: wildcardDomains.sort((a, b) => compareStrings(a.baseUrl, b.baseUrl)),
+  };
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.ts
@@ -1,3 +1,5 @@
+import { stringCompare } from "@hexclave/shared/dist/utils/strings";
+
 export type ClickmapOrigin = {
   id: string,
   origin: string,
@@ -9,6 +11,10 @@ export type ClickmapWildcardDomain = {
 };
 
 export function normalizeClickmapOrigin(baseUrl: string): string | null {
+  if (baseUrl.includes("*")) {
+    return null;
+  }
+
   let url: URL;
   try {
     url = new URL(baseUrl);
@@ -25,16 +31,6 @@ export function normalizeClickmapOrigin(baseUrl: string): string | null {
 
 function isWildcardDomain(baseUrl: string): boolean {
   return baseUrl.includes("*");
-}
-
-function compareStrings(a: string, b: string): number {
-  if (a < b) {
-    return -1;
-  }
-  if (a > b) {
-    return 1;
-  }
-  return 0;
 }
 
 export function getClickmapOriginOptions(trustedDomains: Record<string, { baseUrl?: string | null }>): {
@@ -63,7 +59,7 @@ export function getClickmapOriginOptions(trustedDomains: Record<string, { baseUr
   }
 
   return {
-    origins: Array.from(byOrigin.values()).sort((a, b) => compareStrings(a.origin, b.origin)),
-    wildcardDomains: wildcardDomains.sort((a, b) => compareStrings(a.baseUrl, b.baseUrl)),
+    origins: Array.from(byOrigin.values()).sort((a, b) => stringCompare(a.origin, b.origin)),
+    wildcardDomains: wildcardDomains.sort((a, b) => stringCompare(a.baseUrl, b.baseUrl)),
   };
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
@@ -142,37 +142,37 @@ export default function PageClient() {
         fillWidth
       >
         <DesignAnalyticsCard gradient="slate" className="p-4">
-          <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-            <div className="min-w-0 flex-1 space-y-1">
-              <Typography className="font-medium">Exact page origin</Typography>
-              <Typography type="p" variant="secondary" className="text-xs">
-                Use the exact origin shown in the browser address bar, including for domains matched by a wildcard.
-              </Typography>
-              <Input value={customOrigin} onChange={(event) => setCustomOrigin(event.target.value)} placeholder="https://app.example.com" />
-              {wildcardDomains.length > 0 && (
-                <div className="flex items-start gap-1.5 text-xs text-blue-600 dark:text-blue-400">
-                  <InfoIcon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
-                  <span>
-                    {wildcardDomains.map((d) => d.baseUrl).join(", ")} can match real pages, but cannot be opened directly as a clickmap target.
-                  </span>
-                </div>
-              )}
+          <div className="space-y-1">
+            <Typography className="font-medium">Exact page origin</Typography>
+            <Typography type="p" variant="secondary" className="text-xs">
+              Use the exact origin shown in the browser address bar, including for domains matched by a wildcard.
+            </Typography>
+            <div className="flex items-center gap-2">
+              <Input className="flex-1" value={customOrigin} onChange={(event) => setCustomOrigin(event.target.value)} placeholder="https://app.example.com" />
+              <Button
+                className="shrink-0 gap-1.5"
+                disabled={customOrigin.trim() === ""}
+                onClick={async () => {
+                  const origin = normalizeClickmapOrigin(customOrigin);
+                  if (origin == null) {
+                    window.alert("Enter a valid HTTP(S) origin, for example https://app.example.com.");
+                    return;
+                  }
+                  await showClickmap({ id: "exact-origin", origin });
+                }}
+              >
+                Show clickmap
+                <ArrowRight className="h-4 w-4" />
+              </Button>
             </div>
-            <Button
-              className="gap-1.5"
-              disabled={customOrigin.trim() === ""}
-              onClick={async () => {
-                const origin = normalizeClickmapOrigin(customOrigin);
-                if (origin == null) {
-                  window.alert("Enter a valid HTTP(S) origin, for example https://app.example.com.");
-                  return;
-                }
-                await showClickmap({ id: "exact-origin", origin });
-              }}
-            >
-              Show clickmap
-              <ArrowRight className="h-4 w-4" />
-            </Button>
+            {wildcardDomains.length > 0 && (
+              <div className="flex items-start gap-1.5 text-xs text-blue-600 dark:text-blue-400">
+                <InfoIcon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                <span>
+                  {wildcardDomains.map((d) => d.baseUrl).join(", ")} can match real pages, but cannot be opened directly as a clickmap target.
+                </span>
+              </div>
+            )}
           </div>
         </DesignAnalyticsCard>
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
@@ -18,29 +18,16 @@ import {
   Typography,
 } from "@/components/ui";
 import { DesignAnalyticsCard } from "@/components/design-components/analytics-card";
+import { DesignAlert } from "@/components/design-components/alert";
 import { useRouter } from "@/components/router";
 import type { AnalyticsClickmapTokenResponse } from "@hexclave/shared/dist/interface/admin-metrics";
 import {
   CLICKMAP_OVERLAY_TOKEN_STORAGE_KEY,
   CLICKMAP_OVERLAY_TOKEN_UPDATED_EVENT,
 } from "@hexclave/shared/dist/utils/analytics-clickmap-overlay";
-import { typedEntries } from "@hexclave/shared/dist/utils/objects";
-import { stringCompare } from "@hexclave/shared/dist/utils/strings";
 import { ArrowRight, GlobeHemisphereWest } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
-
-type ClickmapOrigin = {
-  id: string,
-  origin: string,
-};
-
-function normalizeOrigin(baseUrl: string): string | null {
-  try {
-    return new URL(baseUrl).origin;
-  } catch {
-    return null;
-  }
-}
+import { getClickmapOriginOptions, normalizeClickmapOrigin, type ClickmapOrigin } from "./clickmap-origins";
 
 // The clickmap token is a self-describing JWT (its payload carries the project
 // and origin it was minted for), so the snippet only has to hand over the token
@@ -118,19 +105,8 @@ export default function PageClient() {
     setCustomOrigin(window.location.origin);
   }, []);
 
-  const origins = useMemo(() => {
-    const byOrigin = new Map<string, ClickmapOrigin>();
-    for (const [id, domain] of typedEntries(config.domains.trustedDomains)) {
-      if (domain.baseUrl == null) {
-        continue;
-      }
-      const origin = normalizeOrigin(domain.baseUrl);
-      if (origin == null) {
-        continue;
-      }
-      byOrigin.set(origin, { id, origin });
-    }
-    return Array.from(byOrigin.values()).sort((a, b) => stringCompare(a.origin, b.origin));
+  const { origins, wildcardDomains } = useMemo(() => {
+    return getClickmapOriginOptions(config.domains.trustedDomains);
   }, [config.domains.trustedDomains]);
 
   async function showClickmap(origin: ClickmapOrigin) {
@@ -166,39 +142,41 @@ export default function PageClient() {
         description="Launch the clickmap toolbar on a trusted domain."
         fillWidth
       >
-        {config.domains.allowLocalhost && (
-          <DesignAnalyticsCard gradient="slate" className="p-4">
-            <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
-              <div className="min-w-0 flex-1 space-y-1">
-                <Typography className="font-medium">Localhost origin</Typography>
-                <Typography type="p" variant="secondary" className="text-xs">
-                  Use the exact origin shown in the browser address bar for your local site.
-                </Typography>
-                <Input value={customOrigin} onChange={(event) => setCustomOrigin(event.target.value)} placeholder="http://localhost:3000" />
-              </div>
-              <Button
-                className="gap-1.5"
-                disabled={customOrigin.trim() === ""}
-                onClick={async () => {
-                  const origin = normalizeOrigin(customOrigin);
-                  if (origin == null) {
-                    window.alert("Enter a valid HTTP(S) origin, for example http://localhost:3000.");
-                    return;
-                  }
-                  await showClickmap({ id: "localhost", origin });
-                }}
-              >
-                Show clickmap
-                <ArrowRight className="h-4 w-4" />
-              </Button>
+        <DesignAnalyticsCard gradient="slate" className="p-4">
+          <div className="flex flex-col gap-3 sm:flex-row sm:items-end">
+            <div className="min-w-0 flex-1 space-y-1">
+              <Typography className="font-medium">Exact page origin</Typography>
+              <Typography type="p" variant="secondary" className="text-xs">
+                Use the exact origin shown in the browser address bar, including for domains matched by a wildcard.
+              </Typography>
+              <Input value={customOrigin} onChange={(event) => setCustomOrigin(event.target.value)} placeholder="https://app.example.com" />
             </div>
-          </DesignAnalyticsCard>
-        )}
+            <Button
+              className="gap-1.5"
+              disabled={customOrigin.trim() === ""}
+              onClick={async () => {
+                const origin = normalizeClickmapOrigin(customOrigin);
+                if (origin == null) {
+                  window.alert("Enter a valid HTTP(S) origin, for example https://app.example.com.");
+                  return;
+                }
+                await showClickmap({ id: "exact-origin", origin });
+              }}
+            >
+              Show clickmap
+              <ArrowRight className="h-4 w-4" />
+            </Button>
+          </div>
+        </DesignAnalyticsCard>
 
         {origins.length === 0 ? (
           <Alert className="rounded-2xl">
             <div className="flex flex-col gap-3 sm:flex-row sm:items-center sm:justify-between">
-              <span>Add a trusted domain before launching a production clickmap.</span>
+              <span>
+                {wildcardDomains.length === 0
+                  ? "Add a trusted domain before launching a production clickmap."
+                  : "Enter an exact origin that matches a wildcard domain, or add a concrete trusted domain."}
+              </span>
               <Button
                 className="shrink-0 gap-1.5"
                 onClick={() => router.push(`/projects/${project.id}/domains`)}
@@ -230,6 +208,14 @@ export default function PageClient() {
               </div>
             ))}
           </DesignAnalyticsCard>
+        )}
+
+        {wildcardDomains.length > 0 && (
+          <DesignAlert
+            variant="info"
+            title="Wildcard domains need an exact origin"
+            description={`Enter the concrete site origin above. ${wildcardDomains.map((domain) => domain.baseUrl).join(", ")} can match real pages, but cannot be opened directly as a clickmap target.`}
+          />
         )}
 
         <ClickmapTokenDialog

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx
@@ -18,14 +18,13 @@ import {
   Typography,
 } from "@/components/ui";
 import { DesignAnalyticsCard } from "@/components/design-components/analytics-card";
-import { DesignAlert } from "@/components/design-components/alert";
 import { useRouter } from "@/components/router";
 import type { AnalyticsClickmapTokenResponse } from "@hexclave/shared/dist/interface/admin-metrics";
 import {
   CLICKMAP_OVERLAY_TOKEN_STORAGE_KEY,
   CLICKMAP_OVERLAY_TOKEN_UPDATED_EVENT,
 } from "@hexclave/shared/dist/utils/analytics-clickmap-overlay";
-import { ArrowRight, GlobeHemisphereWest } from "@phosphor-icons/react";
+import { ArrowRight, GlobeHemisphereWest, InfoIcon } from "@phosphor-icons/react";
 import { useEffect, useMemo, useState } from "react";
 import { getClickmapOriginOptions, normalizeClickmapOrigin, type ClickmapOrigin } from "./clickmap-origins";
 
@@ -150,6 +149,14 @@ export default function PageClient() {
                 Use the exact origin shown in the browser address bar, including for domains matched by a wildcard.
               </Typography>
               <Input value={customOrigin} onChange={(event) => setCustomOrigin(event.target.value)} placeholder="https://app.example.com" />
+              {wildcardDomains.length > 0 && (
+                <div className="flex items-start gap-1.5 text-xs text-blue-600 dark:text-blue-400">
+                  <InfoIcon className="h-3.5 w-3.5 shrink-0 mt-0.5" />
+                  <span>
+                    {wildcardDomains.map((d) => d.baseUrl).join(", ")} can match real pages, but cannot be opened directly as a clickmap target.
+                  </span>
+                </div>
+              )}
             </div>
             <Button
               className="gap-1.5"
@@ -208,14 +215,6 @@ export default function PageClient() {
               </div>
             ))}
           </DesignAnalyticsCard>
-        )}
-
-        {wildcardDomains.length > 0 && (
-          <DesignAlert
-            variant="info"
-            title="Wildcard domains need an exact origin"
-            description={`Enter the concrete site origin above. ${wildcardDomains.map((domain) => domain.baseUrl).join(", ")} can match real pages, but cannot be opened directly as a clickmap target.`}
-          />
         )}
 
         <ClickmapTokenDialog


### PR DESCRIPTION
## Summary

Fixes the Clickmaps launcher for projects that use wildcard trusted domains.

## What changed

- Split trusted domains into concrete launchable origins and wildcard patterns.
- Stop rendering wildcard domains like `https://**.stack-auth.com` as one-click clickmap targets, which previously became percent-encoded origins such as `https://%2A%2A.stack-auth.com`.
- Keep an exact-origin launcher available so users can paste the real page origin, for example `https://app.dev.stack-auth.com`.
- Add an informational alert explaining that wildcard domains need a concrete origin.
- Add regression tests for wildcard filtering and HTTP(S)-only origin normalization.

## Root cause

The dashboard used `new URL(baseUrl).origin` on wildcard trusted domains. The URL parser percent-encodes `*`, so `https://**.stack-auth.com` turned into `https://%2A%2A.stack-auth.com`. The overlay token was then minted for an origin that is not the real page origin, causing the overlay to reject the token.

## Validation

- `pnpm test run 'apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts'`
- `pnpm -C apps/dashboard exec eslint 'src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.ts' 'src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/clickmap-origins.test.ts' 'src/app/(main)/(protected)/projects/[projectId]/analytics/clickmaps/page-client.tsx'`
- `git diff --check`

Not run: full dashboard typecheck, because this checkout is missing built package outputs such as `@hexclave/shared/dist` and repo instructions say not to build packages from the agent.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Clickmaps launcher for projects with wildcard trusted domains by removing wildcard entries from one‑click targets and requiring an exact HTTP(S) origin. Prevents percent-encoded origins and token mismatches.

- **Bug Fixes**
  - Split trusted domains into concrete origins vs wildcard patterns; filter wildcards from launch targets and sort with shared stringCompare.
  - Normalize HTTP(S) origins and reject wildcard or non-HTTP(S) input when launching.
  - Replace localhost-only input with an “Exact page origin” field and place the “Show clickmap” button inline with the input.
  - Add an inline hint under the origin input explaining wildcards need a concrete origin; refine the empty-state copy for wildcard scenarios.
  - Add tests for wildcard filtering, origin option generation, and origin normalization.

<sup>Written for commit ac2e1f9992fd652703b45af323ef5348b50f7b07. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1606?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an informational alert noting that wildcard-matched pages can’t be opened directly as clickmap targets.

* **Improvements**
  * Updated the clickmap launcher to always show an **Exact page origin** input (replacing the previous localhost-based option).
  * Improved handling and messaging when wildcard domains are involved.
  * Strengthened validation for **Exact page origin**: only HTTP/HTTPS origins are accepted; wildcard/templated host inputs and unsupported schemes are blocked.

* **Tests**
  * Added automated tests covering origin option generation and origin normalization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->