### PR TITLE
fix: suppress React 19 script warning in SsrScript

### DIFF
--- a/packages/template/src/components/elements/ssr-layout-effect.tsx
+++ b/packages/template/src/components/elements/ssr-layout-effect.tsx
@@ -15,19 +15,16 @@ export function SsrScript(props: { script: string, nonce?: string }) {
 
   // Embed the <script> in a span's innerHTML rather than as a React <script> JSX element to
   // avoid React 19's "Scripts inside React components are never executed when rendering on the
-  // client" warning. The browser still executes the script during SSR HTML parsing.
-  // suppressHydrationWarning hides the SSR-vs-client innerHTML difference (server has the
-  // script tag, client has empty string).
-  const isServer = typeof window === 'undefined';
+  // client" warning. The browser still executes the script during SSR HTML parsing, and on the
+  // client React sets innerHTML but the browser won't re-execute the script (innerHTML scripts
+  // don't run). Using the same HTML on both sides avoids hydration mismatches.
   const nonceAttr = props.nonce ? ` nonce="${escapeHtmlAttr(props.nonce)}"` : '';
 
   return (
     <span
-      suppressHydrationWarning
+      suppressHydrationWarning  // the transpiler is setup differently for client/server targets, so if `script` was generated with Function.toString they will differ
       dangerouslySetInnerHTML={{
-        __html: isServer
-          ? `<script${nonceAttr}>${props.script}</script>`
-          : '',
+        __html: `<script${nonceAttr}>${props.script}</script>`,
       }}
     />
   );

--- a/packages/template/src/components/elements/ssr-layout-effect.tsx
+++ b/packages/template/src/components/elements/ssr-layout-effect.tsx
@@ -9,6 +9,15 @@ export function SsrScript(props: { script: string, nonce?: string }) {
     (0, eval)(props.script);
   }, []);
 
+  // Only render the <script> tag during SSR — the browser executes it immediately when parsing
+  // the server HTML. On the client, useLayoutEffect handles execution instead. React 19 warns
+  // about <script> tags rendered on the client ("Scripts inside React components are never
+  // executed when rendering on the client"), and hydration skips <script> tags so omitting it
+  // here doesn't cause a mismatch.
+  if (typeof window !== 'undefined') {
+    return null;
+  }
+
   return (
     <script
       suppressHydrationWarning  // the transpiler is setup differently for client/server targets, so if `script` was generated with Function.toString they will differ

--- a/packages/template/src/components/elements/ssr-layout-effect.tsx
+++ b/packages/template/src/components/elements/ssr-layout-effect.tsx
@@ -1,6 +1,10 @@
 "use client";
 import { useLayoutEffect } from "react";
 
+function escapeHtmlAttr(str: string): string {
+  return str.replace(/&/g, '&amp;').replace(/"/g, '&quot;').replace(/</g, '&lt;').replace(/>/g, '&gt;');
+}
+
 export function SsrScript(props: { script: string, nonce?: string }) {
   useLayoutEffect(() => {
     // TODO fix workaround: React has a bug where it doesn't run the script on the first CSR render if SSR has been skipped due to suspense
@@ -15,7 +19,7 @@ export function SsrScript(props: { script: string, nonce?: string }) {
   // suppressHydrationWarning hides the SSR-vs-client innerHTML difference (server has the
   // script tag, client has empty string).
   const isServer = typeof window === 'undefined';
-  const nonceAttr = props.nonce ? ` nonce="${props.nonce}"` : '';
+  const nonceAttr = props.nonce ? ` nonce="${escapeHtmlAttr(props.nonce)}"` : '';
 
   return (
     <span

--- a/packages/template/src/components/elements/ssr-layout-effect.tsx
+++ b/packages/template/src/components/elements/ssr-layout-effect.tsx
@@ -9,20 +9,22 @@ export function SsrScript(props: { script: string, nonce?: string }) {
     (0, eval)(props.script);
   }, []);
 
-  // Only render the <script> tag during SSR — the browser executes it immediately when parsing
-  // the server HTML. On the client, useLayoutEffect handles execution instead. React 19 warns
-  // about <script> tags rendered on the client ("Scripts inside React components are never
-  // executed when rendering on the client"), and hydration skips <script> tags so omitting it
-  // here doesn't cause a mismatch.
-  if (typeof window !== 'undefined') {
-    return null;
-  }
+  // Embed the <script> in a span's innerHTML rather than as a React <script> JSX element to
+  // avoid React 19's "Scripts inside React components are never executed when rendering on the
+  // client" warning. The browser still executes the script during SSR HTML parsing.
+  // suppressHydrationWarning hides the SSR-vs-client innerHTML difference (server has the
+  // script tag, client has empty string).
+  const isServer = typeof window === 'undefined';
+  const nonceAttr = props.nonce ? ` nonce="${props.nonce}"` : '';
 
   return (
-    <script
-      suppressHydrationWarning  // the transpiler is setup differently for client/server targets, so if `script` was generated with Function.toString they will differ
-      nonce={props.nonce}
-      dangerouslySetInnerHTML={{ __html: props.script }}
+    <span
+      suppressHydrationWarning
+      dangerouslySetInnerHTML={{
+        __html: isServer
+          ? `<script${nonceAttr}>${props.script}</script>`
+          : '',
+      }}
     />
   );
 }


### PR DESCRIPTION
## Summary

`SsrScript` renders a `<script dangerouslySetInnerHTML>` that triggers the React 19 warning "Scripts inside React components are never executed when rendering on the client." The `<script>` tag is only needed during SSR (browser executes it on HTML parse); on the client, `useLayoutEffect` + `eval` already handles execution.

Added `if (typeof window !== 'undefined') return null` before the `<script>` return. React 19 hydration skips `<script>` elements, so omitting it on the client doesn't cause a mismatch.

Link to Devin session: https://app.devin.ai/sessions/5dd8d90d13e04465b3d7c9aeee7aa307
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the React 19 warning by rendering the `<script>` inside a `<span>`’s innerHTML in `SsrScript`, using the same HTML on server and client. Client execution stays in `useLayoutEffect`, and the `nonce` is escaped.

- **Bug Fixes**
  - Render script via `<span dangerouslySetInnerHTML>` so the browser runs it during SSR parse while React never processes a `<script>` node.
  - Use the same innerHTML on SSR and CSR to avoid hydration mismatches; innerHTML scripts don’t re-run on the client.
  - Escape the `nonce` attribute and keep `suppressHydrationWarning` as a safeguard.

<sup>Written for commit ebc90d633a6c820e06d91c6f5b4fdf4b660d44c9. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1648?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-component rendering change with nonce escaping; client script execution still uses the existing eval workaround.
> 
> **Overview**
> **`SsrScript`** no longer renders a React **`<script>`** node. It wraps the tag in a **`<span dangerouslySetInnerHTML>`** whose HTML is `` `<script${nonceAttr}>${props.script}</script>` `` so React 19 does not emit the client-side script warning, while SSR HTML parsing can still run the script.
> 
> A new **`escapeHtmlAttr`** helper escapes the optional **`nonce`** when it is embedded in that attribute string. **`suppressHydrationWarning`** and the existing **`useLayoutEffect` + indirect `eval`** path for client execution are unchanged; the comment documents that innerHTML scripts do not re-run on the client, so the same markup on server and client avoids hydration mismatches.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ebc90d633a6c820e06d91c6f5b4fdf4b660d44c9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed React 19 compatibility warning for server-side rendered scripts and prevented hydration issues while maintaining existing client-side script execution behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->