### PR TITLE
Fix typecheck in template cross-domain test

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -447,7 +447,8 @@ describe("StackClientApp cross-domain auth", () => {
     }));
     let currentHref = callbackUrl.toString();
     let redirectedUrl = "";
-    const redirectSpy = vi.spyOn(StackClientApp.prototype as any, "_redirectTo").mockImplementation(async (options: { url: string | URL }) => {
+    const redirectSpy = vi.spyOn(StackClientApp.prototype as any, "_redirectTo").mockImplementation(async (...args: unknown[]) => {
+      const options = args[0] as { url: string | URL };
       redirectedUrl = options.url.toString();
     });
 


### PR DESCRIPTION
## What

Fixes a TypeScript error in `@hexclave/template` that was breaking `pnpm typecheck` repo-wide:

```
client-app-impl.cross-domain.test.ts(450,101): error TS2345:
Argument of type '(options: { url: string | URL; }) => Promise<void>'
is not assignable to parameter of type '(...args: unknown[]) => unknown'.
```

## Why

The `vi.spyOn(...).mockImplementation(...)` callback typed its parameter directly as `{ url: string | URL }`, but `mockImplementation` expects `(...args: unknown[]) => unknown`. `unknown` isn't assignable to `{ url }`, so the build failed.

## How

Accept variadic `unknown[]` args and cast `args[0]` to the expected shape — matching the spy's actual signature while preserving the test's behavior.

`pnpm --filter=@hexclave/template typecheck` now passes.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix TypeScript typecheck failure in `@hexclave/template` cross-domain auth test by updating the `vi.spyOn(...)._redirectTo.mockImplementation` to accept `(...args: unknown[])` and casting `args[0]` to `{ url: string | URL }`. This aligns the mock with its expected signature and restores `pnpm typecheck`.

<sup>Written for commit 4a1787ee663140ed433c3d96b5e316ab32942535. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1628?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test implementation for OAuth callback error handling during startup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->