### PR TITLE
fix(sdk): bypass urls proxy in internal SDK methods for hosted components

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -375,7 +375,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         {
           provider,
           redirectUrl: this._getOAuthCallbackRedirectUri(),
-          errorRedirectUrl: this.urls.error,
+          errorRedirectUrl: this._getUrls().error,
           providerScope: mergeScopeStrings(scopeString, (this._oauthScopesOnSignIn[provider as ProviderType] ?? []).join(" ")),
         },
         session,
@@ -580,7 +580,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         {
           provider: options.providerId,
           redirectUrl: this._getOAuthCallbackRedirectUri(),
-          errorRedirectUrl: this.urls.error,
+          errorRedirectUrl: this._getUrls().error,
           providerScope: mergeScopeStrings(options.scope || "", (this._oauthScopesOnSignIn[options.providerId] ?? []).join(" ")),
         },
         options.session,
@@ -3148,13 +3148,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   async redirectToMfa(options?: RedirectToOptions) { return await this._redirectToHandler("mfa", options); }
 
   async sendForgotPasswordEmail(email: string, options?: { callbackUrl?: string }): Promise<Result<undefined, KnownErrors["UserNotFound"]>> {
-    return await this._interface.sendForgotPasswordEmail(email, options?.callbackUrl ?? constructRedirectUrl(this.urls.passwordReset, "callbackUrl"));
+    return await this._interface.sendForgotPasswordEmail(email, options?.callbackUrl ?? constructRedirectUrl(this._getUrls().passwordReset, "callbackUrl"));
   }
 
   async sendMagicLinkEmail(email: string, options?: {
     callbackUrl?: string,
   }): Promise<Result<{ nonce: string }, KnownErrors["RedirectUrlNotWhitelisted"] | KnownErrors["BotChallengeFailed"]>> {
-    const callbackUrl = options?.callbackUrl ?? constructRedirectUrl(this.urls.magicLinkCallback, "callbackUrl");
+    const callbackUrl = options?.callbackUrl ?? constructRedirectUrl(this._getUrls().magicLinkCallback, "callbackUrl");
     return await this._executeResultWithBotChallengeFlow({
       action: "send_magic_link_email",
       execute: async (challenge) => {
@@ -3447,7 +3447,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       return await this._interface.authorizeOAuth({
         provider,
         redirectUrl: constructRedirectUrl(this._getOAuthCallbackRedirectUri(), "redirectUrl"),
-        errorRedirectUrl: constructRedirectUrl(this.urls.error, "errorRedirectUrl"),
+        errorRedirectUrl: constructRedirectUrl(this._getUrls().error, "errorRedirectUrl"),
         afterCallbackRedirectUrl,
         type: "authenticate",
         providerScope: this._oauthScopesOnSignIn[provider]?.join(" "),
@@ -3567,7 +3567,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     }
     this._ensurePersistentTokenStore();
     const session = await this._getSession();
-    const emailVerificationRedirectUrl = options.noVerificationCallback ? undefined : options.verificationCallbackUrl ?? constructRedirectUrl(this.urls.emailVerification, "verificationCallbackUrl");
+    const emailVerificationRedirectUrl = options.noVerificationCallback ? undefined : options.verificationCallbackUrl ?? constructRedirectUrl(this._getUrls().emailVerification, "verificationCallbackUrl");
 
     const executeSignUp = async (challenge: { token?: string, phase?: "invisible" | "visible", unavailable?: true }) => {
       let result = await this._interface.signUpWithCredential(
@@ -3730,7 +3730,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
 
     // Step 2: Open the browser for the user to authenticate and display the verification code
     const url = buildCliAuthConfirmUrl({
-      cliAuthConfirmUrl: this.urls.cliAuthConfirm,
+      cliAuthConfirmUrl: this._getUrls().cliAuthConfirm,
       appUrl: options.appUrl,
       loginCode,
     });


### PR DESCRIPTION
## Summary

ec0008d5 added a `createUrlsForPublicAccess` proxy on `this.urls` that throws when accessing hosted handler URLs, and converted `app.urls.*` → `app._getUrls().*` in several internal methods — but missed all the `this.urls.*` call sites.

This caused `signUpWithCredential` (and several other methods) to throw when the app uses hosted components, because `this.urls.emailVerification` hits the proxy.

Fix: `this.urls.<prop>` → `this._getUrls().<prop>` in all internal SDK methods that were missed.

Link to Devin session: https://app.devin.ai/sessions/a9aab8dd4505412a8eb4121076865126
Requested by: @Developing-Gamer

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Bypass the `createUrlsForPublicAccess` proxy in internal SDK methods by using `_getUrls()` for hosted handler URLs. This prevents runtime errors in hosted flows like sign-up, OAuth, password reset, magic link, and CLI auth.

- **Bug Fixes**
  - Replaced internal `this.urls.*` calls with `this._getUrls().*` in `client-app-impl`.
  - Restores hosted flows: sign up with credential, OAuth authorize, forgot password, magic link, CLI auth.

<sup>Written for commit de08c1c6e084446c07c5c6277c78819d09e24e88. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1641?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved internal URL handling in authentication flows to ensure consistent and reliable redirect behavior across OAuth, sign-in, password reset, and verification processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->