### PR TITLE
fix: disable source maps in RDE dashboard build

### DIFF
--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -70,8 +70,9 @@ const nextConfig = {
 
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
 
-  // we're open-source, so we can provide source maps
-  productionBrowserSourceMaps: true,
+  // we're open-source, so we can provide source maps — but skip them for
+  // RDE standalone builds where they just take up space for no reason
+  productionBrowserSourceMaps: process.env.NEXT_CONFIG_OUTPUT !== "standalone",
 
   poweredByHeader: false,
 


### PR DESCRIPTION
## Summary\n\nDisables `productionBrowserSourceMaps` for standalone/RDE builds — they just take up space with no benefit in that context.\n\n```js\nproductionBrowserSourceMaps: process.env.NEXT_CONFIG_OUTPUT !== \"standalone\",\n```

Link to Devin session: https://app.devin.ai/sessions/58f9eefe58c54570940a9376d434f212
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Disable browser source maps in the dashboard when building for RDE/standalone to reduce artifact size. `productionBrowserSourceMaps` now depends on `NEXT_CONFIG_OUTPUT !== "standalone"` so maps stay enabled for normal builds.

<sup>Written for commit 34091bb1554f01c268532e435aa21559c91a5772. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1611?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-time config only; no runtime behavior change beyond smaller standalone artifacts and no client source maps in that build mode.
> 
> **Overview**
> **`productionBrowserSourceMaps`** in `apps/dashboard/next.config.mjs` is now **off when `NEXT_CONFIG_OUTPUT` is `standalone`**, and unchanged (still on) for normal production builds.
> 
> This matches the existing standalone/RDE pattern (e.g. unoptimized images) so RDE artifacts stay smaller without losing source maps for the usual open-source deploy path.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 34091bb1554f01c268532e435aa21559c91a5772. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated production build configuration to conditionally control source map generation based on deployment type, optimizing standalone builds.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->