### PR TITLE
feat: add recent triggers across all rules card to Sign-up Rules page

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
@@ -243,6 +243,17 @@ function ActionBadge({ type, dim = false, size = "sm" }: { type: ActionType, dim
   );
 }
 
+// Trigger rows contain user PII (email, auth method), so assertion metadata must only expose
+// non-sensitive diagnostics (which columns and value types came back), never the raw row.
+function triggerRowAssertionExtra(row: Record<string, unknown>, fieldName: string) {
+  const value = row[fieldName];
+  return {
+    fieldName,
+    actualType: value == null ? "null" : typeof value,
+    rowKeys: Object.keys(row),
+  };
+}
+
 function parseNullableStringField(row: Record<string, unknown>, fieldName: string, rowLabel: string): string | null {
   const value = row[fieldName];
   if (value == null) {
@@ -252,7 +263,7 @@ function parseNullableStringField(row: Record<string, unknown>, fieldName: strin
     return value;
   }
 
-  throw new HexclaveAssertionError(`Expected ${rowLabel} to include ${fieldName}:null|string`, { row });
+  throw new HexclaveAssertionError(`Expected ${rowLabel} to include ${fieldName}:null|string`, triggerRowAssertionExtra(row, fieldName));
 }
 
 function parseActionTypeField(row: Record<string, unknown>, fieldName: string): ActionType | null {
@@ -261,7 +272,7 @@ function parseActionTypeField(row: Record<string, unknown>, fieldName: string): 
     return null;
   }
   if (typeof value !== "string") {
-    throw new HexclaveAssertionError(`Expected sign-up rule trigger row to include ${fieldName}:null|string`, { row });
+    throw new HexclaveAssertionError(`Expected sign-up rule trigger row to include ${fieldName}:null|string`, triggerRowAssertionExtra(row, fieldName));
   }
   return isActionType(value) ? value : null;
 }
@@ -329,7 +340,7 @@ function parseRuleTriggerRows(resultRows: Record<string, unknown>[]): RuleTrigge
   return resultRows.map((row) => {
     const triggeredAt = row.triggered_at;
     if (typeof triggeredAt !== "string") {
-      throw new HexclaveAssertionError("Expected sign-up rule trigger row to include triggered_at:string", { row });
+      throw new HexclaveAssertionError("Expected sign-up rule trigger row to include triggered_at:string", triggerRowAssertionExtra(row, "triggered_at"));
     }
 
     const emailRaw = row.email;
@@ -340,7 +351,7 @@ function parseRuleTriggerRows(resultRows: Record<string, unknown>[]): RuleTrigge
       return { id: generateUuid(), triggeredAt, email: emailRaw };
     }
 
-    throw new HexclaveAssertionError("Expected sign-up rule trigger row to include email:null|string", { row });
+    throw new HexclaveAssertionError("Expected sign-up rule trigger row to include email:null|string", triggerRowAssertionExtra(row, "email"));
   });
 }
 
@@ -348,7 +359,7 @@ function parseAllRuleTriggerRows(resultRows: Record<string, unknown>[]): AllRule
   return resultRows.map((row) => {
     const triggeredAt = row.triggered_at;
     if (typeof triggeredAt !== "string") {
-      throw new HexclaveAssertionError("Expected sign-up rule trigger row to include triggered_at:string", { row });
+      throw new HexclaveAssertionError("Expected sign-up rule trigger row to include triggered_at:string", triggerRowAssertionExtra(row, "triggered_at"));
     }
 
     return {
@@ -468,7 +479,7 @@ function RecentTriggerRow({
   ruleDisplayNameById: Map<string, string>,
 }) {
   const { date, time, relative } = formatTriggerTime(trigger.triggeredAt);
-  const ruleDisplayName = trigger.ruleId == null ? null : ruleDisplayNameById.get(trigger.ruleId) || null;
+  const ruleDisplayName = trigger.ruleId == null ? null : ruleDisplayNameById.get(trigger.ruleId) ?? null;
   const isDeletedRule = trigger.ruleId != null && ruleDisplayName == null;
 
   return (
@@ -628,7 +639,7 @@ function RecentTriggersCard({
     runAsynchronouslyWithAlert(() => fetchTriggerPage({ offset: triggers.length, reset: false }));
   };
 
-  const hasActiveFilters = ruleFilter !== ALL_FILTER_VALUE || actionFilter !== ALL_FILTER_VALUE || debouncedEmailSearch !== "";
+  const hasActiveFilters = ruleFilter !== ALL_FILTER_VALUE || actionFilter !== ALL_FILTER_VALUE || emailSearchInput !== "" || debouncedEmailSearch !== "";
 
   return (
     <DesignCard

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
@@ -191,6 +191,8 @@ ORDER BY event_at DESC
 LIMIT {limit:UInt32}
 OFFSET {offset:UInt32}
 `;
+// Radix Select forbids empty-string item values, so the "all" option uses a sentinel that maps to an empty query param.
+const ALL_FILTER_VALUE = "__all__";
 const ALL_RULE_TRIGGER_EVENTS_QUERY = `
 SELECT
   event_at AS triggered_at,
@@ -526,8 +528,8 @@ function RecentTriggersCard({
 }) {
   const [emailSearchInput, setEmailSearchInput] = useState("");
   const [debouncedEmailSearch, setDebouncedEmailSearch] = useState("");
-  const [ruleFilter, setRuleFilter] = useState("");
-  const [actionFilter, setActionFilter] = useState("");
+  const [ruleFilter, setRuleFilter] = useState(ALL_FILTER_VALUE);
+  const [actionFilter, setActionFilter] = useState(ALL_FILTER_VALUE);
   const [triggers, setTriggers] = useState<AllRuleTriggerListItem[]>([]);
   const [hasMore, setHasMore] = useState(true);
   const [isInitialLoading, setIsInitialLoading] = useState(false);
@@ -543,7 +545,7 @@ function RecentTriggersCard({
     [signUpRules],
   );
   const ruleFilterOptions = useMemo(() => [
-    { value: "", label: "All rules" },
+    { value: ALL_FILTER_VALUE, label: "All rules" },
     ...signUpRules.map((entry) => ({
       value: entry.id,
       label: entry.rule.displayName || entry.id,
@@ -582,8 +584,8 @@ function RecentTriggersCard({
       const response = await hexclaveAdminApp.queryAnalytics({
         query: ALL_RULE_TRIGGER_EVENTS_QUERY,
         params: {
-          rule_id: ruleFilter,
-          action: actionFilter,
+          rule_id: ruleFilter === ALL_FILTER_VALUE ? "" : ruleFilter,
+          action: actionFilter === ALL_FILTER_VALUE ? "" : actionFilter,
           email_search: debouncedEmailSearch,
           limit: RULE_TRIGGER_EVENTS_PAGE_SIZE,
           offset,
@@ -626,7 +628,7 @@ function RecentTriggersCard({
     runAsynchronouslyWithAlert(() => fetchTriggerPage({ offset: triggers.length, reset: false }));
   };
 
-  const hasActiveFilters = ruleFilter !== "" || actionFilter !== "" || debouncedEmailSearch !== "";
+  const hasActiveFilters = ruleFilter !== ALL_FILTER_VALUE || actionFilter !== ALL_FILTER_VALUE || debouncedEmailSearch !== "";
 
   return (
     <DesignCard
@@ -657,7 +659,7 @@ function RecentTriggersCard({
             value={actionFilter}
             onValueChange={setActionFilter}
             options={[
-              { value: "", label: "All actions" },
+              { value: ALL_FILTER_VALUE, label: "All actions" },
               { value: "allow", label: "Allow" },
               { value: "reject", label: "Reject" },
               { value: "restrict", label: "Restrict" },

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sign-up-rules/page-client.tsx
@@ -59,6 +59,7 @@ import {
   ClockIcon,
   DotsSixVerticalIcon,
   FlaskIcon,
+  MagnifyingGlassIcon,
   PencilSimpleIcon,
   PlusIcon,
   PulseIcon,
@@ -106,6 +107,16 @@ type RuleTriggerListItem = {
   id: string,
   triggeredAt: string,
   email: string | null,
+};
+
+type AllRuleTriggerListItem = {
+  id: string,
+  triggeredAt: string,
+  ruleId: string | null,
+  action: ActionType | null,
+  email: string | null,
+  authMethod: string | null,
+  oauthProvider: string | null,
 };
 
 type SignUpRuleEntry = {
@@ -180,6 +191,29 @@ ORDER BY event_at DESC
 LIMIT {limit:UInt32}
 OFFSET {offset:UInt32}
 `;
+const ALL_RULE_TRIGGER_EVENTS_QUERY = `
+SELECT
+  event_at AS triggered_at,
+  COALESCE(
+    NULLIF(CAST(data.rule_id, 'Nullable(String)'), ''),
+    NULLIF(CAST(data.ruleId, 'Nullable(String)'), '')
+  ) AS rule_id,
+  CAST(data.action, 'Nullable(String)') AS action,
+  CAST(data.email, 'Nullable(String)') AS email,
+  CAST(data.auth_method, 'Nullable(String)') AS auth_method,
+  CAST(data.oauth_provider, 'Nullable(String)') AS oauth_provider
+FROM events
+WHERE event_type = '$sign-up-rule-trigger'
+  AND ({rule_id:String} = '' OR COALESCE(
+    NULLIF(CAST(data.rule_id, 'Nullable(String)'), ''),
+    NULLIF(CAST(data.ruleId, 'Nullable(String)'), '')
+  ) = {rule_id:String})
+  AND ({action:String} = '' OR CAST(data.action, 'Nullable(String)') = {action:String})
+  AND ({email_search:String} = '' OR positionCaseInsensitiveUTF8(COALESCE(CAST(data.email, 'Nullable(String)'), ''), {email_search:String}) > 0)
+ORDER BY event_at DESC
+LIMIT {limit:UInt32}
+OFFSET {offset:UInt32}
+`;
 
 const ACTION_LABELS: Record<ActionType, string> = {
   allow: 'Allow',
@@ -205,6 +239,29 @@ function ActionBadge({ type, dim = false, size = "sm" }: { type: ActionType, dim
       <DesignBadge label={ACTION_LABELS[type]} color={ACTION_BADGE_COLOR[type]} size={size} contentMode="text" />
     </span>
   );
+}
+
+function parseNullableStringField(row: Record<string, unknown>, fieldName: string, rowLabel: string): string | null {
+  const value = row[fieldName];
+  if (value == null) {
+    return null;
+  }
+  if (typeof value === "string") {
+    return value;
+  }
+
+  throw new HexclaveAssertionError(`Expected ${rowLabel} to include ${fieldName}:null|string`, { row });
+}
+
+function parseActionTypeField(row: Record<string, unknown>, fieldName: string): ActionType | null {
+  const value = row[fieldName];
+  if (value == null) {
+    return null;
+  }
+  if (typeof value !== "string") {
+    throw new HexclaveAssertionError(`Expected sign-up rule trigger row to include ${fieldName}:null|string`, { row });
+  }
+  return isActionType(value) ? value : null;
 }
 
 // Sparkline (kept identical — purely visual + tooltip)
@@ -282,6 +339,25 @@ function parseRuleTriggerRows(resultRows: Record<string, unknown>[]): RuleTrigge
     }
 
     throw new HexclaveAssertionError("Expected sign-up rule trigger row to include email:null|string", { row });
+  });
+}
+
+function parseAllRuleTriggerRows(resultRows: Record<string, unknown>[]): AllRuleTriggerListItem[] {
+  return resultRows.map((row) => {
+    const triggeredAt = row.triggered_at;
+    if (typeof triggeredAt !== "string") {
+      throw new HexclaveAssertionError("Expected sign-up rule trigger row to include triggered_at:string", { row });
+    }
+
+    return {
+      id: generateUuid(),
+      triggeredAt,
+      ruleId: parseNullableStringField(row, "rule_id", "sign-up rule trigger row"),
+      action: parseActionTypeField(row, "action"),
+      email: parseNullableStringField(row, "email", "sign-up rule trigger row"),
+      authMethod: parseNullableStringField(row, "auth_method", "sign-up rule trigger row"),
+      oauthProvider: parseNullableStringField(row, "oauth_provider", "sign-up rule trigger row"),
+    };
   });
 }
 
@@ -379,6 +455,270 @@ function TriggerRow({ trigger }: { trigger: RuleTriggerListItem }) {
       </div>
       <DesignBadge label={relative} color="blue" size="sm" />
     </div>
+  );
+}
+
+function RecentTriggerRow({
+  trigger,
+  ruleDisplayNameById,
+}: {
+  trigger: AllRuleTriggerListItem,
+  ruleDisplayNameById: Map<string, string>,
+}) {
+  const { date, time, relative } = formatTriggerTime(trigger.triggeredAt);
+  const ruleDisplayName = trigger.ruleId == null ? null : ruleDisplayNameById.get(trigger.ruleId) || null;
+  const isDeletedRule = trigger.ruleId != null && ruleDisplayName == null;
+
+  return (
+    <div className="group flex items-start gap-3 px-3 py-2.5 transition-colors duration-150 hover:bg-foreground/[0.03] hover:transition-none">
+      <div className="h-8 w-8 rounded-lg bg-foreground/[0.04] ring-1 ring-foreground/[0.06] flex items-center justify-center shrink-0 mt-0.5">
+        <ClockIcon className="h-4 w-4 text-muted-foreground" />
+      </div>
+      <div className="min-w-0 flex-1 space-y-1">
+        <div className="flex flex-wrap items-center gap-2 min-w-0">
+          {ruleDisplayName != null ? (
+            <Typography className="text-xs font-medium truncate" title={ruleDisplayName}>
+              {ruleDisplayName}
+            </Typography>
+          ) : isDeletedRule ? (
+            <Typography
+              variant="secondary"
+              className="text-xs italic truncate"
+              title={trigger.ruleId == null ? undefined : trigger.ruleId}
+            >
+              deleted rule · {trigger.ruleId}
+            </Typography>
+          ) : (
+            <Typography variant="secondary" className="text-xs italic truncate">
+              unknown rule
+            </Typography>
+          )}
+          {trigger.action == null ? null : <ActionBadge type={trigger.action} dim />}
+        </div>
+        <div className="flex items-center gap-2 min-w-0">
+          <UserIcon className="h-3.5 w-3.5 text-muted-foreground/70 shrink-0" />
+          {trigger.email != null ? (
+            <Typography className="text-xs font-mono truncate">{trigger.email}</Typography>
+          ) : (
+            <Typography variant="secondary" className="text-xs italic">no email captured</Typography>
+          )}
+        </div>
+        <div className="flex flex-wrap items-center gap-2 text-[10px] text-muted-foreground">
+          {trigger.authMethod != null ? <span className="truncate">auth: {trigger.authMethod}</span> : null}
+          {trigger.oauthProvider != null ? <span className="truncate">oauth: {trigger.oauthProvider}</span> : null}
+        </div>
+      </div>
+      <div className="hidden sm:flex flex-col items-end shrink-0 leading-tight mt-0.5">
+        <Typography className="text-xs font-medium tabular-nums">{time}</Typography>
+        <Typography variant="secondary" className="text-[10px] tabular-nums">{date}</Typography>
+      </div>
+      <DesignBadge label={relative} color="blue" size="sm" />
+    </div>
+  );
+}
+
+function RecentTriggersCard({
+  signUpRules,
+  hexclaveAdminApp,
+}: {
+  signUpRules: SignUpRuleEntry[],
+  hexclaveAdminApp: ReturnType<typeof useAdminApp>,
+}) {
+  const [emailSearchInput, setEmailSearchInput] = useState("");
+  const [debouncedEmailSearch, setDebouncedEmailSearch] = useState("");
+  const [ruleFilter, setRuleFilter] = useState("");
+  const [actionFilter, setActionFilter] = useState("");
+  const [triggers, setTriggers] = useState<AllRuleTriggerListItem[]>([]);
+  const [hasMore, setHasMore] = useState(true);
+  const [isInitialLoading, setIsInitialLoading] = useState(false);
+  const [isLoadingMore, setIsLoadingMore] = useState(false);
+  const [loadingError, setLoadingError] = useState<string | null>(null);
+  const latestRequestIdRef = useRef(0);
+  const hasMoreRef = useRef(true);
+  const isInitialLoadingRef = useRef(false);
+  const isLoadingMoreRef = useRef(false);
+
+  const ruleDisplayNameById = useMemo(
+    () => new Map(signUpRules.map((entry) => [entry.id, entry.rule.displayName ?? entry.id] as const)),
+    [signUpRules],
+  );
+  const ruleFilterOptions = useMemo(() => [
+    { value: "", label: "All rules" },
+    ...signUpRules.map((entry) => ({
+      value: entry.id,
+      label: entry.rule.displayName || entry.id,
+    })),
+  ], [signUpRules]);
+
+  React.useEffect(() => {
+    const timeoutId = window.setTimeout(() => {
+      setDebouncedEmailSearch(emailSearchInput.trim());
+    }, 300);
+    return () => window.clearTimeout(timeoutId);
+  }, [emailSearchInput]);
+
+  const fetchTriggerPage = React.useCallback(async ({ offset, reset }: { offset: number, reset: boolean }) => {
+    if (!reset && (!hasMoreRef.current || isLoadingMoreRef.current || isInitialLoadingRef.current)) {
+      return;
+    }
+
+    const nextRequestId = latestRequestIdRef.current + 1;
+    latestRequestIdRef.current = nextRequestId;
+    if (reset) {
+      setIsInitialLoading(true);
+      isInitialLoadingRef.current = true;
+      setIsLoadingMore(false);
+      isLoadingMoreRef.current = false;
+      setLoadingError(null);
+      setHasMore(true);
+      hasMoreRef.current = true;
+      setTriggers([]);
+    } else {
+      setIsLoadingMore(true);
+      isLoadingMoreRef.current = true;
+    }
+
+    try {
+      const response = await hexclaveAdminApp.queryAnalytics({
+        query: ALL_RULE_TRIGGER_EVENTS_QUERY,
+        params: {
+          rule_id: ruleFilter,
+          action: actionFilter,
+          email_search: debouncedEmailSearch,
+          limit: RULE_TRIGGER_EVENTS_PAGE_SIZE,
+          offset,
+        },
+        timeout_ms: 30_000,
+        include_all_branches: false,
+      });
+
+      if (nextRequestId !== latestRequestIdRef.current) return;
+
+      const parsedRows = parseAllRuleTriggerRows(response.result);
+      setTriggers((current) => reset ? parsedRows : [...current, ...parsedRows]);
+      setHasMore(parsedRows.length === RULE_TRIGGER_EVENTS_PAGE_SIZE);
+      hasMoreRef.current = parsedRows.length === RULE_TRIGGER_EVENTS_PAGE_SIZE;
+    } catch (error) {
+      if (nextRequestId !== latestRequestIdRef.current) return;
+      setLoadingError(error instanceof Error ? error.message : "Failed to load triggers");
+    } finally {
+      if (nextRequestId === latestRequestIdRef.current) {
+        if (reset) {
+          setIsInitialLoading(false);
+          isInitialLoadingRef.current = false;
+        } else {
+          setIsLoadingMore(false);
+          isLoadingMoreRef.current = false;
+        }
+      }
+    }
+  }, [actionFilter, debouncedEmailSearch, hexclaveAdminApp, ruleFilter]);
+
+  React.useEffect(() => {
+    runAsynchronouslyWithAlert(() => fetchTriggerPage({ offset: 0, reset: true }));
+  }, [fetchTriggerPage]);
+
+  const handleScroll: React.UIEventHandler<HTMLDivElement> = (event) => {
+    if (!hasMoreRef.current || isInitialLoadingRef.current || isLoadingMoreRef.current) return;
+    const target = event.currentTarget;
+    const remainingScrollPx = target.scrollHeight - target.scrollTop - target.clientHeight;
+    if (remainingScrollPx > 120) return;
+    runAsynchronouslyWithAlert(() => fetchTriggerPage({ offset: triggers.length, reset: false }));
+  };
+
+  const hasActiveFilters = ruleFilter !== "" || actionFilter !== "" || debouncedEmailSearch !== "";
+
+  return (
+    <DesignCard
+      title="Recent triggers"
+      subtitle="Across all sign-up rules"
+      icon={PulseIcon}
+      gradient="default"
+    >
+      <div className="space-y-3">
+        <div className="flex flex-wrap items-end gap-2">
+          <DesignInput
+            value={emailSearchInput}
+            onChange={(event) => setEmailSearchInput(event.target.value)}
+            placeholder="Search by email…"
+            leadingIcon={<MagnifyingGlassIcon className="h-3.5 w-3.5" />}
+            size="sm"
+            className="min-w-0 flex-1 sm:min-w-72"
+          />
+          <DesignSelectorDropdown
+            value={ruleFilter}
+            onValueChange={setRuleFilter}
+            options={ruleFilterOptions}
+            size="sm"
+            className="w-full sm:w-48"
+            placeholder="All rules"
+          />
+          <DesignSelectorDropdown
+            value={actionFilter}
+            onValueChange={setActionFilter}
+            options={[
+              { value: "", label: "All actions" },
+              { value: "allow", label: "Allow" },
+              { value: "reject", label: "Reject" },
+              { value: "restrict", label: "Restrict" },
+              { value: "log", label: "Log" },
+            ]}
+            size="sm"
+            className="w-full sm:w-44"
+            placeholder="All actions"
+          />
+        </div>
+        {!isInitialLoading && triggers.length > 0 && (
+          <div className="flex justify-end">
+            <Typography variant="secondary" className="text-[11px] tabular-nums">
+              showing {triggers.length}{hasMore ? "+" : ""}
+            </Typography>
+          </div>
+        )}
+
+        {loadingError == null ? null : (
+          <DesignAlert variant="error" description={loadingError} />
+        )}
+
+        <div
+          className={cn("max-h-[360px] overflow-auto rounded-xl", ruleCardMutedSurfaceClass)}
+          onScroll={handleScroll}
+        >
+          {isInitialLoading ? (
+            <div className="space-y-2 p-3">
+              {["one", "two", "three", "four", "five"].map((skeletonId) => (
+                <DesignSkeleton key={skeletonId} className="h-12 rounded-lg" />
+              ))}
+            </div>
+          ) : triggers.length === 0 ? (
+            <DesignEmptyState
+              icon={ClockIcon}
+              title="No triggers found"
+              description={
+                hasActiveFilters
+                  ? "Try broadening your search or clearing the filters."
+                  : "No sign-up rule triggers have been recorded yet."
+              }
+            />
+          ) : (
+            <div className="divide-y divide-foreground/[0.06]">
+              {triggers.map((trigger) => (
+                <RecentTriggerRow
+                  key={trigger.id}
+                  trigger={trigger}
+                  ruleDisplayNameById={ruleDisplayNameById}
+                />
+              ))}
+            </div>
+          )}
+          {isLoadingMore ? (
+            <div className="p-3">
+              <DesignSkeleton className="h-10 rounded-lg" />
+            </div>
+          ) : null}
+        </div>
+      </div>
+    </DesignCard>
   );
 }
 
@@ -1725,6 +2065,10 @@ function PageBody(props: PageBodyProps) {
           value={props.defaultAction}
           onChange={props.onDefaultActionChange}
         />
+
+        <div className="pt-10">
+          <RecentTriggersCard signUpRules={props.signUpRules} hexclaveAdminApp={props.hexclaveAdminApp} />
+        </div>
 
         <div className="pt-10">
           <TestRulesPanel hexclaveAdminApp={props.hexclaveAdminApp} />


### PR DESCRIPTION
## Summary
Adds a **Recent triggers** card to the Sign-up Rules page listing `$sign-up-rule-trigger` events across *all* rules (the existing sparkline dialog only showed one rule at a time). It's searchable by email and filterable by rule and action.

Filtering is done **server-side** in the ClickHouse query so pagination stays correct across the full event set (rather than filtering already-fetched pages, which would leave gaps):

```sql
WHERE event_type = '$sign-up-rule-trigger'
  AND ({rule_id} = '' OR <coalesced rule id> = {rule_id})
  AND ({action} = '' OR action = {action})
  AND ({email_search} = '' OR positionCaseInsensitiveUTF8(email, {email_search}) > 0)
ORDER BY event_at DESC LIMIT {limit} OFFSET {offset}
```

The card reuses the existing trigger-dialog mechanics (infinite-scroll pagination, request-id race guarding, loading/error/empty states). Email input is debounced (~300ms); changing any filter resets pagination. Each row resolves `rule_id` → display name from config, shows an action badge, email, auth method / OAuth provider, and timestamp, with a "deleted rule" hint when the id is no longer in config.


Link to Devin session: https://app.devin.ai/sessions/1f017f3f0093441a94ae7cda221e2903
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a Recent triggers card to the Sign-up Rules page that lists `$sign-up-rule-trigger` events across all rules. Server-side filtering keeps pagination accurate while supporting search and filters.

- **New Features**
  - Search by email (debounced ~300ms); filter by rule and action.
  - Server-side ClickHouse query applies filters; pagination stays consistent.
  - Infinite scroll with request-id race guards; loading, error, and empty states.
  - Rows show rule display name (with “deleted rule” hint), action badge, email, auth method/provider, and timestamp.

- **Bug Fixes**
  - Use a non-empty sentinel for “All rules”/“All actions” to satisfy Radix Select and map to empty query params, fixing a page crash on load.
  - Redact PII from parse assertion metadata; only column names and value types are logged.
  - Correct rule labeling and empty-state UX: don’t treat empty displayName as deleted, and include live email input in filter state during debounce.

<sup>Written for commit 3d0a0e88583384c3fe0f5fa947523b264b54a2c4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1703?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a “Recent triggers” view for sign-up rules with debounced email search, rule/action filters, infinite scrolling pagination, and clear loading/empty states.
  * Enhanced trigger rows to show richer context including email, rule name, action, authentication method, and provider details.
* **Bug Fixes**
  * Improved resilience when trigger data references missing or deleted rules, keeping history readable instead of failing.
* **Refactor**
  * Updated the main dashboard panel to display the new “Recent triggers” card.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->