### PR TITLE
feat: add "View usage" button to analytics limit banner and rename Usage page

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
@@ -15,6 +15,7 @@ import {
   WarningCircleIcon
 } from "@phosphor-icons/react";
 import { Alert, AlertDescription, Button } from "@/components/ui";
+import { Link } from "@/components/link";
 import { useDashboardInternalUser } from "@/lib/dashboard-user";
 import { PLAN_LIMITS, resolvePlanId } from "@hexclave/shared/dist/plans";
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
@@ -340,7 +341,7 @@ export function AnalyticsEventLimitBanner() {
     return null;
   }
 
-  return <AnalyticsEventLimitBannerInner team={ownerTeam} />;
+  return <AnalyticsEventLimitBannerInner team={ownerTeam} projectId={project.id} />;
 }
 
 /**
@@ -395,7 +396,7 @@ function SessionReplayLimitBannerInner({ team }: { team: { useItem: (itemId: str
   );
 }
 
-function AnalyticsEventLimitBannerInner({ team }: { team: { useItem: (itemId: string) => { quantity: number }, useProducts: () => Array<{ id: string | null, type?: string }>, createCheckoutUrl: (options: { productId: string, returnUrl: string }) => Promise<string> } }) {
+function AnalyticsEventLimitBannerInner({ team, projectId }: { team: { useItem: (itemId: string) => { quantity: number }, useProducts: () => Array<{ id: string | null, type?: string }>, createCheckoutUrl: (options: { productId: string, returnUrl: string }) => Promise<string> }, projectId: string }) {
   const eventsItem = team.useItem("analytics_events");
   const products = team.useProducts();
   const planId = resolvePlanId(products);
@@ -433,15 +434,26 @@ function AnalyticsEventLimitBannerInner({ team }: { team: { useItem: (itemId: st
           }
           {canUpgrade && !isExhausted && " Consider upgrading your plan."}
         </span>
-        {canUpgrade && (
+        <div className="flex items-center gap-2 shrink-0">
           <Button
             size="sm"
-            variant={isExhausted ? "destructive" : "outline"}
-            onClick={handleUpgrade}
+            variant="outline"
+            asChild
           >
-            Upgrade plan
+            <Link href={`/projects/${projectId}/project-settings/usage`}>
+              View usage
+            </Link>
           </Button>
-        )}
+          {canUpgrade && (
+            <Button
+              size="sm"
+              variant={isExhausted ? "destructive" : "outline"}
+              onClick={handleUpgrade}
+            >
+              Upgrade plan
+            </Button>
+          )}
+        </div>
       </AlertDescription>
     </Alert>
   );

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/usage/page-client.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/usage/page-client.test.tsx
@@ -106,8 +106,8 @@ describe("Usage settings page", () => {
   it("renders the plan, usage rows, and overage state", () => {
     render(<PageClient />);
 
-    // The page title and usage card share this label.
-    expect(screen.getAllByText("Usage").length).toBeGreaterThan(0);
+    // The page title
+    expect(screen.getAllByText("Billing & Usage").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Free").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Owner").length).toBeGreaterThan(0);
     expect(screen.getAllByText("Dashboard admins").length).toBeGreaterThan(0);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/usage/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/project-settings/usage/page-client.tsx
@@ -362,7 +362,7 @@ export default function PageClient() {
 
   return (
     <PageLayout
-      title="Usage"
+      title="Billing & Usage"
       description={`Usage for ${planUsage.ownerTeamDisplayName} across all projects owned by this team.`}
       width={1050}
     >

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
@@ -139,7 +139,7 @@ const projectSettingsItem: AppSection = {
       match: (fullUrl: URL) => /^\/projects\/[^\/]+\/project-settings\/?$/.test(fullUrl.pathname),
     },
     {
-      name: "Usage",
+      name: "Billing & Usage",
       href: "/project-settings/usage",
       match: (fullUrl: URL) => /^\/projects\/[^\/]+\/project-settings\/usage(\/.*)?$/.test(fullUrl.pathname),
     },


### PR DESCRIPTION
## Summary

Adds a "View usage" button to the analytics event limit banner that links to `/project-settings/usage`. The button appears for all users (not just those who can upgrade). Also renames the "Usage" sidebar item and page title to "Billing & Usage".

Link to Devin session: https://app.devin.ai/sessions/e271cfe85a74483eb51e78723dae9fb0
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a “View usage” button to the analytics event limit banner that links to the project’s Billing & Usage page and is visible to all users. Renames the “Usage” page and sidebar item to “Billing & Usage”.

<sup>Written for commit 256ebaa4f81a0c233d9b3dd3272756391c769d1c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1660?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Dashboard copy and navigation only; no changes to billing, metering, or checkout behavior beyond existing upgrade flow.
> 
> **Overview**
> When analytics event usage hits the warning threshold, the limit banner now always shows a **View usage** control that routes to the project **Billing & Usage** page, including for teams on the highest plan where **Upgrade plan** is hidden. **Upgrade plan** stays available when an upgrade path exists, laid out beside the new link.
> 
> Project settings navigation and the usage page heading are renamed from **Usage** to **Billing & Usage**; the usage page test expectation is updated to match.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 256ebaa4f81a0c233d9b3dd3272756391c769d1c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a "View usage" button to the analytics event limit warning banner, providing quick access to usage details.

* **UI Improvements**
  * Renamed "Usage" to "Billing & Usage" in navigation and page title for improved clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->