### PR TITLE
Make analytics include_all_branches a no-op with TODO

### DIFF
--- a/apps/backend/src/app/api/latest/internal/analytics/query/route.ts
+++ b/apps/backend/src/app/api/latest/internal/analytics/query/route.ts
@@ -6,7 +6,6 @@ import { getHexclaveServerApp } from "@/hexclave";
 import { KnownErrors } from "@hexclave/shared";
 import { ITEM_IDS, PLAN_LIMITS } from "@hexclave/shared/dist/plans";
 import { adaptSchema, adminAuthTypeSchema, jsonSchema, yupBoolean, yupMixed, yupNumber, yupObject, yupRecord, yupString } from "@hexclave/shared/dist/schema-fields";
-import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { Result } from "@hexclave/shared/dist/utils/results";
 import { randomUUID } from "crypto";
 
@@ -36,9 +35,12 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ body, auth }) {
-    if (body.include_all_branches) {
-      throw new HexclaveAssertionError("include_all_branches is not supported yet");
-    }
+    // TODO: implement include_all_branches. When true, this should query across
+    // all branches in the project instead of just auth.tenancy.branchId. For now
+    // it is a no-op: regardless of the flag, queries remain scoped to the current
+    // branch via the ClickHouse row policy that filters on SQL_branch_id (set
+    // below). Callers passing include_all_branches=true will still only receive
+    // data for the current branch until cross-branch filtering is implemented.
 
     let effectiveTimeoutMs = body.timeout_ms;
     const billingTeamId = getBillingTeamId(auth.tenancy.project);

--- a/apps/backend/src/app/api/latest/internal/analytics/query/route.ts
+++ b/apps/backend/src/app/api/latest/internal/analytics/query/route.ts
@@ -35,12 +35,14 @@ export const POST = createSmartRouteHandler({
     }).defined(),
   }),
   async handler({ body, auth }) {
-    // TODO: implement include_all_branches. When true, this should query across
-    // all branches in the project instead of just auth.tenancy.branchId. For now
-    // it is a no-op: regardless of the flag, queries remain scoped to the current
-    // branch via the ClickHouse row policy that filters on SQL_branch_id (set
-    // below). Callers passing include_all_branches=true will still only receive
-    // data for the current branch until cross-branch filtering is implemented.
+    // include_all_branches is currently a no-op. Multiple branches per project
+    // are not implemented yet: every project has a single branch hardcoded to
+    // DEFAULT_BRANCH_ID ("main"), with no way to create or switch branches (see
+    // lib/tenancies.tsx). So there are no other branches to include, and queries
+    // stay scoped to the current branch via the ClickHouse row policy that
+    // filters on SQL_branch_id (set below).
+    // TODO: when multi-branch support lands, make include_all_branches=true query
+    // across all branches in the project instead of just auth.tenancy.branchId.
 
     let effectiveTimeoutMs = body.timeout_ms;
     const billingTeamId = getBillingTeamId(auth.tenancy.project);


### PR DESCRIPTION
## What

The `/internal/analytics/query` route accepts an `include_all_branches` flag (defaults to `false`). Previously, passing `true` threw a `HexclaveAssertionError`. Since the flag is reachable from user input, that assertion surfaced as a 500 / error-tracking noise rather than a clean response.

This makes the flag a **no-op** for now and documents the intended behavior with a TODO.

## Behavior

- Regardless of `include_all_branches`, queries remain scoped to the current branch via the ClickHouse row policy that filters on `SQL_branch_id` (set from `auth.tenancy.branchId`).
- Callers passing `include_all_branches=true` will still only receive data for the **current branch** until cross-branch filtering is implemented.

## Note / follow-up

Because the flag is silently ignored, a caller asking for "all branches" gets single-branch results with no signal. The TODO tracks implementing real cross-branch querying. Flagging in case we'd rather surface a proper client-facing error in the interim instead of a silent no-op.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Made the `include_all_branches` flag on `/internal/analytics/query` a no-op so `true` no longer throws and avoids 500s from user input. Branching isn’t implemented yet, so queries always scope to the current branch via the ClickHouse `SQL_branch_id` row policy; TODO added for real cross-branch querying.

<sup>Written for commit a07e1237e9e33672374b541cea03fa2ab215f667. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1678?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Analytics requests now accept the “include all branches” option without failing.
  * Branch-scoped analytics queries continue to run as before, while the option is treated as a no-op for now.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->