### PR TITLE
fix(events): fail open on bulldozer outage for analytics quota check

### DIFF
--- a/apps/backend/src/lib/events.tsx
+++ b/apps/backend/src/lib/events.tsx
@@ -6,7 +6,7 @@ import { runAsynchronouslyAndWaitUntil } from "@/utils/background-tasks";
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { urlSchema, yupBoolean, yupMixed, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 import { getEnvVariable, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
-import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { HTTP_METHODS } from "@hexclave/shared/dist/utils/http";
 import { filterUndefined, typedKeys } from "@hexclave/shared/dist/utils/objects";
 import { UnionToIntersection } from "@hexclave/shared/dist/utils/types";
@@ -278,9 +278,17 @@ export async function logEvent<T extends EventType[]>(
     const billingTeamId = options.billingTeamId;
 
     if (billingTeamId != null && arePlanLimitsEnforced()) {
-      const app = getHexclaveServerApp();
-      const eventsItem = await app.getItem({ itemId: ITEM_IDS.analyticsEvents, teamId: billingTeamId });
-      const isDebited = await eventsItem.tryDecreaseQuantity(1);
+      // The analytics-events quota lives in bulldozer, but event logging must
+      // not hard-depend on it: if bulldozer is unreachable, report it and log
+      // the event anyway (treat the quota as available)
+      let isDebited = true;
+      try {
+        const app = getHexclaveServerApp();
+        const eventsItem = await app.getItem({ itemId: ITEM_IDS.analyticsEvents, teamId: billingTeamId });
+        isDebited = await eventsItem.tryDecreaseQuantity(1);
+      } catch (error) {
+        captureError("events:analytics-events-quota-check", error);
+      }
       if (!isDebited) {
         return;
       }


### PR DESCRIPTION
## Summary

Makes analytics event logging **fail open** when bulldozer is unreachable, so bulldozer is not a hard dependency for anything outside payment routes.

Previously, in `logEvent` the analytics-events quota check (`app.getItem(...)` + `tryDecreaseQuantity(1)`) would **throw** on a bulldozer outage and short-circuit before `event.create`, silently dropping the event — including auth events like `$token-refresh` and `$sign-up-rule-trigger`. Now the bulldozer calls are wrapped in try/catch: on failure we `captureError` and treat the quota as available, so the event is still logged. A genuine over-quota rejection (`isDebited === false`) still drops the event as before.

This mirrors the fail-open pattern already used at every other non-payment site that reads bulldozer (`plan-entitlements.getTeamWideItemCapacity`, the team-invite accept routes, and the email-queue quota gate in `fef19c6b0`).

## Context

Audit of bulldozer usage confirmed no non-payment surface hard-depends on it anymore:

| Path | Status |
|---|---|
| Analytics logging (`events.tsx`) | ✅ fixed here — fails open |
| Email delivery (`email-queue-step.tsx`) | ✅ fails open (`fef19c6b0`) |
| Team creation, user creation | ✅ fire-and-forget |
| Team-invite accept, entitlement caps | ✅ try/catch fail-open |
| Payment routes | depends on bulldozer by design |

## Testing

- `pnpm --filter @hexclave/backend typecheck` ✅
- `pnpm --filter @hexclave/backend lint` ✅


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fail open the analytics quota check when bulldozer is unreachable so events are still logged outside payment routes. In `logEvent`, wrap `getItem`/`tryDecreaseQuantity` in try/catch, call `captureError`, and continue; real over‑quota still drops.

<sup>Written for commit 399999779174ed53d84af6ba099b531c9a713fcf. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1709?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

