### PR TITLE
Keep local emulator removal in a new migration, not edits to applied ones

### DIFF
--- a/apps/backend/prisma/migrations/20260226100000_add_local_emulator_project_mapping/tests/cascades-on-project-delete.ts
+++ b/apps/backend/prisma/migrations/20260226100000_add_local_emulator_project_mapping/tests/cascades-on-project-delete.ts
@@ -1,0 +1,30 @@
+import { randomUUID } from "crypto";
+import type { Sql } from "postgres";
+import { expect } from "vitest";
+
+export const preMigration = async (sql: Sql) => {
+  const projectId = `test-${randomUUID()}`;
+  await sql`
+    INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
+    VALUES (${projectId}, NOW(), NOW(), 'Cascade Test Project', '', false)
+  `;
+  return { projectId };
+};
+
+export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof preMigration>>) => {
+  const absoluteFilePath = `/tmp/${randomUUID()}/stack.config.ts`;
+
+  await sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${absoluteFilePath}, ${ctx.projectId}, NOW(), NOW())
+  `;
+
+  await sql`DELETE FROM "Project" WHERE "id" = ${ctx.projectId}`;
+
+  const rows = await sql`
+    SELECT "absoluteFilePath"
+    FROM "LocalEmulatorProject"
+    WHERE "absoluteFilePath" = ${absoluteFilePath}
+  `;
+  expect(rows).toHaveLength(0);
+};

--- a/apps/backend/prisma/migrations/20260226100000_add_local_emulator_project_mapping/tests/persists-and-enforces-uniqueness.ts
+++ b/apps/backend/prisma/migrations/20260226100000_add_local_emulator_project_mapping/tests/persists-and-enforces-uniqueness.ts
@@ -1,0 +1,44 @@
+import { randomUUID } from "crypto";
+import type { Sql } from "postgres";
+import { expect } from "vitest";
+
+export const preMigration = async (sql: Sql) => {
+  const projectId1 = `test-${randomUUID()}`;
+  const projectId2 = `test-${randomUUID()}`;
+
+  await sql`
+    INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
+    VALUES (${projectId1}, NOW(), NOW(), 'Local Emulator Project 1', '', false)
+  `;
+  await sql`
+    INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
+    VALUES (${projectId2}, NOW(), NOW(), 'Local Emulator Project 2', '', false)
+  `;
+
+  return { projectId1, projectId2 };
+};
+
+export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof preMigration>>) => {
+  const path1 = `/tmp/${randomUUID()}/stack.config.ts`;
+  const path2 = `/tmp/${randomUUID()}/stack.config.ts`;
+
+  await sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${path1}, ${ctx.projectId1}, NOW(), NOW())
+  `;
+
+  await expect(sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${path1}, ${ctx.projectId2}, NOW(), NOW())
+  `).rejects.toThrow(/LocalEmulatorProject_pkey/);
+
+  await expect(sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${path2}, ${ctx.projectId1}, NOW(), NOW())
+  `).rejects.toThrow(/LocalEmulatorProject_projectId_key/);
+
+  await sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${path2}, ${ctx.projectId2}, NOW(), NOW())
+  `;
+};

--- a/apps/backend/prisma/migrations/20260513000000_add_project_development_environment/migration.sql
+++ b/apps/backend/prisma/migrations/20260513000000_add_project_development_environment/migration.sql
@@ -1,2 +1,9 @@
 ALTER TABLE "Project"
 ADD COLUMN "isDevelopmentEnvironment" BOOLEAN NOT NULL DEFAULT false;
+
+UPDATE "Project"
+SET "isDevelopmentEnvironment" = true
+WHERE "id" IN (
+  SELECT "projectId"
+  FROM "LocalEmulatorProject"
+);

--- a/apps/backend/prisma/migrations/20260513000000_add_project_development_environment/tests/default-and-updates.ts
+++ b/apps/backend/prisma/migrations/20260513000000_add_project_development_environment/tests/default-and-updates.ts
@@ -4,11 +4,20 @@ import { expect } from "vitest";
 
 export const preMigration = async (sql: Sql) => {
   const projectId = `test-${randomUUID()}`;
+  const localEmulatorProjectId = `test-${randomUUID()}`;
   await sql`
     INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
     VALUES (${projectId}, NOW(), NOW(), 'Development Environment Flag Project', '', false)
   `;
-  return { projectId };
+  await sql`
+    INSERT INTO "Project" ("id", "createdAt", "updatedAt", "displayName", "description", "isProductionMode")
+    VALUES (${localEmulatorProjectId}, NOW(), NOW(), 'Existing Local Emulator Project', '', false)
+  `;
+  await sql`
+    INSERT INTO "LocalEmulatorProject" ("absoluteFilePath", "projectId", "createdAt", "updatedAt")
+    VALUES (${`/tmp/${randomUUID()}/stack.config.ts`}, ${localEmulatorProjectId}, NOW(), NOW())
+  `;
+  return { projectId, localEmulatorProjectId };
 };
 
 export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof preMigration>>) => {
@@ -20,4 +29,11 @@ export const postMigration = async (sql: Sql, ctx: Awaited<ReturnType<typeof pre
   expect(rows).toHaveLength(1);
   expect(rows[0].isDevelopmentEnvironment).toBe(false);
 
+  const localEmulatorRows = await sql`
+    SELECT "isDevelopmentEnvironment"
+    FROM "Project"
+    WHERE "id" = ${ctx.localEmulatorProjectId}
+  `;
+  expect(localEmulatorRows).toHaveLength(1);
+  expect(localEmulatorRows[0].isDevelopmentEnvironment).toBe(true);
 };


### PR DESCRIPTION
Follow-up to #1692. That PR edited two already-applied migrations to strip out `LocalEmulatorProject`. This reverts those in-place edits so the table removal lives only in the new drop migration, keeping migration history immutable.

Restored to their original form:
- `20260513000000_add_project_development_environment/migration.sql` — re-adds the `isDevelopmentEnvironment` backfill (`UPDATE "Project" ... WHERE id IN (SELECT projectId FROM "LocalEmulatorProject")`) and its test.
- `20260226100000_add_local_emulator_project_mapping/tests/{cascades-on-project-delete,persists-and-enforces-uniqueness}.ts` — the tests #1692 deleted.

The table is still created (20260226) and backfilled (20260513) at their original points in history, then dropped only by the new `20260630000000_drop_local_emulator_project_mapping` migration (unchanged). These migration tests reference `LocalEmulatorProject` even though it's gone from `schema.prisma`, which is correct: each runs at a point in history where the table exists or doesn't, as expected.

Migration suite passes (31/31), incl. `20260513 default-and-updates` and `20260630 table-dropped`.

Link to Devin session: https://app.devin.ai/sessions/3a54f6b9175e48048007600d09628f70
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reverts in-place edits to previously applied migrations and keeps the local emulator table removal in a new migration to preserve immutable history. Restores the 20260513 backfill and the 20260226 mapping tests; the table is dropped only in the 20260630 migration.

- **Migration**
  - Restored `isDevelopmentEnvironment` backfill in 20260513.
  - Re-added 20260226 tests for `LocalEmulatorProject` mapping (cascade and uniqueness).
  - Kept the drop in 20260630; earlier migrations unchanged. All migration tests pass (31/31).

<sup>Written for commit b410139cfe8cf1b963f9c4b1d1e159807c7aeb03. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1694?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for marking certain projects as development environments.
  * Projects linked to local emulator data are now automatically flagged as development environments.

* **Tests**
  * Added migration coverage for deletion cascades to ensure related emulator mappings are removed with a project.
  * Added migration coverage for uniqueness rules and default/update behavior of the new project flag.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->