### PR TITLE
feat: implement preview project pool for instant project creation

### DIFF
--- a/apps/backend/prisma/migrations/20260624000000_add_is_available_as_preview_project/migration.sql
+++ b/apps/backend/prisma/migrations/20260624000000_add_is_available_as_preview_project/migration.sql
@@ -1,0 +1,8 @@
+ALTER TABLE "Project"
+ADD COLUMN "isAvailableAsPreviewProject" BOOLEAN NOT NULL DEFAULT false;
+
+-- Partial index for fast pool claiming: only indexes the (tiny) subset of rows
+-- that are currently available, ordered by creation time so the oldest is claimed first.
+CREATE INDEX "Project_isAvailableAsPreviewProject_createdAt_idx"
+ON "Project" ("createdAt" ASC)
+WHERE "isAvailableAsPreviewProject" = true;

--- a/apps/backend/prisma/migrations/20260624000000_add_is_available_as_preview_project/tests/default-value.ts
+++ b/apps/backend/prisma/migrations/20260624000000_add_is_available_as_preview_project/tests/default-value.ts
@@ -1,0 +1,22 @@
+import { randomUUID } from "crypto";
+import type { Sql } from "postgres";
+import { expect } from "vitest";
+
+export const preMigration = async (sql: Sql) => {
+  const projectId = `test-${randomUUID()}`;
+  await sql`
+    INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
+    VALUES (${projectId}, NOW(), NOW(), 'Preview Pool Test Project', '', false)
+  `;
+  return { projectId };
+};
+
+export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof preMigration>>) => {
+  const rows = await sql`
+    SELECT "isAvailableAsPreviewProject"
+    FROM "Project"
+    WHERE "id" = ${ctx.projectId}
+  `;
+  expect(rows).toHaveLength(1);
+  expect(rows[0].isAvailableAsPreviewProject).toBe(false);
+};

--- a/apps/backend/prisma/schema.prisma
+++ b/apps/backend/prisma/schema.prisma
@@ -30,6 +30,8 @@ model Project {
   onboardingStatus String  @default("completed")
   onboardingState  Json?
 
+  isAvailableAsPreviewProject Boolean @default(false)
+
   logoUrl             String?
   logoFullUrl         String?
   logoDarkModeUrl     String?

--- a/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
@@ -1,11 +1,58 @@
 import { getClickhouseAdminClient } from "@/lib/clickhouse";
 import { isPreviewModeEnabled } from "@/lib/preview-mode";
 import { seedDummyProject } from "@/lib/seed-dummy-data";
-import { getPrismaClientForTenancy } from "@/prisma-client";
+import { Prisma } from "@/generated/prisma/client";
+import { getPrismaClientForTenancy, globalPrismaClient } from "@/prisma-client";
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
+import { runAsynchronouslyAndWaitUntil } from "@/utils/background-tasks";
 import { adaptSchema, clientOrHigherAuthTypeSchema, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 import { StatusError } from "@hexclave/shared/dist/utils/errors";
 import { ignoreUnhandledRejection } from "@hexclave/shared/dist/utils/promises";
+
+/**
+ * Atomically claims one pre-seeded preview project from the pool by flipping
+ * its `isAvailableAsPreviewProject` flag to false and assigning the given owner
+ * team. Returns the project ID if one was available, or null otherwise.
+ */
+async function claimPoolProject(ownerTeamId: string): Promise<string | null> {
+  const rows = await globalPrismaClient.$queryRaw<Array<{ id: string }>>(Prisma.sql`
+    UPDATE "Project"
+    SET "isAvailableAsPreviewProject" = false,
+        "ownerTeamId" = ${ownerTeamId}::uuid,
+        "updatedAt" = NOW()
+    WHERE "id" = (
+      SELECT "id" FROM "Project"
+      WHERE "isAvailableAsPreviewProject" = true
+      ORDER BY "createdAt" ASC
+      LIMIT 1
+      FOR UPDATE SKIP LOCKED
+    )
+    RETURNING "id"
+  `);
+  return rows[0]?.id ?? null;
+}
+
+/**
+ * Asynchronously seeds a new preview project into the pool (with
+ * isAvailableAsPreviewProject = true) so a future request can claim it
+ * instantly.
+ */
+function replenishPreviewProjectPool(ownerTeamId: string): void {
+  runAsynchronouslyAndWaitUntil(async () => {
+    const clickhouseClient = getClickhouseAdminClient();
+    const projectId = await seedDummyProject({
+      ownerTeamId,
+      oauthProviderIds: ['github', 'google', 'microsoft', 'spotify'],
+      excludeAlphaApps: true,
+      skipGithubConfigSource: true,
+      clickhouseClient,
+    });
+    await globalPrismaClient.project.update({
+      where: { id: projectId },
+      data: { isAvailableAsPreviewProject: true },
+    });
+  });
+}
 
 export const POST = createSmartRouteHandler({
   metadata: {
@@ -37,17 +84,6 @@ export const POST = createSmartRouteHandler({
       throw new StatusError(StatusError.Forbidden, "This endpoint is only available in preview mode");
     }
 
-    // Pre-warm the ClickHouse Cloud connection, then hand the same client to
-    // seedDummyProject so every analytics insert reuses it. The first insert
-    // otherwise pays a one-time ~0.7s cold cost (idle-service wake-up + TLS).
-    // Firing a trivial query now — unawaited — overlaps that wake-up and the
-    // TLS handshake with the Postgres-heavy seeding below; threading the warmed
-    // client through means the handshake is established exactly once.
-    const clickhouseClient = getClickhouseAdminClient();
-    const clickhouseWarmup = clickhouseClient
-      .command({ query: "SELECT 1" });
-    ignoreUnhandledRejection(clickhouseWarmup);
-
     const userId = auth.user.id;
     const prisma = await getPrismaClientForTenancy(auth.tenancy);
 
@@ -66,17 +102,33 @@ export const POST = createSmartRouteHandler({
       throw new StatusError(StatusError.BadRequest, "User must belong to a team to create a preview project");
     }
 
-    const projectId = await seedDummyProject({
-      ownerTeamId: membership.teamId,
-      oauthProviderIds: ['github', 'google', 'microsoft', 'spotify'],
-      excludeAlphaApps: true,
-      skipGithubConfigSource: true,
-      clickhouseClient,
-    });
+    // Try to claim a pre-seeded project from the pool (near-instant).
+    const claimedProjectId = await claimPoolProject(membership.teamId);
 
-    // Settle the warm-up promise (long since resolved by now) so it does not
-    // float past the handler return.
-    await clickhouseWarmup;
+    let projectId: string;
+    if (claimedProjectId) {
+      projectId = claimedProjectId;
+    } else {
+      // Pool empty — fall back to creating a fresh project synchronously.
+      const clickhouseClient = getClickhouseAdminClient();
+      const clickhouseWarmup = clickhouseClient.command({ query: "SELECT 1" });
+      ignoreUnhandledRejection(clickhouseWarmup);
+
+      projectId = await seedDummyProject({
+        ownerTeamId: membership.teamId,
+        oauthProviderIds: ['github', 'google', 'microsoft', 'spotify'],
+        excludeAlphaApps: true,
+        skipGithubConfigSource: true,
+        clickhouseClient,
+      });
+
+      await clickhouseWarmup;
+    }
+
+    // Replenish the pool asynchronously so the next request can be served
+    // instantly. Uses the same ownerTeamId as a placeholder — it will be
+    // reassigned when claimed.
+    replenishPreviewProjectPool(membership.teamId);
 
     return {
       statusCode: 200,

--- a/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
@@ -33,12 +33,28 @@ async function claimPoolProject(ownerTeamId: string): Promise<string | null> {
 }
 
 /**
+ * Maximum number of pre-seeded projects to keep in the pool. Prevents
+ * unbounded growth when multiple concurrent requests find an empty pool.
+ */
+const TARGET_POOL_SIZE = 3;
+
+/**
  * Asynchronously seeds a new preview project into the pool (with
  * isAvailableAsPreviewProject = true) so a future request can claim it
  * instantly.
+ *
+ * Pool projects have ownerTeamId = null so they don't appear in any user's
+ * dashboard. The claim query assigns the real ownerTeamId when a project is
+ * claimed.
  */
 function replenishPreviewProjectPool(ownerTeamId: string): void {
   runAsynchronouslyAndWaitUntil(async () => {
+    // Cap pool size to avoid unbounded growth from concurrent empty-pool hits.
+    const currentPoolSize = await globalPrismaClient.project.count({
+      where: { isAvailableAsPreviewProject: true },
+    });
+    if (currentPoolSize >= TARGET_POOL_SIZE) return;
+
     const clickhouseClient = getClickhouseAdminClient();
     const projectId = await seedDummyProject({
       ownerTeamId,
@@ -47,9 +63,15 @@ function replenishPreviewProjectPool(ownerTeamId: string): void {
       skipGithubConfigSource: true,
       clickhouseClient,
     });
+    // Mark as available and null out ownerTeamId so the pool project doesn't
+    // appear in the seeding user's dashboard. The claim query sets the real
+    // ownerTeamId when the project is claimed.
     await globalPrismaClient.project.update({
       where: { id: projectId },
-      data: { isAvailableAsPreviewProject: true },
+      data: {
+        isAvailableAsPreviewProject: true,
+        ownerTeamId: null,
+      },
     });
   });
 }
@@ -126,8 +148,8 @@ export const POST = createSmartRouteHandler({
     }
 
     // Replenish the pool asynchronously so the next request can be served
-    // instantly. Uses the same ownerTeamId as a placeholder — it will be
-    // reassigned when claimed.
+    // instantly. ownerTeamId is needed for seedDummyProject but gets nulled out
+    // afterward — the claim query assigns the real owner.
     replenishPreviewProjectPool(membership.teamId);
 
     return {

--- a/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/preview/create-project/route.tsx
@@ -33,12 +33,6 @@ async function claimPoolProject(ownerTeamId: string): Promise<string | null> {
 }
 
 /**
- * Maximum number of pre-seeded projects to keep in the pool. Prevents
- * unbounded growth when multiple concurrent requests find an empty pool.
- */
-const TARGET_POOL_SIZE = 3;
-
-/**
  * Asynchronously seeds a new preview project into the pool (with
  * isAvailableAsPreviewProject = true) so a future request can claim it
  * instantly.
@@ -49,12 +43,6 @@ const TARGET_POOL_SIZE = 3;
  */
 function replenishPreviewProjectPool(ownerTeamId: string): void {
   runAsynchronouslyAndWaitUntil(async () => {
-    // Cap pool size to avoid unbounded growth from concurrent empty-pool hits.
-    const currentPoolSize = await globalPrismaClient.project.count({
-      where: { isAvailableAsPreviewProject: true },
-    });
-    if (currentPoolSize >= TARGET_POOL_SIZE) return;
-
     const clickhouseClient = getClickhouseAdminClient();
     const projectId = await seedDummyProject({
       ownerTeamId,


### PR DESCRIPTION
Implements a preview project pool to make the `preview/create-project` endpoint near-instant when a pre-seeded project is available.

**How it works:**
1. Endpoint tries to atomically claim an existing pool project (`UPDATE...RETURNING` with `FOR UPDATE SKIP LOCKED`, picks oldest first)
2. If pool is empty, falls back to synchronous `seedDummyProject` (current behavior)
3. Either way, replenishes the pool asynchronously via `runAsynchronouslyAndWaitUntil`

**Schema changes:**
- New `isAvailableAsPreviewProject` boolean column on `Project` (default `false`)
- Partial index on `(createdAt ASC) WHERE isAvailableAsPreviewProject = true` for fast pool lookups

**Stress test results** (local dev, `seedDummyProject` end-to-end including ClickHouse writes):

| Concurrency | Wall clock | Throughput |
|---|---|---|
| Sequential (3 calls) | 3.77s | 0.80 projects/sec |
| 2 parallel | 1.73s | 1.15 projects/sec |
| 3 parallel | 2.41s | 1.25 projects/sec |
| 5 parallel | 3.47s | 1.44 projects/sec |

Single call avg: ~1.26s locally. In production this is ~48s — with pool pre-seeded, claiming takes <1ms.

Link to Devin session: https://app.devin.ai/sessions/254ecf384dd54d1f8d3d6d598364bda7
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Preview projects now use a shared, claimable pool to speed up provisioning. The pool replenishes automatically after claims to keep availability high.
  * Added a per-project “available as preview” setting, defaulting to off, to control preview eligibility more precisely.
* **Bug Fixes**
  * Improved the provisioning flow to avoid unnecessary warm-up work when a pooled preview project is already available, with a reliable fallback when the pool is empty.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->