### PR TITLE
fix(backend): use structured output for QA reviewer instead of JSON.parse

### DIFF
--- a/apps/backend/src/lib/ai/qa-reviewer.ts
+++ b/apps/backend/src/lib/ai/qa-reviewer.ts
@@ -40,7 +40,9 @@ const qaReviewSchema = z.object({
     severity: z.string(),
     explanation: z.string(),
   })),
-  improvementSuggestions: z.string(),
+  // Optional in practice: the model omits this for good answers with nothing to suggest.
+  // Defaulting (rather than requiring) avoids turning those into structured-output failures.
+  improvementSuggestions: z.string().default(""),
   overallScore: z.number(),
 });
 

--- a/apps/backend/src/lib/ai/qa-reviewer.ts
+++ b/apps/backend/src/lib/ai/qa-reviewer.ts
@@ -1,7 +1,8 @@
 import { createMCPClient } from "@ai-sdk/mcp";
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
 import { captureError } from "@hexclave/shared/dist/utils/errors";
-import { generateText, stepCountIs } from "ai";
+import { generateText, Output, stepCountIs } from "ai";
+import { z } from "zod";
 import { getConnection } from "./mcp-logger";
 import { createOpenRouterProvider } from "./models";
 import { getVerifiedQaContext } from "./verified-qa";
@@ -15,15 +16,7 @@ Your tasks:
 
 The repo name for all tool calls is "stack-auth/stack-auth". Only use the repository documentation tools (read_wiki_structure, read_wiki_contents, ask_question) — do not create sessions or modify any other resources.
 
-You MUST respond with ONLY valid JSON matching this exact schema (no markdown, no explanation outside the JSON):
-{
-  "needsHumanReview": boolean,
-  "answerCorrect": boolean,
-  "answerRelevant": boolean,
-  "flags": [{"type": string, "severity": "low" | "medium" | "high" | "critical", "explanation": string}],
-  "improvementSuggestions": string,
-  "overallScore": number
-}
+Produce a structured review. For each issue you find, add an entry to "flags" with a type, severity (one of "low", "medium", "high", "critical"), and explanation.
 
 Flag types: "factual_error", "incomplete_answer", "off_topic", "hallucination", "outdated_info", "missing_context", "misleading", "reason_mismatch"
 
@@ -37,6 +30,19 @@ Scoring:
 Set needsHumanReview=true if: score < 50, any critical flag, or you are uncertain about correctness.`;
 
 const REVIEW_MODEL_ID = "anthropic/claude-haiku-4.5";
+
+const qaReviewSchema = z.object({
+  needsHumanReview: z.boolean(),
+  answerCorrect: z.boolean(),
+  answerRelevant: z.boolean(),
+  flags: z.array(z.object({
+    type: z.string(),
+    severity: z.string(),
+    explanation: z.string(),
+  })),
+  improvementSuggestions: z.string(),
+  overallScore: z.number(),
+});
 
 export async function reviewMcpCall(entry: {
   logPromise: Promise<void>;
@@ -107,6 +113,7 @@ export async function reviewMcpCall(entry: {
       system: QA_SYSTEM_PROMPT + verifiedQa,
       tools: devinTools as Parameters<typeof generateText>[0]["tools"],
       stopWhen: stepCountIs(10),
+      output: Output.object({ schema: qaReviewSchema }),
       messages: [{ role: "user", content: userMessage }],
     });
 
@@ -125,28 +132,9 @@ export async function reviewMcpCall(entry: {
       };
     });
 
-    const jsonMatch = result.text.match(/\{[\s\S]*\}/);
-    if (!jsonMatch) {
-      throw new Error("No JSON found in QA review response");
-    }
-    const raw = JSON.parse(jsonMatch[0]);
-    if (
-      typeof raw.needsHumanReview !== "boolean" ||
-      typeof raw.answerCorrect !== "boolean" ||
-      typeof raw.answerRelevant !== "boolean" ||
-      !Array.isArray(raw.flags) ||
-      typeof raw.overallScore !== "number"
-    ) {
-      throw new Error(`Invalid QA review response shape: ${JSON.stringify(raw).slice(0, 200)}`);
-    }
-    const parsed = raw as {
-      needsHumanReview: boolean,
-      answerCorrect: boolean,
-      answerRelevant: boolean,
-      flags: Array<{ type: string, severity: string, explanation: string }>,
-      improvementSuggestions: string,
-      overallScore: number,
-    };
+    // The model is constrained to the schema via structured output, so the result is
+    // already a validated object — no fragile text extraction or JSON.parse needed.
+    const parsed = result.output;
     parsed.overallScore = Math.max(0, Math.min(100, Math.round(parsed.overallScore)));
 
     update = {


### PR DESCRIPTION
## Problem

The QA reviewer (`apps/backend/src/lib/ai/qa-reviewer.ts`) extracted the model's JSON verdict from free-form text with a greedy `/\{[\s\S]*\}/` regex followed by `JSON.parse`. Whenever Haiku wrapped its JSON in prose or tool-call text, the captured slice was malformed and `JSON.parse` threw:

```
SyntaxError: Expected property name or '}' in JSON at position 1 (line 1 column 2)
```

This is Sentry issue **STACK-BACKEND-18F** — **218 occurrences in the last 30 days** (262 all-time), still ongoing. It's caught (background QA task, 0 users impacted) but noisy, and on failure the review is silently marked failed.

### Root cause
The brace-matching heuristic assumes the first `{` in the response starts the JSON object and the last `}` ends it. Any stray brace in surrounding prose (a preamble like `"Here's my review {note}: {...}"`, unquoted/single-quoted keys, or `<function_calls>` tool text) breaks the extraction. The reviewer output is non-deterministic, so a low steady fraction of reviews fail.

## Fix

Switch to schema-enforced **structured output** via `generateText`'s `output: Output.object({ schema })` (AI SDK v6), which keeps the existing tool-calling loop while constraining the final result to a validated object. The verdict is read directly off `result.output`, removing the regex, `JSON.parse`, and manual `typeof` shape validation.

- Net **−12 lines**.
- Trimmed the now-redundant "respond with ONLY valid JSON … {inline schema}" block from the system prompt (the schema enforces structure); kept the semantic guidance (flag types, scoring, `needsHumanReview` rule).
- Kept the existing `overallScore` clamp.

## Verification

- **Typecheck** (`tsc --noEmit`): clean.
- **Lint** (`eslint`): clean.
- **Live end-to-end**: ran the real Haiku-4.5 reviewer against the exact prompt/input that failed **11/15** on the old path → **15/15** return a validated object on the new path, zero parse failures.

## Follow-ups (out of scope, noted during investigation)
- These Sentry events leak a live access token + publishable key into the request-context payload; the OpenRouter key sits in plaintext (commented) in `apps/backend/.env.local`. Worth rotating/scrubbing.
- Consider capturing `result.text` on the failure path so any residual structured-output failures are inspectable (currently discarded).

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced regex/JSON.parse extraction in the QA reviewer with schema-enforced structured output using `ai`’s `generateText` + `Output.object`. Also defaulted `improvementSuggestions` to an empty string to avoid false failures when the model omits suggestions.

- **Bug Fixes**
  - Added a `zod` verdict schema and read result from `result.output`.
  - Removed greedy JSON extraction and manual shape checks.
  - Defaulted `improvementSuggestions` to "" to tolerate omission and prevent false `needsHumanReview` verdicts.
  - Slimmed prompt by dropping “respond with ONLY JSON” block; kept review guidance.
  - Kept `overallScore` clamp; tool-calling loop unchanged.
  - Verification: typecheck/lint clean; 15/15 successful runs on a previously failing case.

<sup>Written for commit 72ae71017fb4416f397435f0d56e1f7d5ddf292f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1688?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * QA reviews now use structured output, making review results more reliable and consistently formatted.
  * Review flags now include clearer details such as type, severity, and explanation.

* **Bug Fixes**
  * Improved handling of review output by removing fragile text parsing and manual JSON extraction.
  * Added safer defaults for missing review suggestions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->