### PR TITLE
fix: add accessor functions to Users table columns for CSV export

### DIFF
--- a/apps/dashboard/src/components/data-table/user-table.tsx
+++ b/apps/dashboard/src/components/data-table/user-table.tsx
@@ -108,6 +108,7 @@ const USER_TABLE_COLUMNS: DataGridColumnDef<ExtendedServerUser>[] = [
     width: 180,
     flex: 1,
     sortable: false,
+    accessor: (row) => row.displayName ?? row.primaryEmail ?? "",
     renderCell: ({ row }) => <UserIdentityCell user={row} />,
   },
   {
@@ -116,6 +117,7 @@ const USER_TABLE_COLUMNS: DataGridColumnDef<ExtendedServerUser>[] = [
     width: 180,
     flex: 1,
     sortable: false,
+    accessor: (row) => row.primaryEmail ?? "",
     renderCell: ({ row }) => <UserEmailCell user={row} />,
   },
   {
@@ -123,6 +125,7 @@ const USER_TABLE_COLUMNS: DataGridColumnDef<ExtendedServerUser>[] = [
     header: "User ID",
     width: 130,
     sortable: false,
+    accessor: (row) => row.id,
     renderCell: ({ row }) => <UserIdCell user={row} />,
   },
   {
@@ -130,12 +133,15 @@ const USER_TABLE_COLUMNS: DataGridColumnDef<ExtendedServerUser>[] = [
     header: "Email Verified",
     width: 110,
     sortable: false,
+    accessor: (row) => row.primaryEmailVerified,
+    formatValue: (val) => val ? "Yes" : "No",
     renderCell: ({ row }) => <EmailStatusCell user={row} />,
   },
   {
     id: "lastActiveAt",
     header: "Last active",
     width: 110,
+    accessor: (row) => row.lastActiveAt,
     renderCell: ({ row }) => <DateMetaCell value={row.lastActiveAt} emptyLabel="Never" />,
   },
   {
@@ -144,12 +150,14 @@ const USER_TABLE_COLUMNS: DataGridColumnDef<ExtendedServerUser>[] = [
     width: 150,
     sortable: false,
     cellOverflow: "wrap",
+    accessor: (row) => row.authTypes.join(", "),
     renderCell: ({ row }) => <AuthMethodsCell user={row} />,
   },
   {
     id: "signedUpAt",
     header: "Signed up",
     width: 110,
+    accessor: (row) => row.signedUpAt,
     renderCell: ({ row }) => <DateMetaCell value={row.signedUpAt} emptyLabel="Unknown" />,
   },
   {


### PR DESCRIPTION
The DataGrid's built-in CSV export (`exportToCsv` in `state.ts`) calls `resolveColumnValue`, which falls back to using `col.id` as a property key when no `accessor` is provided. The Users table column IDs (`"user"`, `"email"`, `"userId"`, `"emailStatus"`, `"auth"`) don't match the actual `ExtendedServerUser` property names (`displayName`, `primaryEmail`, `id`, `primaryEmailVerified`, `authTypes`), so all values resolved to `undefined` → empty strings in the exported CSV.

Fix: add `accessor` functions to each column so `resolveColumnValue` extracts the correct data. Also adds `formatValue` for the email-verified column to produce human-readable "Yes"/"No" strings.

Link to Devin session: https://app.devin.ai/sessions/c4f35ef3c06744408824f7dc73c8076b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CSV export for the Users table by adding `accessor` functions that map columns to `ExtendedServerUser` fields, so exported values are no longer empty. Also adds `formatValue` for Email Verified to output "Yes"/"No".

<sup>Written for commit 0b52ef8731eb4953d770c437c9d16b9e38067add. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1657?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

