### PR TITLE
fix: retry OAuth token exchange without code_verifier when provider rejects PKCE

### DIFF
--- a/apps/backend/src/oauth/providers/base.test.ts
+++ b/apps/backend/src/oauth/providers/base.test.ts
@@ -160,10 +160,16 @@ describe("isCodeVerifierNotNeededError", () => {
     })).toBe(false);
   });
 
-  it("recognizes nested error codes", () => {
+  it("recognizes nested error codes with top-level error_description", () => {
     expect(isCodeVerifierNotNeededError({
       error: { error: "invalid_grant" },
       error_description: "verifier is not needed",
+    })).toBe(true);
+  });
+
+  it("recognizes nested error codes with nested error_description", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: { error: "invalid_grant", error_description: "verifier is not needed" },
     })).toBe(true);
   });
 });

--- a/apps/backend/src/oauth/providers/base.test.ts
+++ b/apps/backend/src/oauth/providers/base.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { getOAuthAccessTokenRefreshError, getOAuthAccessTokenRefreshErrorDisposition, getOAuthCallbackExtraParams, isRetryableOAuthUserInfoError, resolveOAuthAccessTokenExpiredAt } from "./base";
+import { getOAuthAccessTokenRefreshError, getOAuthAccessTokenRefreshErrorDisposition, getOAuthCallbackExtraParams, isCodeVerifierNotNeededError, isRetryableOAuthUserInfoError, resolveOAuthAccessTokenExpiredAt } from "./base";
 
 describe("isRetryableOAuthUserInfoError", () => {
   it("returns true for openid-client timeout errors", () => {
@@ -121,6 +121,50 @@ describe("getOAuthCallbackExtraParams", () => {
         scope: "User.Read openid Mail.Read",
       },
     });
+  });
+});
+
+describe("isCodeVerifierNotNeededError", () => {
+  it("returns true for Google's 'code_verifier or verifier is not needed' error", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: "invalid_grant",
+      error_description: "code_verifier or verifier is not needed.",
+      name: "OPError",
+    })).toBe(true);
+  });
+
+  it("returns false for other invalid_grant errors", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: "invalid_grant",
+      error_description: "Token has been expired or revoked.",
+    })).toBe(false);
+  });
+
+  it("returns false for invalid_grant without error_description", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: "invalid_grant",
+    })).toBe(false);
+  });
+
+  it("returns false for non-invalid_grant errors mentioning verifier", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: "invalid_request",
+      error_description: "code_verifier is not needed.",
+    })).toBe(false);
+  });
+
+  it("returns false for invalid code_verifier errors (mismatch, not 'not needed')", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: "invalid_grant",
+      error_description: "Invalid code verifier.",
+    })).toBe(false);
+  });
+
+  it("recognizes nested error codes", () => {
+    expect(isCodeVerifierNotNeededError({
+      error: { error: "invalid_grant" },
+      error_description: "verifier is not needed",
+    })).toBe(true);
   });
 });
 

--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -109,6 +109,20 @@ function getOAuthProviderErrorCode(error: unknown): string | undefined {
   return (directCode ?? nestedCode)?.toLowerCase();
 }
 
+/**
+ * Detects when a provider's token endpoint rejects a code_verifier because the
+ * corresponding authorization code was not associated with a PKCE code_challenge.
+ * Google can trigger this when it silently re-authorizes an already-consented user
+ * (include_granted_scopes + prompt overridden to "none").
+ */
+export function isCodeVerifierNotNeededError(error: unknown): boolean {
+  const errorCode = getOAuthProviderErrorCode(error);
+  if (errorCode !== "invalid_grant") return false;
+  const desc = getStringProperty(error, "error_description") ?? "";
+  const lower = desc.toLowerCase();
+  return lower.includes("verifier") && lower.includes("not needed");
+}
+
 export type OAuthAccessTokenRefreshErrorDisposition =
   | {
     type: "invalid-refresh-token",
@@ -421,25 +435,49 @@ export abstract class OAuthBaseProvider {
       callbackParams.iss = this.oauthClient.issuer.metadata.issuer;
     }
 
-    const params = [
+    const callbackExtraParams = getOAuthCallbackExtraParams({
+      includeScopeInTokenExchange: this.includeScopeInCallbackTokenExchange,
+      baseScope: this.scope,
+      extraScope: options.extraScope,
+    });
+
+    const buildParams = (codeVerifier: string | undefined) => [
       this.redirectUri,
       callbackParams,
       {
-        code_verifier: this.noPKCE ? undefined : options.codeVerifier,
+        code_verifier: codeVerifier,
         state: options.state,
       },
-      getOAuthCallbackExtraParams({
-        includeScopeInTokenExchange: this.includeScopeInCallbackTokenExchange,
-        baseScope: this.scope,
-        extraScope: options.extraScope,
-      }),
+      callbackExtraParams,
     ] as const;
 
-    try {
+    const exchangeCode = async (params: ReturnType<typeof buildParams>) => {
       if (this.openid) {
-        tokenSet = await this.oauthClient.callback(...params);
+        return await this.oauthClient.callback(...params);
       } else {
-        tokenSet = await this.oauthClient.oauthCallback(...params);
+        return await this.oauthClient.oauthCallback(...params);
+      }
+    };
+
+    let params = buildParams(this.noPKCE ? undefined : options.codeVerifier);
+
+    try {
+      try {
+        tokenSet = await exchangeCode(params);
+      } catch (pkceError: unknown) {
+        // Some providers (notably Google with include_granted_scopes) may silently
+        // reissue an authorization code without PKCE tracking when they override
+        // prompt=consent with prompt=none for an already-consented user. The token
+        // endpoint then rejects the code_verifier because it never saw a matching
+        // code_challenge. Retry without code_verifier; this is safe for confidential
+        // clients that authenticate with client_secret.
+        if (!this.noPKCE && isCodeVerifierNotNeededError(pkceError)) {
+          captureError("inner-oauth-callback-pkce-fallback", pkceError);
+          params = buildParams(undefined);
+          tokenSet = await exchangeCode(params);
+        } else {
+          throw pkceError;
+        }
       }
     } catch (error: any) {
       if (error?.error === "invalid_grant" || error?.error?.error === "invalid_grant") {

--- a/apps/backend/src/oauth/providers/base.tsx
+++ b/apps/backend/src/oauth/providers/base.tsx
@@ -118,7 +118,12 @@ function getOAuthProviderErrorCode(error: unknown): string | undefined {
 export function isCodeVerifierNotNeededError(error: unknown): boolean {
   const errorCode = getOAuthProviderErrorCode(error);
   if (errorCode !== "invalid_grant") return false;
-  const desc = getStringProperty(error, "error_description") ?? "";
+  // Also check the nested error object for error_description, mirroring
+  // how getOAuthProviderErrorCode resolves the code from error.error.
+  const nestedError = getUnknownProperty(error, "error");
+  const desc = getStringProperty(error, "error_description")
+    ?? getStringProperty(nestedError, "error_description")
+    ?? "";
   const lower = desc.toLowerCase();
   return lower.includes("verifier") && lower.includes("not needed");
 }


### PR DESCRIPTION
## Summary

Google can silently re-authorize (prompt=none overriding prompt=consent, typically with `include_granted_scopes=true`) and issue an auth code not associated with the PKCE `code_challenge`. The token endpoint rejects the `code_verifier` with "code_verifier or verifier is not needed."

Adds a targeted retry in `OAuthBaseProvider.getCallback`: when `isCodeVerifierNotNeededError(e)` matches, re-exchange without `code_verifier`. Safe for confidential clients authenticated by `client_secret`.

```diff
# pseudocode in getCallback()
- tokenSet = await exchangeCode(params_with_code_verifier)
+ try {
+   tokenSet = await exchangeCode(params_with_code_verifier)
+ } catch (e) {
+   if (isCodeVerifierNotNeededError(e)) {
+     captureError(...)          // telemetry
+     tokenSet = await exchangeCode(params_without_code_verifier)
+   } else throw e
+ }
```

Link to Devin session: https://app.devin.ai/sessions/2059d2bbc7784f74bc740d2da5f889c8
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retries OAuth token exchange without `code_verifier` when a provider (notably Google) rejects PKCE with “verifier is not needed,” fixing intermittent callback failures for already-consented users.

- **Bug Fixes**
  - Added `isCodeVerifierNotNeededError` to detect `invalid_grant` with “verifier is not needed,” including nested `error` and nested `error_description` shapes.
  - In `OAuthBaseProvider.getCallback`, retry without `code_verifier` only for that error; PKCE stays default. Captures telemetry and extends unit tests for these cases.

<sup>Written for commit cbf41872a151f01a4e326cde18709b29c1b41f28. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1622?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the OAuth token exchange flow by detecting a provider response indicating the PKCE code verifier isn’t needed, then automatically retrying without the verifier when PKCE is enabled.

* **Tests**
  * Added dedicated test coverage for the new “code verifier not needed” error detection, including nested error fields and multiple true/false scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->