### PR TITLE
fix: handle show-onboarding sentinel in config update fast path

### DIFF
--- a/packages/shared-backend/src/index.test.ts
+++ b/packages/shared-backend/src/index.test.ts
@@ -78,6 +78,53 @@ describe("local config updater fast path", () => {
   });
 });
 
+describe("local config updater show-onboarding fast path", () => {
+  it("uses the fast path for show-onboarding sentinel (no agent invoked)", async () => {
+    const configPath = writeTempConfig(
+      'import type { HexclaveConfig } from "@hexclave/js/config";\n\nexport const config: HexclaveConfig = "show-onboarding";\n',
+    );
+    mockScriptedWrites = [{ tool_name: "Write", file_path: path.join(getTempDir(), "x.ts") }];
+
+    const { updateConfigObject, readConfigFile } = await import("./index");
+
+    await expect(
+      updateConfigObject(configPath, {
+        "apps.installed.authentication.enabled": true,
+        "apps.installed.emails.enabled": true,
+        "apps.installed.teams.enabled": true,
+        "apps.installed.analytics.enabled": false,
+        "auth.password.allowSignIn": true,
+        "auth.otp.allowSignIn": false,
+        "auth.passkey.allowSignIn": false,
+        "emails.selectedThemeId": "default",
+      }),
+    ).resolves.toBeUndefined();
+
+    // Agent was never called — the show-onboarding sentinel should be
+    // treated as {} on the fast path, just like readConfigFile does.
+    expect(mockHookDecisions).toEqual([]);
+
+    // The resulting config must be a proper nested object, not an array.
+    const { config } = await readConfigFile(configPath);
+    expect(config).toMatchObject({
+      apps: {
+        installed: {
+          authentication: { enabled: true },
+          emails: { enabled: true },
+          teams: { enabled: true },
+          analytics: { enabled: false },
+        },
+      },
+      auth: {
+        password: { allowSignIn: true },
+        otp: { allowSignIn: false },
+        passkey: { allowSignIn: false },
+      },
+      emails: { selectedThemeId: "default" },
+    });
+  });
+});
+
 describe("local config updater agent write boundary", () => {
   it("allows writes inside the config directory and captures them for rollback", async () => {
     const configPath = writeTempConfig(CUSTOM_CONFIG);

--- a/packages/shared-backend/src/index.test.ts
+++ b/packages/shared-backend/src/index.test.ts
@@ -78,8 +78,9 @@ describe("local config updater fast path", () => {
   });
 });
 
-describe("local config updater show-onboarding fast path", () => {
-  it("uses the fast path for show-onboarding sentinel (no agent invoked)", async () => {
+describe("onboarding wizard config update e2e", () => {
+  it("applies the full onboarding config to a show-onboarding sentinel file", async () => {
+    // Simulate the initial hexclave.config.ts created by `hexclave dev`
     const configPath = writeTempConfig(
       'import type { HexclaveConfig } from "@hexclave/js/config";\n\nexport const config: HexclaveConfig = "show-onboarding";\n',
     );
@@ -87,25 +88,30 @@ describe("local config updater show-onboarding fast path", () => {
 
     const { updateConfigObject, readConfigFile } = await import("./index");
 
-    await expect(
-      updateConfigObject(configPath, {
-        "apps.installed.authentication.enabled": true,
-        "apps.installed.emails.enabled": true,
-        "apps.installed.teams.enabled": true,
-        "apps.installed.analytics.enabled": false,
-        "auth.password.allowSignIn": true,
-        "auth.otp.allowSignIn": false,
-        "auth.passkey.allowSignIn": false,
-        "emails.selectedThemeId": "default",
-      }),
-    ).resolves.toBeUndefined();
+    // This is the same shape the onboarding wizard's buildBranchConfigUpdate()
+    // produces — dot-notation paths for apps, auth methods, and email theme.
+    const onboardingConfigUpdate = {
+      "apps.installed.authentication.enabled": true,
+      "apps.installed.emails.enabled": true,
+      "apps.installed.teams.enabled": true,
+      "apps.installed.analytics.enabled": false,
+      "auth.password.allowSignIn": true,
+      "auth.otp.allowSignIn": false,
+      "auth.passkey.allowSignIn": false,
+      "emails.selectedThemeId": "default",
+    };
 
-    // Agent was never called — the show-onboarding sentinel should be
-    // treated as {} on the fast path, just like readConfigFile does.
+    await updateConfigObject(configPath, onboardingConfigUpdate);
+
+    // 1. No agent should have been invoked — the sentinel is replaced with {}
+    //    and then the normal static-update path handles the rest.
     expect(mockHookDecisions).toEqual([]);
 
-    // The resulting config must be a proper nested object, not an array.
-    const { config } = await readConfigFile(configPath);
+    // 2. The on-disk file must be a valid config that can be loaded back.
+    const { config, showOnboarding } = await readConfigFile(configPath);
+    expect(showOnboarding).toBe(false);
+
+    // 3. `apps` must be a nested object, NOT an array of IDs.
     expect(config).toMatchObject({
       apps: {
         installed: {
@@ -122,6 +128,11 @@ describe("local config updater show-onboarding fast path", () => {
       },
       emails: { selectedThemeId: "default" },
     });
+
+    // 4. The file should contain a proper export (not the sentinel).
+    const fileContent = readFileSync(configPath, "utf-8");
+    expect(fileContent).toContain("export const config");
+    expect(fileContent).not.toContain("show-onboarding");
   });
 });
 

--- a/packages/shared-backend/src/index.ts
+++ b/packages/shared-backend/src/index.ts
@@ -128,6 +128,22 @@ export async function updateConfigObject(configFilePath: string, configUpdate: C
 
   if (flattenConfigUpdate(configUpdate).length === 0) return;
 
+  // The "show-onboarding" sentinel means "not yet configured" — semantically
+  // equivalent to an empty config.  Replace it with a real empty config file
+  // before applying the update so the normal static-update path can handle it
+  // (matching readConfigFile, which already treats the sentinel as {}).
+  try {
+    const rawParsed = parseHexclaveConfigFileContent(
+      readFileSync(configFilePath, "utf-8"),
+      configFilePath,
+    );
+    if (rawParsed === showOnboardingHexclaveConfigValue) {
+      renderConfigObjectToFile(configFilePath, {});
+    }
+  } catch {
+    // Not a statically parseable config — will be handled below.
+  }
+
   const content = readFileSync(configFilePath, "utf-8");
 
   // Fast path: if the config is a plain static literal (no imports, no helpers),
@@ -307,12 +323,6 @@ async function validateAgentUpdate(configFilePath: string, baselineConfig: Confi
 function tryParseStaticConfigFileContent(content: string, configFilePath: string): Config | null {
   try {
     const parsed = parseHexclaveConfigFileContent(content, configFilePath);
-    // The "show-onboarding" sentinel is a valid config file value but not a Config
-    // object. Treat it as an empty config — matching readConfigFile's behavior — so
-    // the fast path can apply updates without falling through to the AI agent.
-    if (parsed === showOnboardingHexclaveConfigValue) {
-      return {};
-    }
     return isValidConfig(parsed) ? parsed : null;
   } catch {
     return null;

--- a/packages/shared-backend/src/index.ts
+++ b/packages/shared-backend/src/index.ts
@@ -307,6 +307,12 @@ async function validateAgentUpdate(configFilePath: string, baselineConfig: Confi
 function tryParseStaticConfigFileContent(content: string, configFilePath: string): Config | null {
   try {
     const parsed = parseHexclaveConfigFileContent(content, configFilePath);
+    // The "show-onboarding" sentinel is a valid config file value but not a Config
+    // object. Treat it as an empty config — matching readConfigFile's behavior — so
+    // the fast path can apply updates without falling through to the AI agent.
+    if (parsed === showOnboardingHexclaveConfigValue) {
+      return {};
+    }
     return isValidConfig(parsed) ? parsed : null;
   } catch {
     return null;

--- a/packages/shared-backend/src/index.ts
+++ b/packages/shared-backend/src/index.ts
@@ -132,16 +132,18 @@ export async function updateConfigObject(configFilePath: string, configUpdate: C
   // equivalent to an empty config.  Replace it with a real empty config file
   // before applying the update so the normal static-update path can handle it
   // (matching readConfigFile, which already treats the sentinel as {}).
+  let parsedSentinel = false;
   try {
     const rawParsed = parseHexclaveConfigFileContent(
       readFileSync(configFilePath, "utf-8"),
       configFilePath,
     );
-    if (rawParsed === showOnboardingHexclaveConfigValue) {
-      renderConfigObjectToFile(configFilePath, {});
-    }
+    parsedSentinel = rawParsed === showOnboardingHexclaveConfigValue;
   } catch {
     // Not a statically parseable config — will be handled below.
+  }
+  if (parsedSentinel) {
+    renderConfigObjectToFile(configFilePath, {});
   }
 
   const content = readFileSync(configFilePath, "utf-8");


### PR DESCRIPTION
## Summary

`updateConfigObject` fell through to the AI agent path when the config file contained the `"show-onboarding"` sentinel. The agent produced a malformed config with `apps` as a flat array instead of the expected nested object, causing a 400 on sync.

Fix: at the top of `updateConfigObject`, detect the sentinel and replace the file with `{}` before the update runs. Write errors propagate (not swallowed by the parse catch).

E2e test verifies the full onboarding flow: sentinel file → config update → correct nested structure, no agent invoked.

Link to Devin session: https://app.devin.ai/sessions/2fadbc72087146629c4af84b817e6e81
Requested by: @N2D4

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive end-to-end test suite validating onboarding wizard configuration updates, including config file initialization, field structure validation, and proper state transitions

* **Improvements**
  * Enhanced configuration update system to properly detect and handle onboarding initialization states, ensuring smooth transition from onboarding mode to standard configuration format

<!-- end of auto-generated comment: release notes by coderabbit.ai -->