### PR TITLE
feat: devtool indicator - rename Quick Sign In → Quick Sign Up, remove email input

### DIFF
--- a/packages/template/src/dev-tool/dev-tool-core.ts
+++ b/packages/template/src/dev-tool/dev-tool-core.ts
@@ -635,11 +635,6 @@ function createOverviewTab(app: StackClientApp<true>): TabResult {
 
   const actions = h('div', { className: 'sdt-ov-actions' });
   const toast = h('div', { className: 'sdt-ov-toast', style: { display: 'none' } });
-  const emailRow = h('div', { className: 'sdt-ov-email-input' });
-  const emailInput = h('input', { type: 'email', placeholder: 'Sign in as email\u2026' }) as HTMLInputElement;
-  const emailBtn = h('button', null);
-  setHtml(emailBtn, '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><line x1="5" y1="12" x2="19" y2="12"/><polyline points="12 5 19 12 12 19"/></svg>');
-  emailRow.append(emailInput, emailBtn);
 
   function isBestEffortOverviewError(error: unknown) {
     if (error instanceof DOMException && error.name === 'AbortError') {
@@ -701,15 +696,14 @@ function createOverviewTab(app: StackClientApp<true>): TabResult {
       });
       actions.append(signOutBtn, randomBtn);
     } else {
-      const quickBtn = h('button', { className: 'sdt-ov-btn sdt-ov-btn-primary sdt-ov-btn-wide' }, loading ? 'Working\u2026' : 'Quick Sign In');
+      const quickBtn = h('button', { className: 'sdt-ov-btn sdt-ov-btn-primary sdt-ov-btn-wide' }, loading ? 'Working\u2026' : 'Quick Sign Up');
       quickBtn.disabled = loading;
       quickBtn.addEventListener('click', () => {
         runAsynchronously(doQuickSignIn());
       });
       actions.appendChild(quickBtn);
     }
-    emailInput.placeholder = currentUser ? 'Switch to email\u2026' : 'Sign in as email\u2026';
-    actions.appendChild(emailRow);
+
   }
 
   async function doQuickSignIn() {
@@ -740,54 +734,6 @@ function createOverviewTab(app: StackClientApp<true>): TabResult {
     loading = false;
     await refreshUser();
   }
-
-  async function doSignInAs(targetEmail: string) {
-    if (!targetEmail.trim()) return;
-    if (!isLocalhost(window.location.href)) {
-      showToast('Quick sign-in is only available on localhost', 'error');
-      return;
-    }
-    loading = true;
-    rebuildActions();
-    const trimmed = targetEmail.trim();
-    try {
-      const signInResult = await app.signInWithCredential({ email: trimmed, password: trimmed, noRedirect: true });
-      if (signInResult.status === 'ok') {
-        showToast(`Signed in as ${trimmed}`, 'success');
-        emailInput.value = '';
-        loading = false;
-        await refreshUser();
-        return;
-      }
-      const signUpResult = await app.signUpWithCredential({ email: trimmed, password: trimmed, noRedirect: true } as any);
-      if (signUpResult.status === 'error') {
-        showToast(`Failed: ${signUpResult.error.message}`, 'error');
-        loading = false;
-        rebuildActions();
-        return;
-      }
-      const retryResult = await app.signInWithCredential({ email: trimmed, password: trimmed, noRedirect: true });
-      if (retryResult.status === 'error') {
-        showToast(`Sign in failed: ${retryResult.error.message}`, 'error');
-      } else {
-        showToast(`Signed in as ${trimmed}`, 'success');
-        emailInput.value = '';
-      }
-    } catch (e: any) {
-      showToast(e.message || 'Unknown error', 'error');
-    }
-    loading = false;
-    await refreshUser();
-  }
-
-  emailBtn.addEventListener('click', () => {
-    runAsynchronously(doSignInAs(emailInput.value));
-  });
-  emailInput.addEventListener('keydown', (e) => {
-    if (e.key === 'Enter') {
-      runAsynchronously(doSignInAs(emailInput.value));
-    }
-  });
 
   heroCard.append(actions, toast);
 
@@ -852,7 +798,7 @@ function createOverviewTab(app: StackClientApp<true>): TabResult {
   function buildChecklist() {
     checksCard.innerHTML = '';
     const currentUserCheck = hasPersistentTokenStore
-      ? { ok: !!currentUser, label: 'Sign in a test user', hint: 'Use \u201cQuick Sign In\u201d above \u2192' }
+      ? { ok: !!currentUser, label: 'Sign in a test user', hint: 'Use \u201cQuick Sign Up\u201d above \u2192' }
       : { ok: true, label: 'Current-user tools unavailable', hint: null };
     const checks = [
       { ok: !!projectId && projectId !== 'default', label: 'Project configured', hint: null },
@@ -922,7 +868,7 @@ function createOverviewTab(app: StackClientApp<true>): TabResult {
         } else {
           avatar.textContent = initials;
         }
-        userName.textContent = currentUser.displayName || 'Anonymous';
+        userName.textContent = currentUser.displayName || '(No display name)';
         userEmail.textContent = currentUser.primaryEmail || 'No email';
         authIndicator.style.display = '';
       } else {


### PR DESCRIPTION
## Summary

- Renames "Quick Sign In" button to "Quick Sign Up" (since it creates a new random user)
- Removes the "Sign in with email" input row from the identity card actions
- Fixes misleading "Anonymous" fallback for users without a display name → now shows "(No display name)"


Link to Devin session: https://app.devin.ai/sessions/4b40977e9e0641e69a8c2cc5fcae3a7f
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Renamed the devtool action from "Quick Sign In" to "Quick Sign Up" to reflect that it creates a new random user, and removed the email sign-in input row. Also updated the user name fallback to show "(No display name)" when no display name is set.

<sup>Written for commit be38453547ee0d1f801be7828cf3d190dfd8c843. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1643?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes are limited to dev-tool UI in `dev-tool-core.ts`; auth APIs are unchanged and quick/random flows still use existing localhost-guarded credential helpers.
> 
> **Overview**
> The dev tool **Overview** identity card is simplified for local testing: the **Quick Sign In** primary action is renamed to **Quick Sign Up** (still driven by random credential sign-up via `doQuickSignIn`), and the **email + submit** row plus **`doSignInAs`** (sign-in or sign-up with a chosen email/password on localhost) are removed entirely.
> 
> Copy that pointed at the old flow is updated—the setup checklist hint now references **Quick Sign Up**—and signed-in users without a `displayName` show **(No display name)** instead of **Anonymous**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit be38453547ee0d1f801be7828cf3d190dfd8c843. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Streamlined the Dev Tool's authentication interface by removing manual email input for sign-in.
  * Renamed "Quick Sign In" to "Quick Sign Up" in the setup checklist for clarity.
  * Improved fallback text for users without a display name.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->