### PR TITLE
claude-email-send-feature-support

### DIFF
--- a/.codex/hooks.json
+++ b/.codex/hooks.json
@@ -1,0 +1,25 @@
+{
+  "hooks": {
+    "PostToolUse": [
+      {
+        "matcher": "Edit|MultiEdit|Write",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "jq -r '.tool_input.file_path' | { read file_path; if [[ \"$file_path\" =~ \\.(js|jsx|ts|tsx)$ ]]; then cd \"$(dirname \"$file_path\")\" && pnpm run lint --fix \"$file_path\" || true; fi }"
+          }
+        ]
+      }
+    ],
+    "Stop": [
+      {
+        "hooks": [
+          {
+            "type": "command",
+            "command": "if jq -e '.stop_hook_active == true' >/dev/null 2>&1; then exit 0; fi && (pnpm run typecheck 1>&2 || exit 2) && (pnpm run lint 1>&2 || exit 2)"
+          }
+        ]
+      }
+    ]
+  }
+}


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `.codex` hooks to auto-fix lint on JS/TS edits and block completion if typecheck or lint fails. Improves code quality by running checks automatically.

- **New Features**
  - Post-edit: Use `jq` to read `file_path`; if `.js|.jsx|.ts|.tsx`, run `pnpm run lint --fix` in the file’s directory.
  - Stop: Run `pnpm run typecheck` and `pnpm run lint`; exit with error on failure. Skippable when `stop_hook_active` is true.

<sup>Written for commit 3237e68357d49da74190873efdb2fedaa73745cf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1642?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

