### PR TITLE
fix: resolve MODULE_NOT_FOUND for claude-agent-sdk cli.js in RDE config updates

### DIFF
--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -67,6 +67,12 @@ const nextConfig = {
   output: process.env.NEXT_CONFIG_OUTPUT,
   distDir: process.env.HEXCLAVE_DASHBOARD_NEXT_DIST_DIR,
   outputFileTracingRoot: path.join(__dirname, "../.."),
+  // The claude-agent-sdk spawns cli.js as a child process (resolved via
+  // import.meta.url). If the SDK is bundled, Turbopack bakes the .pnpm path
+  // into import.meta.url, but copy-runtime-assets removes .pnpm — so cli.js
+  // vanishes. Keeping it external ensures it gets a top-level node_modules
+  // entry that survives the .pnpm removal and import.meta.url resolves correctly.
+  serverExternalPackages: ["@anthropic-ai/claude-agent-sdk"],
   outputFileTracingIncludes: {
     "/api/remote-development-environment/config/apply-update": [
       path.join(claudeAgentSdkTraceDir, "cli.js"),

--- a/apps/dashboard/next.config.mjs
+++ b/apps/dashboard/next.config.mjs
@@ -1,12 +1,8 @@
 import { withSentryConfig } from "@sentry/nextjs";
-import { createRequire } from "module";
 import path from "path";
 import { fileURLToPath } from "url";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
-const sharedBackendRequire = createRequire(path.join(__dirname, "../../packages/shared-backend/package.json"));
-const claudeAgentSdkDir = path.dirname(sharedBackendRequire.resolve("@anthropic-ai/claude-agent-sdk"));
-const claudeAgentSdkTraceDir = path.relative(__dirname, claudeAgentSdkDir);
 
 const withConfiguredSentryConfig = (nextConfig) =>
   withSentryConfig(
@@ -68,20 +64,10 @@ const nextConfig = {
   distDir: process.env.HEXCLAVE_DASHBOARD_NEXT_DIST_DIR,
   outputFileTracingRoot: path.join(__dirname, "../.."),
   // The claude-agent-sdk spawns cli.js as a child process (resolved via
-  // import.meta.url). If the SDK is bundled, Turbopack bakes the .pnpm path
-  // into import.meta.url, but copy-runtime-assets removes .pnpm — so cli.js
-  // vanishes. Keeping it external ensures it gets a top-level node_modules
-  // entry that survives the .pnpm removal and import.meta.url resolves correctly.
+  // import.meta.url). Keeping it external ensures the entire package directory
+  // is included in the standalone trace and hoisted to top-level node_modules/
+  // by copy-runtime-assets — so cli.js, vendor/, etc. survive .pnpm removal.
   serverExternalPackages: ["@anthropic-ai/claude-agent-sdk"],
-  outputFileTracingIncludes: {
-    "/api/remote-development-environment/config/apply-update": [
-      path.join(claudeAgentSdkTraceDir, "cli.js"),
-      path.join(claudeAgentSdkTraceDir, "manifest.json"),
-      path.join(claudeAgentSdkTraceDir, "manifest.zst.json"),
-      path.join(claudeAgentSdkTraceDir, "resvg.wasm"),
-      path.join(claudeAgentSdkTraceDir, "vendor/**/*"),
-    ],
-  },
 
   pageExtensions: ["js", "jsx", "mdx", "ts", "tsx"],
 

--- a/packages/cli/scripts/copy-runtime-assets.mjs
+++ b/packages/cli/scripts/copy-runtime-assets.mjs
@@ -123,12 +123,57 @@ function hoistPnpmNodeModules(pnpmDir) {
   }
 }
 
+function getPackageNameFromPnpmSpecifier(specifier) {
+  // Extract the package name from a pnpm store specifier directory name.
+  // e.g. "@anthropic-ai+claude-agent-sdk@0.2.73_zod@4.3.6" → "@anthropic-ai/claude-agent-sdk"
+  // e.g. "react@19.2.3" → "react"
+  const atVersionIndex = specifier.indexOf("@", specifier.startsWith("@") ? 1 : 0);
+  if (atVersionIndex < 0) {
+    return undefined;
+  }
+  const nameWithPlus = specifier.slice(0, atVersionIndex);
+  if (nameWithPlus.startsWith("@")) {
+    const plusIndex = nameWithPlus.indexOf("+");
+    if (plusIndex >= 0) {
+      return nameWithPlus.slice(0, plusIndex) + "/" + nameWithPlus.slice(plusIndex + 1);
+    }
+  }
+  return nameWithPlus;
+}
+
+function hoistPnpmStorePackages(pnpmDir) {
+  // Each .pnpm/<specifier>/node_modules/<name>/ contains the primary package
+  // for that specifier. When serverExternalPackages are used, these directories
+  // hold the actual module files (including non-imported assets like cli.js)
+  // that Node.js needs to resolve at runtime. Hoist them to the top-level
+  // node_modules/ so they survive .pnpm removal.
+  const destNodeModules = dirname(pnpmDir);
+  for (const entry of readdirSync(pnpmDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || entry.name === "node_modules" || entry.name.startsWith(".")) {
+      continue;
+    }
+    const packageName = getPackageNameFromPnpmSpecifier(entry.name);
+    if (packageName == null || EXCLUDED_RUNTIME_PACKAGES.has(packageName)) {
+      continue;
+    }
+    const packageDir = join(pnpmDir, entry.name, "node_modules", ...packageName.split("/"));
+    if (!existsSync(packageDir) || !existsSync(join(packageDir, "package.json"))) {
+      continue;
+    }
+    const dest = join(destNodeModules, packageName);
+    if (!existsSync(dest)) {
+      cpSync(packageDir, dest, { recursive: true, dereference: true });
+    }
+  }
+}
+
 function removePnpmStore(nodeModulesDir) {
   const pnpmDir = join(nodeModulesDir, ".pnpm");
   if (!existsSync(pnpmDir)) {
     return;
   }
   hoistPnpmNodeModules(pnpmDir);
+  hoistPnpmStorePackages(pnpmDir);
   rmSync(pnpmDir, { recursive: true, force: true });
 }
 

--- a/packages/cli/scripts/copy-runtime-assets.mjs
+++ b/packages/cli/scripts/copy-runtime-assets.mjs
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { cpSync, existsSync, readlinkSync, readdirSync, rmSync } from "fs";
+import { cpSync, existsSync, mkdirSync, readlinkSync, readdirSync, rmSync } from "fs";
 import { dirname, join, relative, resolve } from "path";
 import { fileURLToPath } from "url";
 
@@ -162,6 +162,10 @@ function hoistPnpmStorePackages(pnpmDir) {
     }
     const dest = join(destNodeModules, packageName);
     if (!existsSync(dest)) {
+      const scopeDir = packageName.includes("/") ? join(destNodeModules, packageName.split("/")[0]) : null;
+      if (scopeDir && !existsSync(scopeDir)) {
+        mkdirSync(scopeDir, { recursive: true });
+      }
       cpSync(packageDir, dest, { recursive: true, dereference: true });
     }
   }


### PR DESCRIPTION
## Summary

Fixes `MODULE_NOT_FOUND` for `@anthropic-ai/claude-agent-sdk/cli.js` when the RDE config updater runs.

The SDK was bundled by Turbopack, which baked the `.pnpm/` store path into `import.meta.url`. `copy-runtime-assets` then removed `.pnpm/`, so `cli.js` vanished at runtime.

```diff
# next.config.mjs
+ serverExternalPackages: ["@anthropic-ai/claude-agent-sdk"]
- outputFileTracingIncludes: { ... cli.js, vendor/**, ... }
```

```diff
# copy-runtime-assets.mjs — removePnpmStore()
  hoistPnpmNodeModules(pnpmDir);
+ hoistPnpmStorePackages(pnpmDir);  // hoist .pnpm/<spec>/node_modules/<pkg>/ → node_modules/<pkg>/
  rmSync(pnpmDir, ...);
```

`serverExternalPackages` keeps the SDK external so (a) `import.meta.url` resolves to the actual runtime path, and (b) Next.js traces the entire package directory into standalone output. `hoistPnpmStorePackages` ensures those files survive `.pnpm` removal. The old `outputFileTracingIncludes` was a partial workaround that never fully solved the problem — removed.

Link to Devin session: https://app.devin.ai/sessions/a6a5979df5d14204ba7da7af26389200
Requested by: @mantrakp04

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes MODULE_NOT_FOUND for `@anthropic-ai/claude-agent-sdk/cli.js` during RDE config updates by keeping the SDK external and hoisting its files out of `.pnpm/` before cleanup. Also handles scoped packages to avoid copy errors.

- **Bug Fixes**
  - Set `serverExternalPackages: ["@anthropic-ai/claude-agent-sdk"]` in `apps/dashboard/next.config.mjs` so `import.meta.url` resolves at runtime and the full package is traced.
  - Added `hoistPnpmStorePackages()` in `packages/cli/scripts/copy-runtime-assets.mjs` to copy `.pnpm/<spec>/node_modules/<pkg>/` into top-level `node_modules/` before removing `.pnpm`.
  - Create `@scope/` directories with `mkdirSync` before copying hoisted packages to prevent `ENOENT`.

- **Refactors**
  - Removed manual `outputFileTracingIncludes` for the SDK since externalizing the package includes its entire directory automatically.

<sup>Written for commit 67b9013ecf198ced879f5bcaa2dafa1f1922b819. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1639?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Improved dashboard build/packaging behavior to better preserve required runtime files in standalone outputs.
  * Refined runtime asset handling to hoist additional packages from pnpm store locations into top-level `node_modules`, reducing missing-module risks after `.pnpm` removal.
  * Updated build configuration logic to use ESM-compatible path resolution for more consistent packaging.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->