### PR TITLE
Silently ignore ad blocker network errors in EventTracker and SessionRecorder flush

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/event-tracker.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/event-tracker.test.ts
@@ -387,6 +387,39 @@ describe("EventTracker", () => {
     }
   });
 
+  it("silently ignores network errors caused by ad blockers", async () => {
+    vi.useFakeTimers();
+    document.body.innerHTML = "<button>Click me</button>";
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+    const sentBodies: string[] = [];
+    const tracker = new EventTracker({
+      projectId: "internal",
+      sendBatch: async (body) => {
+        sentBodies.push(body);
+        return Result.error(new TypeError("Failed to fetch"));
+      },
+    });
+
+    try {
+      tracker.start();
+
+      await advancePastFlush();
+      expect(sentBodies).toHaveLength(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // Unlike ANALYTICS_NOT_ENABLED, ad blocker errors do NOT disable the
+      // tracker — subsequent flushes continue attempting delivery.
+      document.querySelector("button")?.dispatchEvent(new MouseEvent("click", { bubbles: true }));
+      await advancePastFlush();
+      expect(sentBodies).toHaveLength(2);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      tracker.stop();
+      warnSpy.mockRestore();
+    }
+  });
+
   it("silently disables when client interface returns ANALYTICS_NOT_ENABLED as an error", async () => {
     vi.useFakeTimers();
     document.body.innerHTML = "<button>Click me</button>";

--- a/packages/template/src/lib/hexclave-app/apps/implementations/event-tracker.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/event-tracker.ts
@@ -4,7 +4,7 @@ import { cssEscapeIdent } from "@hexclave/shared/dist/utils/dom";
 import { buildElementsChain, ELEMENTS_CHAIN_MAX_DEPTH } from "@hexclave/shared/dist/utils/elements-chain";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { Result } from "@hexclave/shared/dist/utils/results";
-import { generateUuid, isAnalyticsNotEnabledError } from "./session-replay";
+import { generateUuid, isAdBlockerNetworkError, isAnalyticsNotEnabledError } from "./session-replay";
 
 const FLUSH_INTERVAL_MS = 10_000;
 const MAX_EVENTS_PER_BATCH = 50;
@@ -505,6 +505,11 @@ export class EventTracker {
     if (res.status === "error") {
       if (isAnalyticsNotEnabledError(res.error)) {
         this._disable();
+        return;
+      }
+      // Ad blockers commonly block analytics endpoints, causing network
+      // errors. These are expected and should not pollute the console.
+      if (isAdBlockerNetworkError(res.error)) {
         return;
       }
       console.warn("EventTracker flush failed:", res.error);

--- a/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.test.ts
@@ -45,6 +45,58 @@ describe("analytics option JSON conversion", () => {
 });
 
 describe("SessionRecorder flush", () => {
+  it("silently ignores network errors caused by ad blockers", async () => {
+    vi.useFakeTimers();
+
+    const storageKey = `hexclave:session-replay:v1:test-project`;
+    localStorage.setItem(storageKey, JSON.stringify({
+      session_id: "test-session",
+      created_at_ms: Date.now(),
+      last_activity_ms: Date.now(),
+    }));
+
+    const sentBodies: string[] = [];
+    const recorder = new SessionRecorder(
+      {
+        projectId: "test-project",
+        sendBatch: async (body) => {
+          sentBodies.push(body);
+          return Result.error(new TypeError("Failed to fetch"));
+        },
+      },
+      {},
+    );
+
+    const warnSpy = vi.spyOn(console, "warn").mockImplementation(() => {});
+
+    try {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (recorder as any)._events = [{ type: 2, timestamp: Date.now(), data: {} }];
+
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      (recorder as any)._tick();
+      await vi.advanceTimersByTimeAsync(0);
+
+      expect(sentBodies).toHaveLength(1);
+      expect(warnSpy).not.toHaveBeenCalled();
+
+      // Unlike ANALYTICS_NOT_ENABLED, ad blocker errors do NOT disable the
+      // recorder — subsequent flushes continue attempting delivery.
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access
+      (recorder as any)._events = [{ type: 3, timestamp: Date.now(), data: {} }];
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-call
+      (recorder as any)._tick();
+      await vi.advanceTimersByTimeAsync(0);
+      expect(sentBodies).toHaveLength(2);
+      expect(warnSpy).not.toHaveBeenCalled();
+    } finally {
+      recorder.stop();
+      warnSpy.mockRestore();
+      localStorage.removeItem(storageKey);
+      vi.useRealTimers();
+    }
+  });
+
   it("silently disables when client interface returns ANALYTICS_NOT_ENABLED as an error", async () => {
     vi.useFakeTimers();
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.ts
@@ -172,9 +172,6 @@ export function isAnalyticsNotEnabledError(error: unknown): boolean {
  * production and should be silently ignored rather than logged as warnings.
  */
 export function isAdBlockerNetworkError(error: unknown): boolean {
-  if (error instanceof TypeError) {
-    return true;
-  }
   if (error instanceof Error) {
     return error.message.includes("Failed to fetch")
       || error.message.includes("NetworkError")

--- a/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/session-replay.ts
@@ -166,6 +166,24 @@ export function isAnalyticsNotEnabledError(error: unknown): boolean {
   return KnownErrors.AnalyticsNotEnabled.isInstance(error);
 }
 
+/**
+ * Whether the error looks like a network failure caused by an ad blocker or
+ * similar extension blocking analytics requests. These are expected in
+ * production and should be silently ignored rather than logged as warnings.
+ */
+export function isAdBlockerNetworkError(error: unknown): boolean {
+  if (error instanceof TypeError) {
+    return true;
+  }
+  if (error instanceof Error) {
+    return error.message.includes("Failed to fetch")
+      || error.message.includes("NetworkError")
+      || error.message.includes("Load failed")
+      || error.message.includes("network connection");
+  }
+  return false;
+}
+
 export class SessionRecorder {
   private _started = false;
   private _cancelled = false;
@@ -272,6 +290,11 @@ export class SessionRecorder {
       if (res.status === "error") {
         if (isAnalyticsNotEnabledError(res.error)) {
           this._disable();
+          return;
+        }
+        // Ad blockers commonly block analytics endpoints, causing network
+        // errors. These are expected and should not pollute the console.
+        if (isAdBlockerNetworkError(res.error)) {
           return;
         }
         captureWarning("SessionRecorder.flush", res.error);


### PR DESCRIPTION
## Summary

Ad blockers block analytics/session-recording endpoints, causing `TypeError: Failed to fetch`. Previously these bubbled up as `console.warn` (EventTracker) or `captureWarning` (SessionRecorder). Now both flush paths check `isAdBlockerNetworkError(err)` and silently return — the tracker stays active and retries on the next interval (unlike `AnalyticsNotEnabled` which permanently disables).

Link to Devin session: https://app.devin.ai/sessions/f0669b8ad33941aa9e21985d79fb18f7
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silently ignore ad‑blocker network errors during analytics flush in EventTracker and SessionRecorder to remove noisy warnings while keeping both components active and retrying.

- **Bug Fixes**
  - Added `isAdBlockerNetworkError` to detect common ad‑blocker failures using error message substrings (e.g., "Failed to fetch", "NetworkError", "Load failed") instead of TypeError checks.
  - Applied handling in EventTracker and SessionRecorder flush paths to skip console.warn/captureWarning for these cases; `AnalyticsNotEnabled` still disables.
  - Added tests to confirm silent behavior and continued retries on subsequent flushes.

<sup>Written for commit ef50a1df4c09bef801d61e03b030496ff386da95. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1638?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of ad blocker/extension-style network failures for event tracking and session replay. The app now silently ignores these errors, continues attempting delivery on later flushes, and avoids disabling analytics or emitting console warnings.  
  * Added coverage to ensure ad-blocker network errors are not reported and do not trigger self-disabling behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->