### PR TITLE
Inject HEXCLAVE_* env vars in dev environment

### DIFF
--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -219,21 +219,30 @@ function createInternalApp(apiBaseUrl: string, anonymousRefreshToken?: string) {
 }
 
 function envVarsForProject(project: RemoteDevelopmentEnvironmentProject): Record<string, string> {
-  return {
-    STACK_PROJECT_ID: project.projectId,
-    NEXT_PUBLIC_STACK_PROJECT_ID: project.projectId,
-    VITE_STACK_PROJECT_ID: project.projectId,
-    EXPO_PUBLIC_STACK_PROJECT_ID: project.projectId,
-    STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
-    NEXT_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
-    VITE_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
-    EXPO_PUBLIC_STACK_PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
-    STACK_SECRET_SERVER_KEY: project.secretServerKey,
-    STACK_API_URL: project.apiBaseUrl,
-    NEXT_PUBLIC_STACK_API_URL: project.apiBaseUrl,
-    VITE_STACK_API_URL: project.apiBaseUrl,
-    EXPO_PUBLIC_STACK_API_URL: project.apiBaseUrl,
+  const brands = ["HEXCLAVE", "STACK"];
+  const publicPrefixes = ["", "NEXT_PUBLIC_", "VITE_", "EXPO_PUBLIC_"];
+
+  const publicValues: Record<string, string> = {
+    PROJECT_ID: project.projectId,
+    PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
+    API_URL: project.apiBaseUrl,
   };
+  const secretValues: Record<string, string> = {
+    SECRET_SERVER_KEY: project.secretServerKey,
+  };
+
+  const env: Record<string, string> = {};
+  for (const brand of brands) {
+    for (const [name, value] of Object.entries(publicValues)) {
+      for (const prefix of publicPrefixes) {
+        env[`${prefix}${brand}_${name}`] = value;
+      }
+    }
+    for (const [name, value] of Object.entries(secretValues)) {
+      env[`${brand}_${name}`] = value;
+    }
+  }
+  return env;
 }
 
 async function getOrCreateProject(options: {


### PR DESCRIPTION
## Problem

`envVarsForProject` in the dev-environment manager only emits the legacy `STACK_*` env var names. The rest of the CLI was migrated to the `HEXCLAVE_*` brand as canonical, keeping `STACK_*` only as a fallback:

- `init` scaffolds `.env` with `NEXT_PUBLIC_HEXCLAVE_PROJECT_ID`, `NEXT_PUBLIC_HEXCLAVE_PUBLISHABLE_CLIENT_KEY`, `HEXCLAVE_SECRET_SERVER_KEY`
- `resolveProjectId` reads `HEXCLAVE_PROJECT_ID` first, then `STACK_PROJECT_ID` (commented as "legacy")
- `doctor` lists the `HEXCLAVE_*` names first

So `hexclave dev` injects a different set of names than the CLI otherwise expects/generates.

## Change

`envVarsForProject` now emits both brands (`HEXCLAVE_*` and `STACK_*`) across the public framework prefixes (`NEXT_PUBLIC_`, `VITE_`, `EXPO_PUBLIC_`), built from a single source list.

- All previously-emitted `STACK_*` keys are unchanged (no regression).
- The secret server key is still only emitted as `HEXCLAVE_SECRET_SERVER_KEY` / `STACK_SECRET_SERVER_KEY` — never under a public, client-readable prefix.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Updated the dev environment to emit both `HEXCLAVE_*` and legacy `STACK_*` env vars so `hexclave dev` matches the rest of the CLI and avoids name mismatches. Secret keys remain non-public.

- **Bug Fixes**
  - Emit both brands for `PROJECT_ID`, `PUBLISHABLE_CLIENT_KEY`, and `API_URL` under ``, `NEXT_PUBLIC_`, `VITE_`, `EXPO_PUBLIC_`.
  - Only emit `HEXCLAVE_SECRET_SERVER_KEY` / `STACK_SECRET_SERVER_KEY` (never with public prefixes).
  - Keep existing `STACK_*` outputs unchanged for backward compatibility.

<sup>Written for commit 2aef5d4b1a59c8029f6b963d96dc4540ed9f1781. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1627?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal environment variable generation architecture for enhanced maintainability and multi-framework support.

---

**Note:** This release contains internal code improvements with no changes to user-facing functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->