### PR TITLE
fix: allow Google/GitHub/Microsoft OAuth in RDE onboarding

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
@@ -161,6 +161,34 @@ describe("ProjectOnboardingWizard", () => {
     expect(normalizedState.selected_apps).toEqual(REQUIRED_APP_IDS);
   });
 
+  it("preserves OAuth sign-in methods when developmentEnvironment is true but isLocalEmulator is false (RDE)", () => {
+    const normalizedState = normalizeProjectOnboardingState({
+      selected_config_choice: "create-new",
+      selected_apps: [],
+      selected_sign_in_methods: ["credential", "google", "github"],
+      selected_email_theme_id: null,
+      selected_payments_country: "US",
+    }, { developmentEnvironment: true, isLocalEmulator: false });
+
+    expect(normalizedState.selected_sign_in_methods).toContain("google");
+    expect(normalizedState.selected_sign_in_methods).toContain("github");
+  });
+
+  it("strips OAuth sign-in methods when isLocalEmulator is true", () => {
+    const normalizedState = normalizeProjectOnboardingState({
+      selected_config_choice: "create-new",
+      selected_apps: [],
+      selected_sign_in_methods: ["credential", "google", "github", "microsoft"],
+      selected_email_theme_id: null,
+      selected_payments_country: "US",
+    }, { developmentEnvironment: true, isLocalEmulator: true });
+
+    expect(normalizedState.selected_sign_in_methods).toContain("credential");
+    expect(normalizedState.selected_sign_in_methods).not.toContain("google");
+    expect(normalizedState.selected_sign_in_methods).not.toContain("github");
+    expect(normalizedState.selected_sign_in_methods).not.toContain("microsoft");
+  });
+
   it("does not offer alpha apps during app selection", () => {
     const alphaAppIds = Object.entries(ALL_APPS)
       .filter(([, app]) => app.stage === "alpha")

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -96,12 +96,13 @@ export function ProjectOnboardingWizard(props: {
       selectedEmailThemeId: completeConfig.emails.selectedThemeId,
       selectedPaymentsCountry: "US",
       developmentEnvironment: isDevelopmentEnvironment,
+      isLocalEmulator,
     });
     if (onboardingState == null) {
       return defaultState;
     }
-    return normalizeProjectOnboardingState(onboardingState, { developmentEnvironment: isDevelopmentEnvironment });
-  }, [completeConfig, isDevelopmentEnvironment, onboardingState, project]);
+    return normalizeProjectOnboardingState(onboardingState, { developmentEnvironment: isDevelopmentEnvironment, isLocalEmulator });
+  }, [completeConfig, isDevelopmentEnvironment, isLocalEmulator, onboardingState, project]);
   const initialOnboardingState = deriveCurrentOnboardingState(status);
   const [saving, setSaving] = useState(false);
   const [selectedApps, setSelectedApps] = useState<Set<AppId>>(() => new Set(initialOnboardingState.selected_apps));
@@ -282,8 +283,9 @@ export function ProjectOnboardingWizard(props: {
       selectedEmailThemeId: selectedEmailThemeId ?? completeConfig.emails.selectedThemeId,
       selectedPaymentsCountry,
       developmentEnvironment: isDevelopmentEnvironment,
+      isLocalEmulator,
     });
-  }, [completeConfig.emails.selectedThemeId, isDevelopmentEnvironment, selectedApps, selectedConfigChoice, selectedEmailThemeId, selectedPaymentsCountry, signInMethods]);
+  }, [completeConfig.emails.selectedThemeId, isDevelopmentEnvironment, isLocalEmulator, selectedApps, selectedConfigChoice, selectedEmailThemeId, selectedPaymentsCountry, signInMethods]);
 
   const persistOnboardingState = useCallback(async () => {
     await setOnboardingState(buildOnboardingState());
@@ -300,7 +302,7 @@ export function ProjectOnboardingWizard(props: {
     for (const appId of ALL_APP_IDS) {
       configUpdate[`apps.installed.${appId}.enabled`] = selectedApps.has(appId);
     }
-    if (isDevelopmentEnvironment) {
+    if (isLocalEmulator) {
       configUpdate["auth.oauth.providers.google"] = signInMethods.has("google") ? {
         type: "google",
         allowSignIn: true,
@@ -318,7 +320,7 @@ export function ProjectOnboardingWizard(props: {
       } : null;
     }
     return configUpdate;
-  }, [completeConfig.emails.selectedThemeId, isDevelopmentEnvironment, selectedApps, selectedEmailThemeId, signInMethods]);
+  }, [completeConfig.emails.selectedThemeId, isLocalEmulator, selectedApps, selectedEmailThemeId, signInMethods]);
 
   const buildEnvironmentOAuthConfigUpdate = useCallback(() => {
     const configUpdate: EnvironmentConfigOverrideOverride = {};
@@ -347,7 +349,7 @@ export function ProjectOnboardingWizard(props: {
           return;
         }
 
-        if (!isDevelopmentEnvironment) {
+        if (!isLocalEmulator) {
           const providersUpdated = await updateConfig({
             adminApp: props.project.app,
             configUpdate: buildEnvironmentOAuthConfigUpdate(),
@@ -368,7 +370,7 @@ export function ProjectOnboardingWizard(props: {
     buildEnvironmentOAuthConfigUpdate,
     finishProjectOnboarding,
     isLinkExistingMode,
-    isDevelopmentEnvironment,
+    isLocalEmulator,
     persistOnboardingState,
     props.project.app,
     clearOnboardingState,
@@ -698,7 +700,7 @@ export function ProjectOnboardingWizard(props: {
   }
 
   if (props.status === "auth_setup") {
-    const availableSignInMethods = isDevelopmentEnvironment
+    const availableSignInMethods = isLocalEmulator
       ? SIGN_IN_METHODS.filter((method) => !OAUTH_SIGN_IN_METHODS.some((oauthMethod) => oauthMethod === method.id))
       : SIGN_IN_METHODS;
 

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/shared.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/shared.ts
@@ -84,7 +84,7 @@ export function isProjectOnboardingState(value: unknown): value is ProjectOnboar
 
 export function normalizeProjectOnboardingState(
   value: ProjectOnboardingState,
-  options?: { developmentEnvironment: boolean },
+  options?: { developmentEnvironment: boolean, isLocalEmulator?: boolean },
 ): ProjectOnboardingState {
   const selectedApps = ALL_APP_IDS.filter((appId) => (
     value.selected_apps.some((selectedAppId) => selectedAppId === appId)
@@ -94,7 +94,11 @@ export function normalizeProjectOnboardingState(
     .map((method) => method.id)
     .filter((methodId) => value.selected_sign_in_methods.some((selectedMethodId) => selectedMethodId === methodId));
   const developmentEnvironment = options?.developmentEnvironment === true;
-  const normalizedSignInMethods = developmentEnvironment
+  const isLocalEmulator = options?.isLocalEmulator === true;
+  // Only strip OAuth sign-in methods for the local emulator, which lacks real OAuth
+  // infrastructure. The RDE connects to the production backend where shared OAuth
+  // providers work normally.
+  const normalizedSignInMethods = isLocalEmulator
     ? selectedSignInMethods.filter((methodId) => !OAUTH_SIGN_IN_METHODS.some((oauthMethod) => oauthMethod === methodId))
     : selectedSignInMethods;
   return {
@@ -113,6 +117,7 @@ export function createProjectOnboardingState(options: {
   selectedEmailThemeId: string | null,
   selectedPaymentsCountry: OnboardingPaymentsCountry,
   developmentEnvironment: boolean,
+  isLocalEmulator?: boolean,
 }): ProjectOnboardingState {
   return normalizeProjectOnboardingState({
     selected_config_choice: options.selectedConfigChoice,
@@ -122,7 +127,7 @@ export function createProjectOnboardingState(options: {
       .filter((methodId) => options.selectedSignInMethods.has(methodId)),
     selected_email_theme_id: options.selectedEmailThemeId,
     selected_payments_country: options.selectedPaymentsCountry,
-  }, { developmentEnvironment: options.developmentEnvironment });
+  }, { developmentEnvironment: options.developmentEnvironment, isLocalEmulator: options.isLocalEmulator });
 }
 
 export function isStackAppInternals(value: unknown): value is HexclaveAppInternals {


### PR DESCRIPTION
## Summary

The onboarding wizard filtered out OAuth sign-in methods (Google, GitHub, Microsoft) for all development environments via `isDevelopmentEnvironment`, but this was only correct for the local emulator which lacks real OAuth infrastructure. The RDE connects to the production backend where shared OAuth providers work normally.

Changed `isDevelopmentEnvironment` → `isLocalEmulator` in the auth setup filtering, `normalizeProjectOnboardingState`, `buildBranchConfigUpdate`, and `finalizeOnboarding` — so RDE now follows the production OAuth path (shared providers via environment config) while the local emulator continues to strip OAuth methods.


Link to Devin session: https://app.devin.ai/sessions/fd495a19448145bf8eeb4b8e591f8739
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Allow Google, GitHub, and Microsoft OAuth during RDE onboarding by only stripping OAuth in the local emulator. RDE now uses shared providers against production; the emulator remains credential-only.

- **Bug Fixes**
  - Switched guards from isDevelopmentEnvironment to isLocalEmulator in sign-in method filtering, onboarding state normalization, and branch/environment OAuth config updates.
  - Added tests to verify OAuth is preserved in RDE and removed in the local emulator.

<sup>Written for commit 492956fa4af8321f7a9ef7bcb369b615a16bd154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1640?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes auth onboarding and config writes for dev vs production-like paths, but scope is dashboard onboarding only and is covered by new tests.
> 
> **Overview**
> Project onboarding treated **all** development environments like the local emulator and hid or dropped Google/GitHub/Microsoft OAuth. **RDE** still talks to the production backend, so shared OAuth should behave like production.
> 
> OAuth-specific behavior now keys off **`isLocalEmulator`** instead of **`isDevelopmentEnvironment`**: persisted state normalization only strips OAuth in the emulator; the auth step shows full sign-in options in RDE; finalize applies **shared** environment OAuth config when not on the emulator (emulator keeps branch-level provider stubs).
> 
> Tests cover RDE preserving OAuth selections and the emulator still stripping them.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 492956fa4af8321f7a9ef7bcb369b615a16bd154. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Refined new project onboarding wizard to properly distinguish local emulator environments from other development setups, with appropriate sign-in method availability for each.
  * Enhanced sign-in method handling to ensure OAuth methods are available in standard development environments but optimized for local emulator configurations.
  * Added comprehensive test coverage for onboarding state normalization.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->