### PR TITLE
perf: prefetch email theme previews during earlier onboarding steps

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.test.tsx
@@ -234,6 +234,7 @@ describe("ProjectOnboardingWizard", () => {
       throw new Error("Stripe account info should not load on the app selection step.");
     });
     const listEmailThemes = vi.fn(async () => []);
+    const getEmailPreview = vi.fn(async () => "");
     const getStripeAccountInfo = vi.fn(async () => null);
 
     render(
@@ -265,6 +266,7 @@ describe("ProjectOnboardingWizard", () => {
           app: {
             setupPayments: vi.fn(async () => ({ url: "https://example.com" })),
             listEmailThemes,
+            getEmailPreview,
             getStripeAccountInfo,
             useEmailThemes,
             useStripeAccountInfo,
@@ -280,6 +282,7 @@ describe("ProjectOnboardingWizard", () => {
     );
 
     expect(listEmailThemes).toHaveBeenCalledOnce();
+    expect(getEmailPreview).not.toHaveBeenCalled();
     expect(getStripeAccountInfo).not.toHaveBeenCalled();
     expect(useEmailThemes).not.toHaveBeenCalled();
     expect(useStripeAccountInfo).not.toHaveBeenCalled();

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -33,6 +33,7 @@ import {
 import { AuthPage, type AdminOwnedProject } from "@hexclave/next";
 import { type AppId } from "@hexclave/shared/dist/apps/apps-config";
 import { type EnvironmentConfigOverrideOverride } from "@hexclave/shared/dist/config/schema";
+import { previewTemplateSource } from "@hexclave/shared/dist/helpers/emails";
 import { runAsynchronously, runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
 import { Suspense, useCallback, useEffect, useMemo, useRef, useState } from "react";
 
@@ -187,7 +188,10 @@ export function ProjectOnboardingWizard(props: {
     }
 
     runAsynchronously(async () => {
-      await project.app.listEmailThemes();
+      const themes = await project.app.listEmailThemes();
+      await Promise.all(themes.map((theme) =>
+        project.app.getEmailPreview({ themeId: theme.id, templateTsxSource: previewTemplateSource })
+      ));
     }, { noErrorLogging: true });
   }, [isLinkExistingMode, project.app, status]);
 

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -189,7 +189,7 @@ export function ProjectOnboardingWizard(props: {
 
     runAsynchronously(async () => {
       const themes = await project.app.listEmailThemes();
-      await Promise.all(themes.map((theme) =>
+      await Promise.allSettled(themes.map((theme) =>
         project.app.getEmailPreview({ themeId: theme.id, templateTsxSource: previewTemplateSource })
       ));
     }, { noErrorLogging: true });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
@@ -828,7 +828,8 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
   }
 
   async getEmailPreview(options: { themeId?: string | null | false, themeTsxSource?: string, templateId?: string, templateTsxSource?: string }): Promise<string> {
-    return (await this._interface.renderEmailPreview(options)).html;
+    const result = Result.orThrow(await this._emailPreviewCache.getOrWait([options.themeId, options.themeTsxSource, options.templateId, options.templateTsxSource], "write-only"));
+    return result.html;
   }
   // IF_PLATFORM react-like
   useEmailPreview(options: { themeId?: string | null | false, themeTsxSource?: string, templateId?: string, templateTsxSource?: string }): string {


### PR DESCRIPTION
## Summary

The "Select an email theme" onboarding step was slow because `useEmailPreview` had to render each theme's preview HTML on-demand when the step mounted. Two changes fix this:

1. `getEmailPreview()` now uses `_emailPreviewCache` (the same cache backing `useEmailPreview`) instead of calling `renderEmailPreview` directly — so calling the async method warms the hook's cache.

2. The existing prefetch effect (fires during `apps_selection`/`auth_setup`) now also calls `getEmailPreview` for each theme after fetching the list, so all preview HTML is cached by the time the user reaches the email theme step.

Link to Devin session: https://app.devin.ai/sessions/98763c749c59485ea4c80a07093f8bc1
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prefetch and cache email theme preview HTML earlier in onboarding to remove the delay on the “Select an email theme” step. `getEmailPreview` now uses the shared `_emailPreviewCache`, so `useEmailPreview` is warm when the step mounts.

- **Refactors**
  - In `ProjectOnboardingWizard`, during `apps_selection`/`auth_setup`, fetch themes and prefetch each preview using `previewTemplateSource`; run via `Promise.allSettled` for fire-and-forget.
  - In admin app impl, route `getEmailPreview` through `_emailPreviewCache` (via `getOrWait`) and return the cached `html`.
  - Test updated to assert no preview fetch when the theme list is empty.

<sup>Written for commit fec7d4925d75e34d0cf34768859c8ab965a3e696. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1655?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Email theme previews are now prefetched during project onboarding setup, reducing load times when accessing theme details.
  * Preview data is cached for better performance.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->