### PR TITLE
fix(backend): use paid z-ai/glm-4.5-air slug instead of retired :free variant

### DIFF
--- a/apps/backend/src/lib/ai/models.ts
+++ b/apps/backend/src/lib/ai/models.ts
@@ -19,7 +19,7 @@ const MODEL_SELECTION_MATRIX: Record<
 > = {
   dumb: {
     slow: {
-      authenticated: { modelId: "z-ai/glm-4.5-air:free" },
+      authenticated: { modelId: "z-ai/glm-4.5-air" },
       unauthenticated: { modelId: "nvidia/nemotron-3-super-120b-a12b" },
     },
     fast: {


### PR DESCRIPTION
## Problem

Sentry is reporting an `AI_APICallError` on the AI proxy path:

> This model is unavailable for free. The paid version is available now - use this slug instead: `z-ai/glm-4.5-air`

OpenRouter discontinued the **free** tier for GLM 4.5 Air. The model selection matrix still pinned the `:free` variant for the **dumb / slow / authenticated** path, so every request routed there fails.

## Fix

Drop the `:free` suffix in `apps/backend/src/lib/ai/models.ts` so it uses the paid slug OpenRouter recommends:

```diff
-      authenticated: { modelId: "z-ai/glm-4.5-air:free" },
+      authenticated: { modelId: "z-ai/glm-4.5-air" },
```

`ALLOWED_MODEL_IDS` is derived from the matrix, so the new slug is picked up automatically.

## Notes

- This was the only `:free` slug in the matrix; nothing else is exposed to the same break.
- This moves a previously-free path onto paid inference (cheap model, but no longer $0).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Switch the dumb/slow/authenticated path to the paid `z-ai/glm-4.5-air` slug, replacing the retired `:free` variant to stop “This model is unavailable for free” errors. Restores successful requests after OpenRouter ended the free tier.

- **Bug Fixes**
  - Updated model matrix in apps/backend/src/lib/ai/models.ts to use `z-ai/glm-4.5-air`; `ALLOWED_MODEL_IDS` picks up the new slug automatically.

<sup>Written for commit c354b5fcf2924eab7b5a77b90d351d2355ae8fa0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1685?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated the model selection for authenticated requests in one quality/speed setting, so the app now uses the correct model ID and accepts the updated option in allowed model lists.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->