### PR TITLE
feat(emails): allow custom emails on shared server with dev wrapper

### DIFF
--- a/apps/backend/src/app/api/latest/emails/send-email/route.tsx
+++ b/apps/backend/src/app/api/latest/emails/send-email/route.tsx
@@ -63,9 +63,8 @@ export const POST = createSmartRouteHandler({
     if (!getEnvVariable("STACK_FREESTYLE_API_KEY")) {
       throw new StatusError(500, "STACK_FREESTYLE_API_KEY is not set");
     }
-    if (auth.tenancy.config.emails.server.isShared) {
-      throw new KnownErrors.RequiresCustomEmailServer();
-    }
+    // Custom emails ARE allowed on the shared email server; they get a "dev email" wrapper applied at send time
+    // (see wrapSharedDevEmail / isCustomEmailForSharedServer) so unexpected recipients know they can ignore them.
     if ((body.user_ids && body.all_users) || (!body.user_ids && !body.all_users)) {
       throw new KnownErrors.SchemaError("Exactly one of user_ids or all_users must be provided");
     }

--- a/apps/backend/src/app/api/latest/emails/send-email/route.tsx
+++ b/apps/backend/src/app/api/latest/emails/send-email/route.tsx
@@ -63,8 +63,7 @@ export const POST = createSmartRouteHandler({
     if (!getEnvVariable("STACK_FREESTYLE_API_KEY")) {
       throw new StatusError(500, "STACK_FREESTYLE_API_KEY is not set");
     }
-    // Custom emails ARE allowed on the shared email server; they get a "dev email" wrapper applied at send time
-    // (see wrapSharedDevEmail / isCustomEmailForSharedServer) so unexpected recipients know they can ignore them.
+    // Custom emails are allowed on the shared server; they get a dev wrapper at send time (see wrapSharedDevEmail).
     if ((body.user_ids && body.all_users) || (!body.user_ids && !body.all_users)) {
       throw new KnownErrors.SchemaError("Exactly one of user_ids or all_users must be provided");
     }

--- a/apps/backend/src/app/api/latest/emails/send-email/route.tsx
+++ b/apps/backend/src/app/api/latest/emails/send-email/route.tsx
@@ -63,7 +63,6 @@ export const POST = createSmartRouteHandler({
     if (!getEnvVariable("STACK_FREESTYLE_API_KEY")) {
       throw new StatusError(500, "STACK_FREESTYLE_API_KEY is not set");
     }
-    // Custom emails are allowed on the shared server; they get a dev wrapper at send time (see wrapSharedDevEmail).
     if ((body.user_ids && body.all_users) || (!body.user_ids && !body.all_users)) {
       throw new KnownErrors.SchemaError("Exactly one of user_ids or all_users must be provided");
     }

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -741,7 +741,7 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
       html: row.renderedHtml ?? undefined,
       text: row.renderedText ?? undefined,
     };
-    const emailContent = context.emailConfig.type === "shared" && isCustomEmailForSharedServer(row.createdWith, row.emailProgrammaticCallTemplateId)
+    const emailContent = context.emailConfig.type === "shared" && isCustomEmailForSharedServer(recipient, row.createdWith, row.emailProgrammaticCallTemplateId)
       ? wrapSharedDevEmail(baseContent)
       : baseContent;
 

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -735,9 +735,7 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
         return;
       }
     }
-    // When project-defined custom emails go out over the shared (Hexclave-provided) email server, wrap their
-    // subject and body with a notice that this is a development email so unexpected recipients can ignore it.
-    // Hexclave's own default-template emails (verification, password reset, etc.) are trusted and sent verbatim.
+    // Wrap project-defined custom emails sent over the shared server; default templates are sent verbatim.
     const baseContent = {
       subject: row.renderedSubject ?? "",
       html: row.renderedHtml ?? undefined,

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -1,7 +1,7 @@
 import { EmailOutbox, EmailOutboxSkippedReason, Prisma } from "@/generated/prisma/client";
 import { calculateCapacityRate, getEmailCapacityBoostExpiresAt, getEmailDeliveryStatsForTenancy } from "@/lib/email-delivery-stats";
 import { getEmailThemeForThemeId, renderEmailsForTenancyBatched } from "@/lib/email-rendering";
-import { EmailOutboxRecipient, getEmailConfig, } from "@/lib/emails";
+import { EmailOutboxRecipient, getEmailConfig, isCustomEmailForSharedServer, wrapSharedDevEmail, } from "@/lib/emails";
 import { generateUnsubscribeLink, getNotificationCategoryById, hasNotificationEnabled, listNotificationCategories } from "@/lib/notification-categories";
 import { arePlanLimitsEnforced, getBillingTeamId } from "@/lib/plan-entitlements";
 import { getHexclaveServerApp } from "@/hexclave";
@@ -735,15 +735,27 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
         return;
       }
     }
+    // When project-defined custom emails go out over the shared (Hexclave-provided) email server, wrap their
+    // subject and body with a notice that this is a development email so unexpected recipients can ignore it.
+    // Hexclave's own default-template emails (verification, password reset, etc.) are trusted and sent verbatim.
+    const baseContent = {
+      subject: row.renderedSubject ?? "",
+      html: row.renderedHtml ?? undefined,
+      text: row.renderedText ?? undefined,
+    };
+    const emailContent = context.emailConfig.type === "shared" && isCustomEmailForSharedServer(row.createdWith, row.emailProgrammaticCallTemplateId)
+      ? wrapSharedDevEmail(baseContent)
+      : baseContent;
+
     const result = getEnvBoolean("STACK_EMAIL_BRANCHING_DISABLE_QUEUE_SENDING")
       ? Result.error({ errorType: "email-sending-disabled", canRetry: false, message: "Email sending is disabled", rawError: new Error("Email sending is disabled") })
       : await lowLevelSendEmailDirectWithoutRetries({
         tenancyId: context.tenancy.id,
         emailConfig: context.emailConfig,
         to: resolution.emails,
-        subject: row.renderedSubject ?? "",
-        html: row.renderedHtml ?? undefined,
-        text: row.renderedText ?? undefined,
+        subject: emailContent.subject,
+        html: emailContent.html,
+        text: emailContent.text,
       });
     if (result.status === "error") {
       const newAttemptCount = row.sendRetries + 1;

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -735,7 +735,6 @@ async function processSingleEmail(context: TenancyProcessingContext, row: EmailO
         return;
       }
     }
-    // Wrap project-defined custom emails sent over the shared server; default templates are sent verbatim.
     const baseContent = {
       subject: row.renderedSubject ?? "",
       html: row.renderedHtml ?? undefined,

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -98,6 +98,49 @@ export async function sendEmailFromDefaultTemplate(options: {
   });
 }
 
+const DEFAULT_TEMPLATE_ID_SET: ReadonlySet<string> = new Set(Object.values(DEFAULT_TEMPLATE_IDS));
+
+/**
+ * Decides whether an outbox email counts as project-defined ("custom") content for the purposes of the shared
+ * email server dev wrapper (see {@link wrapSharedDevEmail}).
+ *
+ * Emails rendered from Hexclave's own default templates (email verification, password reset, magic link, etc.)
+ * are trusted and should be sent verbatim. Everything else — raw HTML sends, custom templates, and drafts — is
+ * controlled by the project, so when it goes out over the shared server it gets the dev wrapper.
+ */
+export function isCustomEmailForSharedServer(createdWith: EmailOutboxCreatedWith, programmaticCallTemplateId: string | null): boolean {
+  if (createdWith === EmailOutboxCreatedWith.DRAFT) {
+    return true;
+  }
+  // PROGRAMMATIC_CALL with a default template id => trusted Hexclave default template. Anything else (a custom
+  // template id, or `null` which means raw HTML was sent) is project-defined custom content.
+  return !(programmaticCallTemplateId !== null && DEFAULT_TEMPLATE_ID_SET.has(programmaticCallTemplateId));
+}
+
+/**
+ * Wraps a custom email's subject and body with a clear notice that it was sent through Hexclave's shared
+ * (development) email server. This lets us keep the shared server usable for sending arbitrary project content
+ * during development without lending Hexclave's sending reputation to convincing unsolicited mail: unexpected
+ * recipients are told upfront that they can ignore the message.
+ */
+export function wrapSharedDevEmail(content: { subject: string, html?: string, text?: string }): { subject: string, html?: string, text?: string } {
+  const wrappedSubject = `[Hexclave dev email] ${content.subject}`;
+
+  const noticeHtml = `<div style="margin:0 0 16px 0;padding:12px 16px;border:1px solid #f0c000;border-radius:8px;background:#fff8e1;color:#5b4a00;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;">`
+    + `<strong>This is a development email sent via Hexclave's shared email server.</strong><br />`
+    + `It was sent by an app that has not configured its own email server yet. If you were not expecting this email, you can safely ignore it.`
+    + `</div>`;
+
+  const noticeText = `[Development email sent via Hexclave's shared email server]\n`
+    + `It was sent by an app that has not configured its own email server yet. If you were not expecting this email, you can safely ignore it.\n\n`;
+
+  return {
+    subject: wrappedSubject,
+    html: content.html === undefined ? undefined : noticeHtml + content.html,
+    text: content.text === undefined ? undefined : noticeText + content.text,
+  };
+}
+
 export async function getEmailConfig(tenancy: Tenancy): Promise<LowLevelEmailConfig> {
   const projectEmailConfig = tenancy.config.emails.server;
 

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -101,27 +101,21 @@ export async function sendEmailFromDefaultTemplate(options: {
 const DEFAULT_TEMPLATE_ID_SET: ReadonlySet<string> = new Set(Object.values(DEFAULT_TEMPLATE_IDS));
 
 /**
- * Decides whether an outbox email counts as project-defined ("custom") content for the purposes of the shared
- * email server dev wrapper (see {@link wrapSharedDevEmail}).
- *
- * Emails rendered from Hexclave's own default templates (email verification, password reset, magic link, etc.)
- * are trusted and should be sent verbatim. Everything else — raw HTML sends, custom templates, and drafts — is
- * controlled by the project, so when it goes out over the shared server it gets the dev wrapper.
+ * Whether an outbox email is project-defined ("custom") content rather than a Hexclave default template, and so
+ * should get the shared-server dev wrapper. Drafts, raw HTML, and custom templates are custom; the built-in
+ * default templates (verification, password reset, etc.) are sent verbatim.
  */
 export function isCustomEmailForSharedServer(createdWith: EmailOutboxCreatedWith, programmaticCallTemplateId: string | null): boolean {
   if (createdWith === EmailOutboxCreatedWith.DRAFT) {
     return true;
   }
-  // PROGRAMMATIC_CALL with a default template id => trusted Hexclave default template. Anything else (a custom
-  // template id, or `null` which means raw HTML was sent) is project-defined custom content.
+  // A null template id means raw HTML was sent, which is custom; only a known default template id is verbatim.
   return !(programmaticCallTemplateId !== null && DEFAULT_TEMPLATE_ID_SET.has(programmaticCallTemplateId));
 }
 
 /**
- * Wraps a custom email's subject and body with a clear notice that it was sent through Hexclave's shared
- * (development) email server. This lets us keep the shared server usable for sending arbitrary project content
- * during development without lending Hexclave's sending reputation to convincing unsolicited mail: unexpected
- * recipients are told upfront that they can ignore the message.
+ * Wraps a custom email's subject and body with a notice that it was sent through Hexclave's shared (development)
+ * email server, so unexpected recipients know they can ignore it.
  */
 export function wrapSharedDevEmail(content: { subject: string, html?: string, text?: string }): { subject: string, html?: string, text?: string } {
   const wrappedSubject = `[Hexclave dev email] ${content.subject}`;

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -117,18 +117,27 @@ export function wrapSharedDevEmail(content: { subject: string, html?: string, te
   const wrappedSubject = `[Hexclave dev email] ${content.subject}`;
 
   const noticeHtml = `<div style="margin:0 0 16px 0;padding:12px 16px;border:1px solid #f0c000;border-radius:8px;background:#fff8e1;color:#5b4a00;font-family:-apple-system,BlinkMacSystemFont,'Segoe UI',Roboto,Helvetica,Arial,sans-serif;font-size:13px;line-height:1.5;">`
-    + `<strong>This is a development email sent via Hexclave's shared email server.</strong><br />`
-    + `It was sent by an app that has not configured its own email server yet. If you were not expecting this email, you can safely ignore it.`
+    + `<strong>This is a development email from an app built on Hexclave.</strong><br />`
+    + `The app hasn't configured its own email server yet, so it was sent through Hexclave's shared development email server. If this is your app, set up a custom email server in your Hexclave dashboard to send emails from your own domain. If you don't recognize this app, you can ignore this email.`
     + `</div>`;
 
-  const noticeText = `[Development email sent via Hexclave's shared email server]\n`
-    + `It was sent by an app that has not configured its own email server yet. If you were not expecting this email, you can safely ignore it.\n\n`;
+  const noticeText = `[Development email from an app built on Hexclave]\n`
+    + `The app hasn't configured its own email server yet, so it was sent through Hexclave's shared development email server. If this is your app, set up a custom email server in your Hexclave dashboard to send emails from your own domain. If you don't recognize this app, you can ignore this email.\n\n`;
 
   return {
     subject: wrappedSubject,
-    html: content.html === undefined ? undefined : noticeHtml + content.html,
+    html: content.html === undefined ? undefined : injectDevNoticeIntoHtml(content.html, noticeHtml),
     text: content.text === undefined ? undefined : noticeText + content.text,
   };
+}
+
+// Insert the notice just inside <body> so it stays valid markup for full HTML documents; fall back to prepending for fragments.
+function injectDevNoticeIntoHtml(html: string, noticeHtml: string): string {
+  const bodyOpenTag = /<body[^>]*>/i;
+  if (bodyOpenTag.test(html)) {
+    return html.replace(bodyOpenTag, (match) => match + noticeHtml);
+  }
+  return noticeHtml + html;
 }
 
 export async function getEmailConfig(tenancy: Tenancy): Promise<LowLevelEmailConfig> {

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -101,16 +101,22 @@ export async function sendEmailFromDefaultTemplate(options: {
 const DEFAULT_TEMPLATE_ID_SET: ReadonlySet<string> = new Set(Object.values(DEFAULT_TEMPLATE_IDS));
 
 /**
- * Whether an outbox email is project-defined ("custom") content rather than a Hexclave default template, and so
- * should get the shared-server dev wrapper. Drafts, raw HTML, and custom templates are custom; the built-in
- * default templates (verification, password reset, etc.) are sent verbatim.
+ * Whether an outbox email is project-defined ("custom") content that should get the shared-server dev wrapper.
+ * Drafts, raw HTML, and custom templates are custom; Hexclave's built-in default templates (verification,
+ * password reset, etc.) are sent verbatim.
  */
-export function isCustomEmailForSharedServer(createdWith: EmailOutboxCreatedWith, programmaticCallTemplateId: string | null): boolean {
+export function isCustomEmailForSharedServer(recipient: EmailOutboxRecipient, createdWith: EmailOutboxCreatedWith, programmaticCallTemplateId: string | null): boolean {
+  // Hexclave's own system notifications (credential-scanning revoke alerts, internal feedback, etc.) address
+  // bare addresses via "custom-emails" and must be sent verbatim. Project sends through the send-email API
+  // always target the project's own users, so only user-addressed emails are eligible for the wrapper.
+  if (recipient.type === "custom-emails") {
+    return false;
+  }
   if (createdWith === EmailOutboxCreatedWith.DRAFT) {
     return true;
   }
   // A null template id means raw HTML was sent, which is custom; only a known default template id is verbatim.
-  return !(programmaticCallTemplateId !== null && DEFAULT_TEMPLATE_ID_SET.has(programmaticCallTemplateId));
+  return programmaticCallTemplateId === null || !DEFAULT_TEMPLATE_ID_SET.has(programmaticCallTemplateId);
 }
 
 /**

--- a/apps/backend/src/lib/emails.tsx
+++ b/apps/backend/src/lib/emails.tsx
@@ -100,29 +100,19 @@ export async function sendEmailFromDefaultTemplate(options: {
 
 const DEFAULT_TEMPLATE_ID_SET: ReadonlySet<string> = new Set(Object.values(DEFAULT_TEMPLATE_IDS));
 
-/**
- * Whether an outbox email is project-defined ("custom") content that should get the shared-server dev wrapper.
- * Drafts, raw HTML, and custom templates are custom; Hexclave's built-in default templates (verification,
- * password reset, etc.) are sent verbatim.
- */
+/** Whether an outbox email is project-defined custom content that should get the shared-server dev wrapper. */
 export function isCustomEmailForSharedServer(recipient: EmailOutboxRecipient, createdWith: EmailOutboxCreatedWith, programmaticCallTemplateId: string | null): boolean {
-  // Hexclave's own system notifications (credential-scanning revoke alerts, internal feedback, etc.) address
-  // bare addresses via "custom-emails" and must be sent verbatim. Project sends through the send-email API
-  // always target the project's own users, so only user-addressed emails are eligible for the wrapper.
+  // Hexclave's own system notifications (credential-scanning alerts, internal feedback) send raw HTML to bare
+  // "custom-emails" addresses and must go out verbatim; the send-email API always targets the project's users.
   if (recipient.type === "custom-emails") {
     return false;
   }
   if (createdWith === EmailOutboxCreatedWith.DRAFT) {
     return true;
   }
-  // A null template id means raw HTML was sent, which is custom; only a known default template id is verbatim.
   return programmaticCallTemplateId === null || !DEFAULT_TEMPLATE_ID_SET.has(programmaticCallTemplateId);
 }
 
-/**
- * Wraps a custom email's subject and body with a notice that it was sent through Hexclave's shared (development)
- * email server, so unexpected recipients know they can ignore it.
- */
 export function wrapSharedDevEmail(content: { subject: string, html?: string, text?: string }): { subject: string, html?: string, text?: string } {
   const wrappedSubject = `[Hexclave dev email] ${content.subject}`;
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -80,43 +80,6 @@ describe("invalid requests", () => {
     `);
   });
 
-  it("should return 400 when using shared email config", async ({ expect }) => {
-    await Project.createAndSwitch();
-    const createUserResponse = await niceBackendFetch("/api/v1/users", {
-      method: "POST",
-      accessType: "server",
-      body: {
-        primary_email: "test@example.com",
-      },
-    });
-    const response = await niceBackendFetch(
-      "/api/v1/emails/send-email",
-      {
-        method: "POST",
-        accessType: "server",
-        body: {
-          user_ids: [createUserResponse.body.id],
-          html: "<p>Test email</p>",
-          subject: "Test Subject",
-          notification_category_name: "Marketing",
-        }
-      }
-    );
-    expect(response).toMatchInlineSnapshot(`
-      NiceResponse {
-        "status": 400,
-        "body": {
-          "code": "REQUIRES_CUSTOM_EMAIL_SERVER",
-          "error": "This action requires a custom SMTP server. Please edit your email server configuration and try again.",
-        },
-        "headers": Headers {
-          "x-stack-known-error": "REQUIRES_CUSTOM_EMAIL_SERVER",
-          <some fields may have been hidden>,
-        },
-      }
-    `);
-  });
-
   it("should return 400 when invalid notification category name is provided", async ({ expect }) => {
     await Project.createAndSwitch({
       display_name: "Test Successful Email Project",
@@ -289,6 +252,43 @@ it("should return 200 and send email successfully", async ({ expect }) => {
       },
     ]
   `);
+});
+
+describe("shared email server", () => {
+  it("should send custom emails over the shared server wrapped as Hexclave dev emails", async ({ expect }) => {
+    // No email_config => the project uses Hexclave's shared (development) email server.
+    await Project.createAndSwitch({ display_name: "Shared Server Email Project" });
+    const mailbox = await bumpEmailAddress();
+    const user = await User.create({ primary_email: mailbox.emailAddress, primary_email_verified: true });
+
+    const response = await niceBackendFetch(
+      "/api/v1/emails/send-email",
+      {
+        method: "POST",
+        accessType: "server",
+        body: {
+          user_ids: [user.userId],
+          html: "<p>Original custom email body</p>",
+          subject: "Original Subject",
+          notification_category_name: "Transactional",
+        }
+      }
+    );
+    expect(response).toMatchInlineSnapshot(`
+      NiceResponse {
+        "status": 200,
+        "body": { "results": [{ "user_id": "<stripped UUID>" }] },
+        "headers": Headers { <some fields may have been hidden> },
+      }
+    `);
+
+    // The subject is prefixed and the body gets a notice so unexpected recipients know they can ignore it.
+    const messages = await mailbox.waitForMessagesWithSubject("[Hexclave dev email] Original Subject");
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    const html = messages[0].body?.html ?? "";
+    expect(html).toContain("development email sent via Hexclave's shared email server");
+    expect(html).toContain("Original custom email body");
+  });
 });
 
 it("should handle user that does not exist", async ({ expect }) => {

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -1,3 +1,4 @@
+import { DEFAULT_TEMPLATE_IDS } from "@hexclave/shared/dist/helpers/emails";
 import { randomUUID } from "crypto";
 import { describe } from "vitest";
 import { it } from "../../../../helpers";
@@ -287,6 +288,32 @@ describe("shared email server", () => {
     const html = messages[0].body?.html ?? "";
     expect(html).toContain("development email sent via Hexclave's shared email server");
     expect(html).toContain("Original custom email body");
+  });
+
+  it("should NOT wrap Hexclave default-template emails sent over the shared server", async ({ expect }) => {
+    await Project.createAndSwitch({ display_name: "Shared Default Template Project" });
+    const mailbox = await bumpEmailAddress();
+    const user = await User.create({ primary_email: mailbox.emailAddress, primary_email_verified: true });
+
+    const response = await niceBackendFetch(
+      "/api/v1/emails/send-email",
+      {
+        method: "POST",
+        accessType: "server",
+        body: {
+          user_ids: [user.userId],
+          template_id: DEFAULT_TEMPLATE_IDS.sign_in_invitation,
+          variables: { teamDisplayName: "My Team", signInInvitationLink: "https://example.com" },
+        }
+      }
+    );
+    expect(response.status).toBe(200);
+
+    // Default templates are Hexclave-owned and must be sent verbatim — no subject prefix, no notice banner.
+    const messages = await mailbox.waitForMessagesWithSubject("You have been invited to sign in to Shared Default Template Project");
+    expect(messages.length).toBeGreaterThanOrEqual(1);
+    expect(messages[0].subject).not.toContain("[Hexclave dev email]");
+    expect(messages[0].body?.html ?? "").not.toContain("development email sent via Hexclave's shared email server");
   });
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -285,8 +285,10 @@ describe("shared email server", () => {
     const messages = await mailbox.waitForMessagesWithSubject("[Hexclave dev email] Original Subject");
     expect(messages.length).toBeGreaterThanOrEqual(1);
     const html = messages[0].body?.html ?? "";
-    expect(html).toContain("development email sent via Hexclave's shared email server");
+    expect(html).toContain("set up a custom email server in your Hexclave dashboard");
     expect(html).toContain("Original custom email body");
+    // The notice must be injected inside <body>, not before the document, to keep the markup valid.
+    expect(html.indexOf("set up a custom email server in your Hexclave dashboard")).toBeGreaterThan(html.indexOf("<body"));
   });
 
   it("should NOT wrap Hexclave default-template emails sent over the shared server", async ({ expect }) => {
@@ -311,7 +313,7 @@ describe("shared email server", () => {
     const messages = await mailbox.waitForMessagesWithSubject("You have been invited to sign in to Shared Default Template Project");
     expect(messages.length).toBeGreaterThanOrEqual(1);
     expect(messages[0].subject).not.toContain("[Hexclave dev email]");
-    expect(messages[0].body?.html ?? "").not.toContain("development email sent via Hexclave's shared email server");
+    expect(messages[0].body?.html ?? "").not.toContain("set up a custom email server in your Hexclave dashboard");
   });
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -256,7 +256,7 @@ it("should return 200 and send email successfully", async ({ expect }) => {
 
 describe("shared email server", () => {
   it("should send custom emails over the shared server wrapped as Hexclave dev emails", async ({ expect }) => {
-    // No email_config => the project uses Hexclave's shared (development) email server.
+    // No email_config => shared (development) email server.
     await Project.createAndSwitch({ display_name: "Shared Server Email Project" });
     const mailbox = await bumpEmailAddress();
     const user = await User.create({ primary_email: mailbox.emailAddress, primary_email_verified: true });
@@ -282,7 +282,6 @@ describe("shared email server", () => {
       }
     `);
 
-    // The subject is prefixed and the body gets a notice so unexpected recipients know they can ignore it.
     const messages = await mailbox.waitForMessagesWithSubject("[Hexclave dev email] Original Subject");
     expect(messages.length).toBeGreaterThanOrEqual(1);
     const html = messages[0].body?.html ?? "";

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -257,7 +257,6 @@ it("should return 200 and send email successfully", async ({ expect }) => {
 
 describe("shared email server", () => {
   it("should send custom emails over the shared server wrapped as Hexclave dev emails", async ({ expect }) => {
-    // No email_config => shared (development) email server.
     await Project.createAndSwitch({ display_name: "Shared Server Email Project" });
     const mailbox = await bumpEmailAddress();
     const user = await User.create({ primary_email: mailbox.emailAddress, primary_email_verified: true });
@@ -309,7 +308,6 @@ describe("shared email server", () => {
     );
     expect(response.status).toBe(200);
 
-    // Default templates are Hexclave-owned and must be sent verbatim — no subject prefix, no notice banner.
     const messages = await mailbox.waitForMessagesWithSubject("You have been invited to sign in to Shared Default Template Project");
     expect(messages.length).toBeGreaterThanOrEqual(1);
     expect(messages[0].subject).not.toContain("[Hexclave dev email]");

--- a/apps/e2e/tests/js/email.test.ts
+++ b/apps/e2e/tests/js/email.test.ts
@@ -113,7 +113,9 @@ it("should send email with notification category", async ({ expect }) => {
   })).resolves.not.toThrow();
 });
 
-it("should throw RequiresCustomEmailServer error when email server is not configured", async ({ expect }) => {
+it("should send custom emails over the shared server (wrapped as dev emails) when no custom server is configured", async ({ expect }) => {
+  // Don't call setupEmailServer, so the project keeps Hexclave's shared (development) email server. Custom
+  // emails are still allowed; they just get a "dev email" wrapper applied at send time.
   const { serverApp } = await createApp();
 
   const user = await serverApp.createUser({
@@ -123,9 +125,9 @@ it("should throw RequiresCustomEmailServer error when email server is not config
 
   await expect(serverApp.sendEmail({
     userIds: [user.id],
-    html: "<p>This should fail</p>",
+    html: "<p>This now sends over the shared server</p>",
     subject: "Test Email",
-  })).rejects.toThrow(KnownErrors.RequiresCustomEmailServer);
+  })).resolves.not.toThrow();
 });
 
 it("should handle non-existent user IDs", async ({ expect }) => {

--- a/apps/e2e/tests/js/email.test.ts
+++ b/apps/e2e/tests/js/email.test.ts
@@ -114,8 +114,7 @@ it("should send email with notification category", async ({ expect }) => {
 });
 
 it("should send custom emails over the shared server (wrapped as dev emails) when no custom server is configured", async ({ expect }) => {
-  // Don't call setupEmailServer, so the project keeps Hexclave's shared (development) email server. Custom
-  // emails are still allowed; they just get a "dev email" wrapper applied at send time.
+  // No setupEmailServer => shared server, on which custom emails are now allowed (with a dev wrapper).
   const { serverApp } = await createApp();
 
   const user = await serverApp.createUser({

--- a/apps/e2e/tests/js/email.test.ts
+++ b/apps/e2e/tests/js/email.test.ts
@@ -114,7 +114,6 @@ it("should send email with notification category", async ({ expect }) => {
 });
 
 it("should send custom emails over the shared server (wrapped as dev emails) when no custom server is configured", async ({ expect }) => {
-  // No setupEmailServer => shared server, on which custom emails are now allowed (with a dev wrapper).
   const { serverApp } = await createApp();
 
   const user = await serverApp.createUser({

--- a/docker/dependencies/freestyle-mock/Dockerfile
+++ b/docker/dependencies/freestyle-mock/Dockerfile
@@ -309,7 +309,7 @@ const server = createServer(async (req, res) => {
   let workDir = null;
   try {
     const url = new URL(req.url, `http://${req.headers.host}`);
-    const isValidEndpoint = req.method === "POST" && (url.pathname === "/execute/v1/script" || url.pathname === "/execute/v2/script");
+    const isValidEndpoint = req.method === "POST" && (url.pathname === "/execute/v1/script" || url.pathname === "/execute/v2/script" || url.pathname === "/execute/v3/script");
 
     if (!isValidEndpoint) {
       res.writeHead(404);


### PR DESCRIPTION
## What

Custom emails / templates / drafts sent through Hexclave's **shared (development) email server** are no longer blocked with `RequiresCustomEmailServer`. They are now allowed, but their **subject and body are wrapped** at send time with a notice that this is a development email from Hexclave, so unexpected recipients know they can safely ignore it.

The wrapper only applies to **project-defined content addressed to the project's own users**. Hexclave's own default-template emails (verification, password reset, magic link, etc.) and system notifications (credential-scanning alerts, internal feedback) are sent **verbatim**.

## How

- **[send-email/route.tsx](apps/backend/src/app/api/latest/emails/send-email/route.tsx)** — removed the `RequiresCustomEmailServer` throw that blocked the shared server.
- **[emails.tsx](apps/backend/src/lib/emails.tsx)** — added `wrapSharedDevEmail()` (prefixes the subject with `[Hexclave dev email]` and prepends a notice banner to HTML/text) and `isCustomEmailForSharedServer(recipient, createdWith, templateId)`.
- **[email-queue-step.tsx](apps/backend/src/lib/email-queue-step.tsx)** — applies the wrapper at send time, gated on `emailConfig.type === "shared"` **and** the email being project-defined custom content. Applying it at send time reliably wraps both the subject (from `overrideSubject` or the template's `<Subject>`) and the rendered HTML.

### What counts as "wrap-eligible"
`isCustomEmailForSharedServer` returns true only when **all** hold:
1. the email is addressed to one of the project's own users (recipient type is not `custom-emails`), **and**
2. it is a draft, a custom template, or raw HTML — i.e. **not** one of the built-in `DEFAULT_TEMPLATE_IDS`.

Condition (1) exempts Hexclave's own system senders (credential-scanning revoke, internal feedback) which send raw HTML to bare addresses via `custom-emails` and would otherwise be mis-classified as project content. This was a bug caught in review — a leaked-API-key security alert to a shared-server customer would have been prefixed `[Hexclave dev email]` with a "you can safely ignore it" banner. The recipient type is already persisted on the outbox row, so no schema change was needed.

## Tests

- **send-email.test.ts** — replaced the old "400 on shared config" test with two new tests: (a) a custom email on the shared server is delivered with the `[Hexclave dev email]` subject prefix + notice banner, and (b) a **default template** (`sign_in_invitation`) on the shared server is delivered **verbatim** (no prefix, no banner) — pinning the core safety contract.
- **js/email.test.ts** — flipped the "throws RequiresCustomEmailServer" test to assert the send now resolves.

Verified locally against a full stack:
- ✅ `send-email.test.ts` — 18/18
- ✅ `js/email.test.ts` — 12/12
- ✅ `password/send-reset-code.test.ts` — passes (default templates on shared server stay unwrapped)

## Known limitations (intentional scope)

- **Template CRUD still blocked on the shared server.** `internal/email-templates` routes still throw `RequiresCustomEmailServer`, so a shared-server project can send raw HTML / a default template via the API but cannot create or edit a *saved* custom template. Sending arbitrary HTML is unaffected; only the saved-template editor remains gated.
- **A project can send a (project-edited) default template unwrapped** by calling `send-email` with a `template_id` equal to a built-in `DEFAULT_TEMPLATE_IDS` value. Low impact (requires a server key, limited upside), noted for awareness.

## Note: freestyle-mock fix included

[freestyle-mock/Dockerfile](docker/dependencies/freestyle-mock/Dockerfile) now also accepts `/execute/v3/script`. The `freestyle` SDK bump in #1654 moved to `/v3`, but the mock only served `/v1`+`/v2`, so **all** local email rendering 404'd (pre-existing `dev` breakage, not from this feature). The v3 request/response is identical to v2. Happy to split this into its own PR if preferred.

Out of scope: `emails/email-queue.test.ts` has 2 pre-existing snapshot failures (`margin:0` vs recorded `margin:0rem`, a `@react-email/components` version drift in the mock) — those tests use a custom email server, so this PR's shared-only code path never runs for them.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Email sending can now proceed when using a shared email server.
  * Development-style wrapping is applied to eligible shared-server custom email content, including HTML notice injection.

* **Bug Fixes**
  * Removed the previous blocking “requires custom email server” behavior for shared-server configurations.
  * Default-template emails over the shared server are no longer wrapped.

* **Tests**
  * Updated end-to-end and JS email tests to validate both wrapped custom-email behavior and unwrapped default-template behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->