### PR TITLE
fix(bulldozer): preserve timefold history across source-row rewrites

### DIFF
--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -432,6 +432,60 @@ describe("Bulldozer", () => {
     expect(await rows(snapshot, "time")).toEqual([]);
   });
 
+  it("keeps emitted outputs and fold state across source updates with onSourceRowChanged", async () => {
+    const firstTrigger = Date.UTC(2026, 0, 1, 0, 0, 1);
+    const secondTrigger = Date.UTC(2026, 0, 1, 0, 0, 2);
+    const changedCalls: Array<{ state: PiledriverObject, rowData: PiledriverObject, oldRowData: PiledriverObject, previousTrigger: number | null }> = [];
+    const fold = declareTimeFoldTable({
+      initialState: 0,
+      reducer: async (state, row, trigger) => {
+        const count = Number(state) + 1;
+        return {
+          newState: count,
+          newRowData: `${row.rowData}:${trigger ? count : "initial"}`,
+          nextTriggerTime: trigger ? null : new Date(firstTrigger),
+        };
+      },
+      onSourceRowChanged: async (state, row, previous) => {
+        changedCalls.push({ state, rowData: row.rowData, oldRowData: previous.rowData, previousTrigger: previous.nextTriggerTime?.getTime() ?? null });
+        return { newState: Number(state) + 100, nextTriggerTime: new Date(secondTrigger) };
+      },
+    });
+    let snapshot = await initializedSnapshot([[
+      { type: "initTable", tableId: "store", table: defineStoredTable(), inputTables: {} },
+      { type: "initTable", tableId: "time", table: fold, inputTables: { input: "store" } },
+    ]]);
+
+    snapshot = await set(snapshot, "store", "a", "A");
+    snapshot = await snapshot.tick(new Date(firstTrigger));
+    expect(await rows(snapshot, "time")).toEqual([
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 0]), rowSortKey: null, rowData: "A:initial" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 1]), rowSortKey: null, rowData: "A:2" },
+    ]);
+
+    // The update keeps all previously emitted outputs verbatim (no deletions, no re-derivation)
+    // and hands the fold state + old row to the hook instead of re-running from initialState.
+    snapshot = await set(snapshot, "store", "a", "B");
+    expect(await rows(snapshot, "time")).toEqual([
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 0]), rowSortKey: null, rowData: "A:initial" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 1]), rowSortKey: null, rowData: "A:2" },
+    ]);
+    expect(changedCalls).toEqual([{ state: 2, rowData: "B", oldRowData: "A", previousTrigger: null }]);
+
+    // The hook's returned state and trigger drive subsequent timed steps: the next tick appends
+    // (using the carried-over state) instead of replaying history.
+    snapshot = await snapshot.tick(new Date(secondTrigger));
+    expect(await rows(snapshot, "time")).toEqual([
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 0]), rowSortKey: null, rowData: "A:initial" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 1]), rowSortKey: null, rowData: "A:2" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 2]), rowSortKey: null, rowData: "B:103" },
+    ]);
+
+    // Deleting the source row still removes everything.
+    snapshot = await set(snapshot, "store", "a", undefined);
+    expect(await rows(snapshot, "time")).toEqual([]);
+  });
+
   it("ticks all tickable tables from the snapshot object", async () => {
     const trigger = Date.UTC(2026, 0, 1, 0, 0, 1);
     const db = newDb([[

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -2225,8 +2225,16 @@ export function declareLeftFoldTable(options: {
  *
  * Each input row runs once immediately with `triggerTimeIfRepeated = null`. If the reducer
  * returns `nextTriggerTime`, database/snapshot `tick(now)` processes queued rows whose trigger
- * time is due. Timed reruns append output rows for that source row; source updates reset that
- * source row's emitted outputs and fold state.
+ * time is due. Timed reruns append output rows for that source row.
+ *
+ * Source-row updates come in two flavors:
+ * - Without `onSourceRowChanged`, an update resets that source row's emitted outputs and fold
+ *   state and re-runs the reducer from `initialState` — previously emitted outputs are deleted
+ *   and past trigger times replay (against the *new* row data) on subsequent ticks.
+ * - With `onSourceRowChanged`, an update keeps the row's emitted outputs, fold state, and timer
+ *   progress; the hook folds the new row data into the existing state and returns the next
+ *   trigger time. Use this when emitted outputs are append-only facts (e.g. a ledger) that a
+ *   source rewrite must not retract or rederive.
  */
 export function declareTimeFoldTable(options: {
   initialState: PiledriverObject,
@@ -2235,6 +2243,11 @@ export function declareTimeFoldTable(options: {
     row: { groupKey: PiledriverObject, rowIdentifier: string, rowSortKey: PiledriverObject, rowData: PiledriverObject },
     triggerTimeIfRepeated: Date | null,
   ) => Promise<{ newState: PiledriverObject, newRowData: PiledriverObject, nextTriggerTime: Date | null }>,
+  onSourceRowChanged?: (
+    state: PiledriverObject,
+    row: { groupKey: PiledriverObject, rowIdentifier: string, rowSortKey: PiledriverObject, rowData: PiledriverObject },
+    previous: { rowData: PiledriverObject, nextTriggerTime: Date | null },
+  ) => Promise<{ newState: PiledriverObject, nextTriggerTime: Date | null }>,
 }): BulldozerTableImplementation {
   type SourceRow = { groupKey: PiledriverObject, rowIdentifier: string, rowSortKey: PiledriverObject, rowData: PiledriverObject };
   type RowState = SourceRow & {
@@ -2365,6 +2378,20 @@ export function declareTimeFoldTable(options: {
     state = await replaceOutputs(state, oldRow, newRow, outputChanges);
     return await addQueuedTrigger(state, newRow);
   };
+  const updateSourceRow = async (state: State, row: SourceRow, outputChanges: TableChanges, onSourceRowChanged: NonNullable<typeof options.onSourceRowChanged>) => {
+    const oldRow = await state.rows.get(row.rowIdentifier);
+    if (oldRow === undefined) return await setSourceRow(state, row, outputChanges);
+    state = await removeQueuedTrigger(state, oldRow);
+    const result = await onSourceRowChanged(oldRow.state, row, {
+      rowData: oldRow.rowData,
+      nextTriggerTime: oldRow.nextTriggerTimeMs === null ? null : new Date(oldRow.nextTriggerTimeMs),
+    });
+    const newRow: RowState = { ...row, state: result.newState, nextTriggerTimeMs: toTimestampMs(result.nextTriggerTime), emittedRows: oldRow.emittedRows };
+    state = { ...state, rows: await state.rows.set(row.rowIdentifier, newRow) };
+    // emittedRows are carried over verbatim (and modified rows never change group), so the
+    // materialized output rows are untouched and no output changes are emitted.
+    return await addQueuedTrigger(state, newRow);
+  };
   const deleteSourceRow = async (state: State, rowIdentifier: string, outputChanges: TableChanges) => {
     const oldRow = await state.rows.get(rowIdentifier);
     if (!oldRow) return state;
@@ -2418,6 +2445,10 @@ export function declareTimeFoldTable(options: {
       const outputChanges = emptyTableChanges();
       for (const { groupKey } of changes.input.addedGroups) outputChanges.addedGroups.push({ groupKey });
       for (const row of changedRowsFromTableChanges(changes.input)) {
+        if (row.old && row.new && options.onSourceRowChanged) {
+          state = await updateSourceRow(state, row.new, outputChanges, options.onSourceRowChanged);
+          continue;
+        }
         if (row.old) state = await deleteSourceRow(state, row.old.rowIdentifier, outputChanges);
         if (row.new) state = await setSourceRow(state, row.new, outputChanges);
       }

--- a/apps/bulldozer-js/src/payments/schema/index.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.test.ts
@@ -255,6 +255,118 @@ describe("payments schema", () => {
     expect(asRecord(asRecord(owned.ownedProducts)["prod-repeat"]).quantity).toBe(0);
   });
 
+  it("preserves emitted repeat grants when the subscription row is rewritten", async () => {
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    const firstRepeatMillis = Date.UTC(1970, 1, 1);
+    const secondRepeatMillis = Date.UTC(1970, 2, 1);
+    // expires: "never" makes the grants accumulate, which is exactly the shape that a re-derived
+    // history would corrupt (an upgrade would retroactively double every past month's grant).
+    const subRow = (overrides: Partial<Parameters<typeof subscription>[1]> = {}) => subscription("sub-rewrite", {
+      customerId: "u-rewrite",
+      productId: "prod-rewrite",
+      product: product({ credits: { quantity: 10, repeat: [1, "month"], expires: "never" } }),
+      currentPeriodEndMillis: Date.UTC(1971, 0, 1),
+      ...overrides,
+    }) as unknown as PiledriverObject;
+    snapshot = await set(snapshot, schema.subscriptions, "sub-rewrite", subRow());
+    snapshot = await snapshot.tick(new Date(firstRepeatMillis));
+
+    const group = customerGroup("u-rewrite");
+    const txnIds = async () => ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[]).map(txn => txn.txnId).sort(stringCompare);
+    expect(await txnIds()).toEqual([`igr:sub-rewrite:${firstRepeatMillis}`, "sub-start:sub-rewrite"]);
+    expect(await balanceAt(snapshot, group, "credits", firstRepeatMillis)).toBe(20);
+
+    // Renewal-style webhook resync: same product/quantity, only volatile fields move. The ledger
+    // must be untouched *immediately* after the write — the reset-on-update behavior deleted every
+    // item-grant-repeat transaction here and only restored them on the next tick.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-rewrite", subRow({ status: "past_due", currentPeriodStartMillis: firstRepeatMillis }));
+    expect(await txnIds()).toEqual([`igr:sub-rewrite:${firstRepeatMillis}`, "sub-start:sub-rewrite"]);
+    expect(await balanceAt(snapshot, group, "credits", firstRepeatMillis)).toBe(20);
+
+    // Quantity upgrade: history keeps the originally granted quantities; only future repeats scale.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-rewrite", subRow({ quantity: 2, currentPeriodStartMillis: firstRepeatMillis }));
+    expect(await balanceAt(snapshot, group, "credits", firstRepeatMillis)).toBe(20);
+    snapshot = await snapshot.tick(new Date(secondRepeatMillis));
+    expect(await balanceAt(snapshot, group, "credits", secondRepeatMillis)).toBe(40);
+    const secondGrant = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[]).find(txn => txn.txnId === `igr:sub-rewrite:${secondRepeatMillis}`);
+    expect(secondGrant?.entries).toMatchObject([{ type: "item-quantity-change", itemId: "credits", quantity: 20 }]);
+  });
+
+  it("preserves emitted one-time-purchase repeat grants when the purchase row is rewritten", async () => {
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    const firstRepeatMillis = Date.UTC(1970, 1, 1);
+    const otpRow = (overrides: Record<string, PiledriverObject> = {}) => ({
+      id: "otp-rewrite",
+      tenancyId: "t1",
+      customerId: "u-otp-rewrite",
+      customerType: "user",
+      productId: "prod-otp",
+      priceId: null,
+      product: product({ credits: { quantity: 5, repeat: [1, "month"], expires: "never" } }),
+      quantity: 1,
+      stripePaymentIntentId: "pi-rewrite",
+      revokedAtMillis: null,
+      refundedAtMillis: null,
+      creationSource: "PURCHASE_PAGE",
+      createdAtMillis: 0,
+      ...overrides,
+    });
+    snapshot = await set(snapshot, schema.oneTimePurchases, "otp-rewrite", otpRow());
+    snapshot = await snapshot.tick(new Date(firstRepeatMillis));
+
+    const group = customerGroup("u-otp-rewrite");
+    expect(await balanceAt(snapshot, group, "credits", firstRepeatMillis)).toBe(10);
+
+    // Revocation arrives as a rewrite of the purchase row: the already-granted repeat must
+    // survive the write, and future repeats stop at the revocation.
+    snapshot = await set(snapshot, schema.oneTimePurchases, "otp-rewrite", otpRow({ revokedAtMillis: Date.UTC(1970, 1, 10) }));
+    expect(await balanceAt(snapshot, group, "credits", firstRepeatMillis)).toBe(10);
+    snapshot = await snapshot.tick(new Date(Date.UTC(1970, 2, 1)));
+    const txnIds = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[]).map(txn => txn.txnId).sort(stringCompare);
+    expect(txnIds).toEqual([`igr:otp-rewrite:${firstRepeatMillis}`, "otp:otp-rewrite"]);
+  });
+
+  it("ends a subscription via a row rewrite and seals the fold against further rewrites", async () => {
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    const firstRepeatMillis = Date.UTC(1970, 1, 1);
+    const subEndMillis = Date.UTC(1970, 1, 15);
+    const subRow = (overrides: Partial<Parameters<typeof subscription>[1]> = {}) => subscription("sub-seal", {
+      customerId: "u-seal",
+      productId: "prod-seal",
+      product: product({ credits: { quantity: 10, repeat: [1, "month"], expires: "when-repeated" } }),
+      currentPeriodEndMillis: Date.UTC(1970, 2, 1),
+      ...overrides,
+    }) as unknown as PiledriverObject;
+    snapshot = await set(snapshot, schema.subscriptions, "sub-seal", subRow());
+    snapshot = await snapshot.tick(new Date(firstRepeatMillis));
+
+    // Cancellation arrives as a rewrite of the live row (that's how the Stripe sync works); the
+    // end event must fire off the *existing* fold state, expiring the actually-emitted grants.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-seal", subRow({ status: "canceled", endedAtMillis: subEndMillis, canceledAtMillis: subEndMillis }));
+    snapshot = await snapshot.tick(new Date(subEndMillis));
+
+    const group = customerGroup("u-seal");
+    const txns = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[])
+      .sort((a, b) => a.effectiveAtMillis - b.effectiveAtMillis || stringCompare(a.txnId, b.txnId));
+    expect(txns.map(txn => txn.txnId)).toEqual(["sub-start:sub-seal", `igr:sub-seal:${firstRepeatMillis}`, "sub-end:sub-seal"]);
+    expect(txns[2].entries).toMatchObject([
+      { type: "active-subscription-end", subscriptionId: "sub-seal" },
+      { type: "product-revocation", adjustedTransactionId: "sub-start:sub-seal", quantity: 1 },
+      { type: "item-quantity-expire", adjustedTransactionId: `igr:sub-seal:${firstRepeatMillis}`, itemId: "credits", quantity: 10 },
+    ]);
+    expect(await balanceAt(snapshot, group, "credits", subEndMillis)).toBe(0);
+
+    // Once ended, further webhook rewrites must not re-arm the fold: no duplicate subscription-end,
+    // no resumed repeats past the end.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-seal", subRow({ status: "canceled", endedAtMillis: subEndMillis, canceledAtMillis: subEndMillis, currentPeriodStartMillis: firstRepeatMillis }));
+    snapshot = await snapshot.tick(new Date(Date.UTC(1970, 3, 1)));
+    const txnIdsAfter = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[]).map(txn => txn.txnId).sort(stringCompare);
+    expect(txnIdsAfter).toEqual([`igr:sub-seal:${firstRepeatMillis}`, "sub-end:sub-seal", "sub-start:sub-seal"]);
+  });
+
   it("treats a manual item quantity change whose expiry is at/before its grant as a no-op", async () => {
     const schema = createPaymentsSchema();
     let snapshot = await initializedSnapshot();

--- a/apps/bulldozer-js/src/payments/schema/index.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.ts
@@ -249,6 +249,52 @@ const grantRefsToExpire = (grants: OutstandingGrant[], expiresWhen: "when-repeat
     .filter(grant => (expiresWhen === "both" ? grant.expiresWhen === "when-repeated" || grant.expiresWhen === "when-purchase-expires" : grant.expiresWhen === expiresWhen))
     .filter(grant => dueItemIds === undefined || dueItemIds.has(grant.itemId))
     .map(grant => ({ transactionId: grant.txnId, entryIndex: grant.entryIndex, itemId: grant.itemId, quantity: grant.quantity }));
+// The most recent repeat boundary this schedule has already granted, used as the floor when
+// fast-forwarding items that appear (or change interval) on a rewritten source row. Falls back to
+// `fallbackMillis` (purchase creation) when nothing has repeated yet.
+const processedThroughMillis = (schedule: RepeatSchedule, fallbackMillis: number): number => Math.max(
+  fallbackMillis,
+  ...Object.values(schedule).flatMap(entry => entry.interval !== null && entry.occurrencesElapsed > 0
+    ? [nthDayIntervalMillis(entry.anchorMillis, entry.interval, entry.occurrencesElapsed)]
+    : []),
+);
+// Advance a fresh schedule entry (anchored at purchase creation) past `floorMillis`. Every
+// already-granted boundary is <= floorMillis, so starting strictly after it means an item added
+// mid-life (a) doesn't replay grants for boundaries that predate it and (b) can't reuse an `igr:`
+// transaction id that was already emitted at one of those boundaries.
+const fastForwardScheduleEntry = (entry: RepeatSchedule[string], floorMillis: number): RepeatSchedule[string] => {
+  if (entry.interval === null || entry.nextRepeatMillis === null) return entry;
+  let occurrencesElapsed = entry.occurrencesElapsed;
+  let nextRepeatMillis = entry.nextRepeatMillis;
+  while (nextRepeatMillis <= floorMillis) {
+    occurrencesElapsed += 1;
+    nextRepeatMillis = nthDayIntervalMillis(entry.anchorMillis, entry.interval, occurrencesElapsed + 1);
+  }
+  return { ...entry, occurrencesElapsed, nextRepeatMillis };
+};
+const sameInterval = (a: DayInterval | null, b: DayInterval | null): boolean => JSON.stringify(a) === JSON.stringify(b);
+// Fold a rewritten source row's schedule into the fold's existing one. Items whose interval is
+// unchanged keep their repeat progress (anchor/occurrences/next boundary) and adopt the new
+// quantity/expiry going forward; items that are new or changed interval start fresh, fast-forwarded
+// past everything already granted; items no longer repeating stop. Items that dropped out entirely
+// are kept as inert tombstones (nextRepeatMillis null) so their history still counts toward
+// `processedThroughMillis` — otherwise a removed-then-readded item could re-emit an already-used
+// `igr:` transaction timestamp.
+const mergeRepeatSchedule = (oldSchedule: RepeatSchedule, freshSchedule: RepeatSchedule, floorMillis: number): RepeatSchedule => {
+  const merged: RepeatSchedule = Object.fromEntries(
+    Object.entries(freshSchedule).map(([itemId, freshEntry]) => {
+      const oldEntry = itemId in oldSchedule ? oldSchedule[itemId] : undefined;
+      if (oldEntry !== undefined && oldEntry.nextRepeatMillis !== null && sameInterval(oldEntry.interval, freshEntry.interval)) {
+        return [itemId, { ...freshEntry, anchorMillis: oldEntry.anchorMillis, occurrencesElapsed: oldEntry.occurrencesElapsed, nextRepeatMillis: oldEntry.nextRepeatMillis }];
+      }
+      return [itemId, fastForwardScheduleEntry(freshEntry, floorMillis)];
+    }),
+  );
+  for (const [itemId, oldEntry] of Object.entries(oldSchedule)) {
+    if (!(itemId in merged) && oldEntry.occurrencesElapsed > 0) merged[itemId] = { ...oldEntry, nextRepeatMillis: null };
+  }
+  return merged;
+};
 
 function subscriptionInitialState(row: SubscriptionRow): SubscriptionFoldState {
   const provider = paymentProvider(row.creationSource);
@@ -350,6 +396,34 @@ function subscriptionRepeatStep(state: SubscriptionFoldState, currentMillis: num
   };
 }
 
+// Fold a rewritten subscription row into the existing fold state (Stripe webhooks re-upsert the
+// row on every subscription/invoice event, so this runs often, usually with no meaningful change).
+// Emitted transactions are immutable facts: everything that references them survives untouched
+// (startTxnId, entry indices, outstandingGrants, repeatCount), while the fields that shape *future*
+// events adopt the new row. Repeat progress is merged so past grants are neither replayed nor
+// rederived against the new row data.
+function subscriptionUpdatedState(state: SubscriptionFoldState, row: SubscriptionRow): SubscriptionFoldState {
+  return {
+    ...state,
+    customerId: row.customerId,
+    customerType: row.customerType,
+    productId: row.productId,
+    product: row.product,
+    productLineId: productLineId(row.product),
+    priceId: row.priceId,
+    quantity: row.quantity,
+    paymentProvider: paymentProvider(row.creationSource),
+    endedAtMillis: row.endedAtMillis,
+    productRevokedAtMillis: row.productRevokedAtMillis,
+    chargedAmount: chargedAmount(row.product, row.priceId, row.quantity),
+    itemRepeatSchedule: mergeRepeatSchedule(
+      state.itemRepeatSchedule,
+      repeatSchedule(row.product, row.quantity, row.createdAtMillis),
+      processedThroughMillis(state.itemRepeatSchedule, row.createdAtMillis),
+    ),
+  };
+}
+
 function otpInitialState(row: OneTimePurchaseRow): OtpFoldState {
   const provider = paymentProvider(row.creationSource);
   const hasMoneyTransfer = provider !== "test_mode" && Object.keys(chargedAmount(row.product, row.priceId, row.quantity)).length > 0;
@@ -395,6 +469,21 @@ function otpRepeatStep(state: OtpFoldState, currentMillis: number): { state: Otp
       effectiveAtMillis: currentMillis,
       createdAtMillis: currentMillis,
     }),
+  };
+}
+
+// One-time-purchase counterpart of `subscriptionUpdatedState`: refs to emitted transactions
+// survive, future-facing fields (most importantly `revokedAtMillis`) adopt the new row, repeat
+// progress is merged. Mirrors otpInitialState's interval filter so non-repeating items stay out.
+function otpUpdatedState(state: OtpFoldState, row: OneTimePurchaseRow): OtpFoldState {
+  const freshSchedule = Object.fromEntries(Object.entries(repeatSchedule(row.product, row.quantity, row.createdAtMillis)).filter(([, schedule]) => schedule.interval !== null));
+  return {
+    ...state,
+    customerId: row.customerId,
+    customerType: row.customerType,
+    paymentProvider: paymentProvider(row.creationSource),
+    revokedAtMillis: row.revokedAtMillis,
+    itemRepeatSchedule: mergeRepeatSchedule(state.itemRepeatSchedule, freshSchedule, processedThroughMillis(state.itemRepeatSchedule, row.createdAtMillis)),
   };
 }
 
@@ -622,6 +711,22 @@ export function createPaymentsSchema() {
         const repeat = subscriptionRepeatStep(state, currentMillis);
         return { newState: toPiledriverObject(repeat.state), newRowData: toPiledriverObject([repeat.event]), nextTriggerTime: dateFromMillis(soonestNextMillis(repeat.state, repeat.state.endedAtMillis)) };
       },
+      // Stripe webhooks re-upsert the subscription row on every subscription/invoice event (incl.
+      // every renewal), so a row rewrite must fold into the existing state instead of resetting
+      // it — resetting deletes every emitted item-grant-repeat transaction until the next tick
+      // re-derives them (transiently wrong balances) and re-derives history against the *new* row
+      // (a quantity change would retroactively rewrite all past grants).
+      onSourceRowChanged: async (_state, row, previous) => {
+        const state = rowObject<SubscriptionFoldState>(_state);
+        // A quiet fold (no queued trigger) with an end date has already emitted subscription-end
+        // (via the timed end step or the immediate-end shortcut at creation). Re-arming it would
+        // append a duplicate end event, so the fold stays sealed regardless of the rewrite.
+        if (state.endedAtMillis !== null && previous.nextTriggerTime === null) {
+          return { newState: _state, nextTriggerTime: null };
+        }
+        const updated = subscriptionUpdatedState(state, rowObject<SubscriptionRow>(row.rowData));
+        return { newState: toPiledriverObject(updated), nextTriggerTime: dateFromMillis(soonestNextMillis(updated, updated.endedAtMillis)) };
+      },
     }), { input: "payments-subscriptions" }),
     table("payments-subscription-timefold-events", defineFlatMapTable(row => Array.isArray(row.rowData) ? row.rowData : []), { input: "payments-subscription-timefold" }),
     table("payments-subscription-start-events", defineFilterTable(row => isObject(row.rowData) && row.rowData.type === "subscription-start"), { input: "payments-subscription-timefold-events" }),
@@ -662,6 +767,17 @@ export function createPaymentsSchema() {
         const next = soonestNextMillis(repeat.state, null);
         const cappedNext = repeat.state.revokedAtMillis !== null && next !== null && next > repeat.state.revokedAtMillis ? null : next;
         return { newState: toPiledriverObject(repeat.state), newRowData: toPiledriverObject([repeat.event]), nextTriggerTime: dateFromMillis(cappedNext) };
+      },
+      // Same reasoning as the subscription timefold: purchase rows are re-upserted by webhooks
+      // (and revocation/refund updates), so fold the rewrite into the existing state instead of
+      // resetting emitted grants. No sealed-fold guard is needed — this fold emits no end event,
+      // and the revocation cap below keeps a revoked purchase dormant.
+      onSourceRowChanged: async (_state, row) => {
+        const state = rowObject<OtpFoldState>(_state);
+        const updated = otpUpdatedState(state, rowObject<OneTimePurchaseRow>(row.rowData));
+        const next = soonestNextMillis(updated, null);
+        const cappedNext = updated.revokedAtMillis !== null && next !== null && next > updated.revokedAtMillis ? null : next;
+        return { newState: toPiledriverObject(updated), nextTriggerTime: dateFromMillis(cappedNext) };
       },
     }), { input: "payments-one-time-purchases" }),
     table("payments-otp-timefold-events", defineFlatMapTable(row => Array.isArray(row.rowData) ? row.rowData : []), { input: "payments-otp-timefold" }),


### PR DESCRIPTION
## The bug, in simple terms

The payments ledger (item grants, credit balances, subscription transactions) is derived by a "time fold": for each subscription or one-time purchase row, a reducer emits the initial transactions and then appends one \`item-grant-repeat\` transaction per repeat boundary as the clock ticks.

The problem: **whenever a source row was *updated*, the fold threw away everything and started over from scratch.** It deleted every transaction it had ever emitted for that row, re-ran the reducer against the *current* row data, and replayed all past repeat boundaries on later ticks.

That would be fine if rows were only written once — but Stripe webhooks re-upsert a customer's subscription rows on ~20 different event types (`invoice.created`, `customer.subscription.updated`, every renewal, ...), often with no meaningful change. So in practice, many times a day, for every active subscription:

1. **Transiently wrong balances.** Between the webhook write and the next tick (the tick loop runs ~1/second, plus catch-up time), all of that subscription's historical repeat-grant transactions were simply *gone* from the ledger. Any read in that window saw wrong quantities.
2. **Retroactively rewritten history.** The replay re-derived past grants from the *new* row. Upgrade a plan from 100 to 200 credits/month and every past month's grant silently became 200 — for accumulating (non-expiring) items that doubles the balance retroactively, and a downgrade can push an already-spent balance negative.
3. **Wasted work that grows forever.** Every rewrite cost O(subscription age) reducer re-runs, on every webhook, for every subscription of that customer.

No test caught this because the reset behavior was the *documented spec* of the engine primitive (the engine test asserts it), and no payments-schema test ever wrote the same subscription row twice — the "Stripe rewrites this row constantly" pattern only exists in production.

## The fix

\`declareTimeFoldTable\` gains an optional \`onSourceRowChanged(state, newRow, previous)\` hook. When provided, a modified source row **keeps its fold state, its emitted outputs, and its timer progress**; the hook folds the new row data into the existing state and returns the next trigger time. Without the hook, the old reset semantics are unchanged (the existing engine test still passes as-is).

Both payments timefolds now implement the hook, treating emitted transactions as immutable facts:

- **Nothing already emitted is deleted or re-derived.** References into emitted transactions (\`startTxnId\`, entry indices, \`outstandingGrants\`, \`repeatCount\`) survive the rewrite untouched, so end-of-subscription expiry still points at the grants that actually happened, with the quantities that were actually granted.
- **Future-facing fields adopt the new row.** Quantity/product/price/end-date changes affect the *next* repeat onward — an upgrade doubles next month's grant, not last year's.
- **Repeat progress merges per item** (\`mergeRepeatSchedule\`): items whose interval is unchanged keep their anchor/occurrence progress; items added (or re-intervaled) mid-life fast-forward past everything already granted, so they neither replay history nor collide with an already-used \`igr:\` transaction id; removed items leave inert tombstones so their history keeps counting toward that floor.
- **An ended subscription fold is sealed.** Once \`subscription-end\` has been emitted (fold quiet + end date set), further webhook rewrites can't re-arm it and append a duplicate end event.
- **Cancellations still work through the same path:** a rewrite that sets \`endedAtMillis\` re-arms the timer and the existing timed end step emits the end event off the preserved state.

Updates are now O(1) instead of O(age), and there is no window where the ledger is missing history.

## Deliberate trade-off

History is now immutable by design: the \`sub-start\` transaction keeps its original product/quantity forever. A genuine data *correction* (as opposed to a plan change) now requires delete + recreate of the source row, which still uses the full reset path.

## Testing

- New engine test: outputs/state/timer survive an update with the hook; reset semantics without it are untouched.
- New payments-schema tests: renewal-style rewrite leaves the ledger byte-identical with no tick in between; a quantity upgrade keeps past grants and scales only future ones; cancellation-by-rewrite emits a single sealed \`subscription-end\`; OTP revocation-by-rewrite preserves granted repeats and stops future ones.
- Full \`bulldozer-js\` suite (158 tests), \`pnpm typecheck\`, \`pnpm lint\` all green.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserves timefold history across source-row rewrites to stop transient wrong balances and retroactive ledger changes. Adds an `onSourceRowChanged` hook and uses it in payments timefolds for subscriptions and one-time purchases.

- **New Features**
  - `declareTimeFoldTable` adds optional `onSourceRowChanged` to merge updated source rows without resetting. Keeps fold state, emitted outputs, and timer, and returns the next trigger.

- **Bug Fixes**
  - Payments timefolds implement the hook so emitted transactions are immutable and never re-derived.
  - Future-facing fields (quantity/product/price/end-date) apply from the next repeat onward.
  - Repeat progress merges per item: new or re-intervaled items fast-forward; removed items leave tombstones; ended subscriptions are sealed to prevent duplicate `subscription-end`.
  - Removes transient balance gaps and reduces update cost to O(1).

<sup>Written for commit ab9f6e75eeba776c84ffbb55106881a619dfa13f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1711?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

