### PR TITLE
feat: show info note when Reject action is selected in signup rule editor

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
@@ -717,6 +717,15 @@ function RejectMessageField({ state, size = "sm", className }: { state: RuleEdit
   );
 }
 
+function RejectActionNote({ state }: { state: RuleEditorState }) {
+  if (state.actionType !== 'reject') return null;
+  return (
+    <p className="text-xs text-muted-foreground">
+      Reject will prevent users from signing in completely. Consider using Restrict instead — it still creates the user account but blocks app access, and you can unrestrict users later from the dashboard.
+    </p>
+  );
+}
+
 function SaveCancelButtons({ state, size = "sm" }: { state: RuleEditorState, size?: "sm" | "lg" }) {
   return (
     <>
@@ -797,6 +806,7 @@ function RuleEditor(props: {
           <ActionDropdown state={state} />
           <RejectMessageField state={state} />
         </div>
+        <RejectActionNote state={state} />
       </NumberedStep>
       <div className="flex items-center justify-end gap-2 pt-2 border-t border-foreground/[0.06]">
         <SaveCancelButtons state={state} />

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
@@ -720,8 +720,8 @@ function RejectMessageField({ state, size = "sm", className }: { state: RuleEdit
 function RejectActionNote({ state }: { state: RuleEditorState }) {
   if (state.actionType !== 'reject') return null;
   return (
-    <p className="text-xs text-muted-foreground">
-      Reject will prevent users from signing in completely. Consider using Restrict instead — it still creates the user account but blocks app access, and you can unrestrict users later from the dashboard.
+    <p className="text-[11px] leading-snug text-muted-foreground/70">
+      Reject will prevent users from signing up completely. Consider using Restrict instead — it still creates the user account but blocks app access, and you can unrestrict users later from the dashboard.
     </p>
   );
 }


### PR DESCRIPTION
## Summary

When creating or editing a signup rule and selecting "Reject" as the action, a small informational note now appears below the action dropdown explaining that Reject prevents signing in completely and suggesting Restrict as an alternative (creates the account but blocks app access, with the option to unrestrict later from the dashboard).

Link to Devin session: https://app.devin.ai/sessions/27e4156913774e40ae22f7a2798e84b2
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a contextual note when the Reject action is selected in the sign‑up rule editor. It clarifies that Reject prevents signing up entirely and suggests Restrict instead (creates the account but blocks app access, can be unrestricted later), shown as small, muted text below the action.

<sup>Written for commit 44a83bc94ff85e572fcc3e430ec3ad452c8fd045. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1633?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Rule editor now displays informational guidance when configuring reject actions, positioned beneath the reject message input for improved user experience.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->