### PR TITLE
feat: add instrumentation for redirect loop and handler home landing detection

### DIFF
--- a/packages/template/src/components-page/hexclave-handler-client.tsx
+++ b/packages/template/src/components-page/hexclave-handler-client.tsx
@@ -6,10 +6,7 @@ import { FilterUndefined, filterUndefined } from "@hexclave/shared/dist/utils/ob
 import { use } from "@hexclave/shared/dist/utils/react";
 import { getRelativePart } from "@hexclave/shared/dist/utils/urls";
 import { notFound, redirect, RedirectType, usePathname, useSearchParams } from 'next/navigation'; // THIS_LINE_PLATFORM next
-import { Suspense, useMemo, useSyncExternalStore } from 'react';
-/* IF_PLATFORM react
-import { useEffect, useRef } from 'react';
-// END_PLATFORM */
+import { Suspense, useEffect, useMemo, useRef, useSyncExternalStore } from 'react';
 import { SignIn, SignUp, StackServerApp } from "..";
 import { useStackApp } from "../lib/hooks";
 import { HandlerUrls, StackClientApp, hexclaveAppInternalsSymbol } from "../lib/hexclave-app";
@@ -299,6 +296,29 @@ export function HexclaveHandlerClient(props: BaseHandlerProps & Partial<RoutePro
       handlerPath,
     };
   }, [currentLocation, searchParamsSource, handlerUrls.handler]);
+
+  // Detect when a user lands on the handler root (empty path), which is never the intended
+  // destination — it means a redirect flow dropped them here instead of sending them back to the
+  // app. Fire captureError so it shows up in Sentry for investigation.
+  const handlerHomeDetectionFired = useRef(false);
+  useEffect(() => {
+    if (path === "" && !handlerHomeDetectionFired.current) {
+      handlerHomeDetectionFired.current = true;
+      captureError(
+        "handler-home-landing-detected",
+        new HexclaveAssertionError(
+          `User landed on the hosted handler home page (path=""), which should never be the final destination. ` +
+          `This likely means a redirect flow failed to return the user to their app.`,
+          {
+            currentUrl: window.location.href,
+            referrer: document.referrer,
+            handlerPath,
+            projectId: hexclaveApp.projectId,
+          },
+        ),
+      );
+    }
+  }, [path, handlerPath, hexclaveApp.projectId]);
 
   const getDefaultUnknownPathUrl = (unknownPath: string): string | null => {
     return resolveUnknownHandlerPathFallbackUrl({

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -57,6 +57,7 @@ import { TeamPermission } from "../../permissions";
 import { AdminOwnedProject, AdminProjectUpdateOptions, Project, adminProjectCreateOptionsToCrud } from "../../projects";
 import { EditableTeamMemberProfile, ReceivedTeamInvitation, SentTeamInvitation, Team, TeamCreateOptions, TeamUpdateOptions, TeamUser, teamCreateOptionsToCrud, teamUpdateOptionsToCrud } from "../../teams";
 import { buildCliAuthConfirmUrl, getHostedHandlerUrl, isHostedHandlerUrlForProject, resolveHandlerUrls } from "../../url-targets";
+import { detectRedirectLoop } from "./redirect-loop-detection";
 import { ActiveSession, Auth, BaseUser, CurrentUser, InternalUserExtra, OAuthProvider, ProjectCurrentUser, SyncedPartialUser, TokenPartialUser, UserExtra, UserUpdateOptions, userUpdateOptionsToCrud, withUserDestructureGuard } from "../../users";
 import { StackClientApp, StackClientAppConstructorOptions, StackClientAppJson } from "../interfaces/client-app";
 import { _HexclaveAdminAppImplIncomplete } from "./admin-app-impl";
@@ -3016,6 +3017,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   }
 
   protected async _redirectTo(options: { url: URL | string, replace?: boolean }) {
+    if (isBrowserLike()) {
+      detectRedirectLoop({ targetUrl: options.url.toString(), projectId: this.projectId });
+    }
+
     if (this._redirectMethod === "none") {
       return;
       // IF_PLATFORM next

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-detection.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-detection.test.ts
@@ -1,0 +1,155 @@
+// @vitest-environment jsdom
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+
+const captureErrorMock = vi.fn();
+vi.mock("@hexclave/shared/dist/utils/errors", () => ({
+  captureError: (...args: unknown[]) => captureErrorMock(...args),
+  HexclaveAssertionError: class HexclaveAssertionError extends Error {
+    constructor(message: string, public readonly details?: Record<string, unknown>) {
+      super(message);
+    }
+  },
+}));
+
+import { detectRedirectLoop } from "./redirect-loop-detection";
+
+const STORAGE_KEY = "hexclave-redirect-breadcrumbs";
+
+describe("detectRedirectLoop", () => {
+  beforeEach(() => {
+    sessionStorage.clear();
+    captureErrorMock.mockClear();
+    Object.defineProperty(window, "location", {
+      value: { pathname: "/a", href: "http://localhost/a", origin: "http://localhost" },
+      writable: true,
+      configurable: true,
+    });
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("does not fire captureError on the first redirect", () => {
+    detectRedirectLoop({ targetUrl: "/b", projectId: "test-project" });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("does not fire captureError when redirecting to different pages", () => {
+    detectRedirectLoop({ targetUrl: "/b", projectId: "test-project" });
+
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "/c", projectId: "test-project" });
+
+    window.location.pathname = "/c";
+    window.location.href = "http://localhost/c";
+    detectRedirectLoop({ targetUrl: "/d", projectId: "test-project" });
+
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("fires captureError when an A->B->A loop is detected", () => {
+    // First redirect: on /a, redirecting to /b — records pair (/a → /b)
+    detectRedirectLoop({ targetUrl: "/b", projectId: "test-project" });
+
+    // Second redirect: on /b, redirecting to /a — records pair (/b → /a)
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "/a", projectId: "test-project" });
+
+    // Third redirect: on /a, redirecting to /b — pair (/a → /b) already seen, loop detected
+    window.location.pathname = "/a";
+    window.location.href = "http://localhost/a";
+    detectRedirectLoop({ targetUrl: "/b", projectId: "test-project" });
+
+    expect(captureErrorMock).toHaveBeenCalledOnce();
+    expect(captureErrorMock).toHaveBeenCalledWith(
+      "redirect-loop-detected",
+      expect.objectContaining({
+        message: expect.stringContaining("Redirect loop detected"),
+      }),
+    );
+  });
+
+  it("clears breadcrumbs after firing so it does not spam on subsequent redirects", () => {
+    // Build up to a loop
+    detectRedirectLoop({ targetUrl: "/b", projectId: "p" });
+
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "/a", projectId: "p" });
+
+    window.location.pathname = "/a";
+    window.location.href = "http://localhost/a";
+    detectRedirectLoop({ targetUrl: "/b", projectId: "p" });
+
+    expect(captureErrorMock).toHaveBeenCalledOnce();
+
+    // Subsequent redirect after loop detection should NOT fire again (breadcrumbs cleared)
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "/a", projectId: "p" });
+
+    expect(captureErrorMock).toHaveBeenCalledOnce();
+  });
+
+  it("ignores old breadcrumbs outside the 30s window", () => {
+    // Simulate old breadcrumbs from > 30s ago
+    const oldTimestamp = performance.now() - 31_000;
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify([
+      { from: "/a", to: "/b", timestamp: oldTimestamp },
+      { from: "/b", to: "/a", timestamp: oldTimestamp + 100 },
+    ]));
+
+    // New redirect /a → /b — the old pair (/a → /b) is outside the window, so no loop
+    detectRedirectLoop({ targetUrl: "/b", projectId: "p" });
+    expect(captureErrorMock).not.toHaveBeenCalled();
+  });
+
+  it("handles full absolute URLs as target", () => {
+    detectRedirectLoop({ targetUrl: "http://localhost/b", projectId: "p" });
+
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "http://localhost/a", projectId: "p" });
+
+    window.location.pathname = "/a";
+    window.location.href = "http://localhost/a";
+    detectRedirectLoop({ targetUrl: "http://localhost/b", projectId: "p" });
+
+    expect(captureErrorMock).toHaveBeenCalledOnce();
+  });
+
+  it("silently ignores sessionStorage errors", () => {
+    const getItemSpy = vi.spyOn(Storage.prototype, "getItem").mockImplementation(() => {
+      throw new Error("SecurityError: access denied");
+    });
+
+    expect(() => {
+      detectRedirectLoop({ targetUrl: "/b", projectId: "p" });
+    }).not.toThrow();
+    expect(captureErrorMock).not.toHaveBeenCalled();
+
+    getItemSpy.mockRestore();
+  });
+
+  it("includes projectId and URLs in the error details", () => {
+    detectRedirectLoop({ targetUrl: "/b", projectId: "my-project-123" });
+
+    window.location.pathname = "/b";
+    window.location.href = "http://localhost/b";
+    detectRedirectLoop({ targetUrl: "/a", projectId: "my-project-123" });
+
+    window.location.pathname = "/a";
+    window.location.href = "http://localhost/a";
+    detectRedirectLoop({ targetUrl: "/b", projectId: "my-project-123" });
+
+    const error = captureErrorMock.mock.calls[0][1];
+    expect(error.details).toEqual(expect.objectContaining({
+      projectId: "my-project-123",
+      targetUrl: "/b",
+      currentUrl: "http://localhost/a",
+    }));
+  });
+});

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-detection.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-detection.ts
@@ -1,0 +1,69 @@
+import { HexclaveAssertionError, captureError } from "@hexclave/shared/dist/utils/errors";
+
+const STORAGE_KEY = "hexclave-redirect-breadcrumbs";
+const MAX_BREADCRUMBS = 10;
+// Only consider redirects within the last 30 seconds as part of a potential loop
+const LOOP_WINDOW_MS = 30_000;
+
+type Breadcrumb = { from: string, to: string, timestamp: number };
+
+/**
+ * Records the current redirect in sessionStorage and checks for redirect loops (A→B→A pattern).
+ * Fires captureError when a loop is detected so it shows up in Sentry.
+ *
+ * Called from _redirectTo() before every browser-side navigation.
+ */
+export function detectRedirectLoop(options: {
+  targetUrl: string,
+  projectId: string,
+}) {
+  try {
+    const now = performance.now();
+    const currentPathname = window.location.pathname;
+    const targetPathname = (() => {
+      try {
+        return new URL(options.targetUrl, window.location.origin).pathname;
+      } catch {
+        return options.targetUrl;
+      }
+    })();
+
+    const stored = sessionStorage.getItem(STORAGE_KEY);
+    const breadcrumbs: Breadcrumb[] = stored != null ? JSON.parse(stored) : [];
+
+    // Trim old entries outside the time window
+    const recentBreadcrumbs = breadcrumbs.filter(b => now - b.timestamp < LOOP_WINDOW_MS);
+
+    // Detect loop: if the same (from → to) redirect pair has been seen recently, we're in a loop
+    const isLoop = recentBreadcrumbs.some(b => b.from === currentPathname && b.to === targetPathname);
+
+    // Record this redirect pair
+    recentBreadcrumbs.push({ from: currentPathname, to: targetPathname, timestamp: now });
+
+    // Keep only the most recent entries
+    const trimmed = recentBreadcrumbs.slice(-MAX_BREADCRUMBS);
+    sessionStorage.setItem(STORAGE_KEY, JSON.stringify(trimmed));
+
+    if (isLoop) {
+      const recentPathnames = trimmed.map(b => b.from);
+      captureError(
+        "redirect-loop-detected",
+        new HexclaveAssertionError(
+          `Redirect loop detected: the redirect ${currentPathname} → ${targetPathname} was observed multiple times within ${LOOP_WINDOW_MS / 1000}s. ` +
+          `Recent redirect chain: ${recentPathnames.join(" → ")} → ${targetPathname}`,
+          {
+            targetUrl: options.targetUrl,
+            currentUrl: window.location.href,
+            recentPathnames,
+            projectId: options.projectId,
+          },
+        ),
+      );
+
+      // Clear breadcrumbs so we don't keep firing on every subsequent redirect in the same loop
+      sessionStorage.removeItem(STORAGE_KEY);
+    }
+  } catch {
+    // sessionStorage may be unavailable (eg. in incognito/iframe with restrictions); silently ignore
+  }
+}


### PR DESCRIPTION
## Summary

Adds `captureError` instrumentation for two hosted-component stuck-state patterns so they show up in Sentry:

1. **Redirect loop detection** — `detectRedirectLoop()` in `redirect-loop-detection.ts`, called from `_redirectTo()` before every browser-side navigation. Tracks `(from, to)` redirect pairs in `sessionStorage` within a 30s sliding window. When the same pair recurs, fires `captureError("redirect-loop-detected", ...)` with the recent redirect chain and project context, then clears breadcrumbs to avoid spam.

2. **Handler home landing detection** — in `HexclaveHandlerClient`, a `useEffect` fires `captureError("handler-home-landing-detected", ...)` when `path === ""` (the hosted handler root, which is never the intended destination). Uses a `useRef` guard to fire once per component lifecycle.

Detection only — no user-facing changes or prevention logic.

Link to Devin session: https://app.devin.ai/sessions/cfac8803c54341af944909ce03d86106
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds client-side instrumentation to detect redirect loops and unexpected landings on the hosted handler root. Sends `captureError` events for Sentry visibility of stuck states; no user-facing changes.

- **New Features**
  - Redirect loop detection: `detectRedirectLoop()` (30s window) is called from `_redirectTo()` in the client app. It tracks `(from → to)` pairs in `sessionStorage`, triggers `captureError("redirect-loop-detected", ...)`, then clears breadcrumbs.
  - Handler home landing detection: in `HexclaveHandlerClient`, fires `captureError("handler-home-landing-detected", ...)` once per mount when `path === ""`, including URL, referrer, and `projectId` in details.

<sup>Written for commit a9dc84752242d10632bee040a76f15c7d2f09e6f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1674?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

