### PR TITLE
[Chore]: Fix broken build due to absent key

### DIFF
--- a/docs/src/components/mdx/app-card.tsx
+++ b/docs/src/components/mdx/app-card.tsx
@@ -2,7 +2,7 @@
 
 import { ALL_APPS, AppId } from "@hexclave/shared/dist/apps/apps-config";
 import { AppIcon, appSquarePaddingExpression, appSquareWidthExpression } from "@hexclave/shared/dist/apps/apps-ui";
-import { BarChart3, ClipboardList, Code, CreditCard, Headset, KeyRound, Mail, Mails, PlayCircle, Rocket, ShieldCheck, ShieldEllipsis, Sparkles, Triangle, Tv, UserCog, Users, Vault, Webhook } from "lucide-react";
+import { BarChart3, ClipboardList, Code, CreditCard, Headset, KeyRound, Mail, Mails, MousePointerClick, PlayCircle, Rocket, ShieldCheck, ShieldEllipsis, Sparkles, Triangle, Tv, UserCog, Users, Vault, Webhook } from "lucide-react";
 import Link from "next/link";
 import { cn } from "../../lib/cn";
 
@@ -43,6 +43,7 @@ const APP_ICONS: Record<AppId, React.FunctionComponent<React.SVGProps<SVGSVGElem
   "tanstack-start": Code,
   onboarding: ClipboardList,
   analytics: BarChart3,
+  clickmaps: MousePointerClick,
   "session-replays": PlayCircle,
 };
 


### PR DESCRIPTION
### Summary of Changes
Added clickmap to the app-card



<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixed a build error by adding the missing `clickmaps` key to `APP_ICONS` in the docs app-card and importing `MousePointerClick` from `lucide-react`. This restores the docs build and shows the Clickmaps icon in app cards.

<sup>Written for commit 0c5d3331ac547e0d8dae2fafd19ece5e1634bc83. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1614?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated the app feature display in documentation to include a new clickmaps feature with an appropriate visual icon.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->