### PR TITLE
feat: add Hexclave analytics to Mintlify docs

### DIFF
--- a/docs-mintlify/hexclave.js
+++ b/docs-mintlify/hexclave.js
@@ -5,7 +5,7 @@
 
   new HexclaveClientApp({
     projectId: "internal",
-    publishableClientKey: "pck_gdjdkp91a359xtb8ajypqg74se1134z8bwb36appwss7r",
+    publishableClientKey: "pck_3e7rwjp3mfgztqv312zs52xkn4tm9bzrnxf7w9wfcn850",
     tokenStore: "cookie",
     analytics: {
       replays: {

--- a/docs-mintlify/hexclave.js
+++ b/docs-mintlify/hexclave.js
@@ -1,0 +1,17 @@
+(async function () {
+  if (typeof window === "undefined") return;
+
+  const { HexclaveClientApp } = await import("https://esm.sh/@hexclave/js@1.0.22");
+
+  new HexclaveClientApp({
+    projectId: "internal",
+    publishableClientKey: "pck_gdjdkp91a359xtb8ajypqg74se1134z8bwb36appwss7r",
+    tokenStore: "cookie",
+    analytics: {
+      replays: {
+        enabled: true,
+        maskAllInputs: false,
+      },
+    },
+  });
+})();


### PR DESCRIPTION
Adds a custom JS script to the Mintlify docs that loads `@hexclave/js` from esm.sh and initializes a `HexclaveClientApp` for session replay recording.

Link to Devin session: https://app.devin.ai/sessions/f1cabe17143148f2982e03080dfa7345
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a script to Mintlify docs that loads `@hexclave/js@1.0.22` from esm.sh and initializes Hexclave analytics. Replays enabled; cookie token; inputs unmasked; publishable key updated.

<sup>Written for commit c665bc5a9f3b4e850e29a81670c3599b5f6977b7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1635?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Docs-only client analytics with an expected publishable key; replay with unmasked inputs is a minor privacy consideration for anyone typing on the docs site.
> 
> **Overview**
> Introduces **`docs-mintlify/hexclave.js`**, a browser-only IIFE that dynamically imports **`@hexclave/js@1.0.22`** from **esm.sh** and constructs **`HexclaveClientApp`** for the **`internal`** project using a **publishable client key** and **cookie** token storage.
> 
> Analytics is configured with **session replays enabled** and **`maskAllInputs: false`**, so replay capture on docs pages will not mask form fields by default.
> 
> This diff only adds the script file; **`docs.json`** **`customScripts`** still lists **`apps-sidebar-filter.js`** and **`code-language-labels.js`** only—confirm the new script is wired (e.g. via **`customScripts`**) before it runs in production.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c665bc5a9f3b4e850e29a81670c3599b5f6977b7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Hexclave integration to initialize client-side functionality with support for session tracking and replay analytics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->