### PR TITLE
fix: prevent OAuth callback race condition between startup handler and OAuthCallback component

### DIFF
--- a/packages/template/src/components-page/oauth-callback.test.tsx
+++ b/packages/template/src/components-page/oauth-callback.test.tsx
@@ -5,6 +5,7 @@ import React, { act } from "react";
 import { createRoot, type Root } from "react-dom/client";
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
 import type { StackClientApp } from "../lib/hexclave-app/apps/interfaces/client-app";
+import { hexclaveAppInternalsSymbol } from "../lib/hexclave-app/common";
 import { TranslationProviderClient } from "../providers/translation-provider-client";
 import { OAuthCallback } from "./oauth-callback";
 
@@ -40,6 +41,9 @@ function createAppTestDouble(options: {
     callOAuthCallback: options.callOAuthCallback,
     redirectToSignIn: vi.fn(async () => {}),
     redirectToHome: vi.fn(async () => {}),
+    [hexclaveAppInternalsSymbol]: {
+      awaitPendingAuthResolutions: vi.fn(async () => {}),
+    },
   };
 
   // This test double intentionally implements only the StackClientApp surface

--- a/packages/template/src/components-page/oauth-callback.tsx
+++ b/packages/template/src/components-page/oauth-callback.tsx
@@ -8,6 +8,7 @@ import { useEffect, useRef, useState } from "react";
 import { useStackApp } from "..";
 import { MaybeFullPage } from "../components/elements/maybe-full-page";
 import { StyledLink } from "../components/link";
+import { hexclaveAppInternalsSymbol } from "../lib/hexclave-app/common";
 import { useTranslation } from "../lib/translations";
 import { ErrorPage } from "./error-page";
 
@@ -22,6 +23,11 @@ export function OAuthCallback({ fullPage }: { fullPage?: boolean }) {
     if (called.current) return;
     called.current = true;
     try {
+      // The startup handler in StackClientApp's constructor may have already consumed the
+      // one-time OAuth params (code + state cookie) via a microtask that fires before this
+      // macrotask-scheduled useEffect. Await its completion so we don't race: if it succeeds
+      // it will redirect and this page tears down; if it fails we fall through below.
+      await app[hexclaveAppInternalsSymbol].awaitPendingAuthResolutions();
       const hasRedirected = await app.callOAuthCallback();
       if (!hasRedirected) {
         await app.redirectToSignIn({ noRedirectBack: true });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -4204,6 +4204,9 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       signInWithTokens: async (tokens: { accessToken: string, refreshToken: string }) => {
         await this._signInToAccountWithTokens(tokens);
       },
+      awaitPendingAuthResolutions: async () => {
+        await this._awaitPendingAuthResolutions();
+      },
     };
   };
 

--- a/packages/template/src/lib/hexclave-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/hexclave-app/apps/interfaces/client-app.ts
@@ -136,6 +136,7 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
       redirectToUrl(url: string | URL, options?: { replace?: boolean }): Promise<void>,
       redirectToHandler(handlerName: keyof HandlerUrls, options?: RedirectToOptions): Promise<void>,
       signInWithTokens(tokens: { accessToken: string, refreshToken: string }): Promise<void>,
+      awaitPendingAuthResolutions(): Promise<void>,
     },
   }
   & AsyncStoreProperty<"project", [], Project, false>


### PR DESCRIPTION
## Summary

Fixes a deterministic race condition where the `OAuthCallback` component's `useEffect` (macrotask) races against `StackClientApp`'s startup handler (microtask via `_trackPendingAuthResolution`). The startup handler always wins, consuming the one-time OAuth params (cookie + URL `code`/`state`) destructively via `consumeOAuthCallbackQueryParams()`. When `OAuthCallback` fires, params are gone → `callOAuthCallback()` returns `false` → component calls `redirectToSignIn()` → navigates away before the startup handler's token exchange completes → redirect loop through hosted auth pages.

Fix: `OAuthCallback` now calls `await app[hexclaveAppInternalsSymbol].awaitPendingAuthResolutions()` before `callOAuthCallback()`. If the startup handler already consumed the params and is mid-redirect, the component waits for completion (page tears down). If the startup handler failed, the component falls through and handles the callback itself.

```diff
// oauth-callback.tsx useEffect
+ await app[hexclaveAppInternalsSymbol].awaitPendingAuthResolutions();
  const hasRedirected = await app.callOAuthCallback();
```

New `awaitPendingAuthResolutions()` added to `hexclaveAppInternalsSymbol` interface, delegating to the existing `_awaitPendingAuthResolutions()` on the impl.

Link to Devin session: https://app.devin.ai/sessions/cfac8803c54341af944909ce03d86106
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a race in OAuth handling that caused redirect loops by double‑consuming one-time params. The `OAuthCallback` page now waits for any in‑flight startup auth work before handling the callback.

- **Bug Fixes**
  - `OAuthCallback` calls `app[hexclaveAppInternalsSymbol].awaitPendingAuthResolutions()` before `callOAuthCallback()` to avoid racing with startup.
  - Added `awaitPendingAuthResolutions()` to `hexclaveAppInternalsSymbol`, delegating to the existing internal `_awaitPendingAuthResolutions()`.
  - Updated tests to include the new internals method in the `StackClientApp` test double.

<sup>Written for commit 06e7c48bcaa7c6148b4f5bde7946a14c91e7a3d7. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1671?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved OAuth sign-in handling so the callback page waits for authentication to finish before redirecting.
  * Reduced the chance of one-time sign-in parameters being missed during page startup, helping prevent login flow race conditions.
  * No visible changes to the rest of the redirect behavior or user flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->