### PR TITLE
fix(bulldozer): emit subscription-end synchronously when a rewrite ends a no-repeat sub

### DIFF
--- a/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.test.ts
@@ -448,6 +448,9 @@ describe("Bulldozer", () => {
       },
       onSourceRowChanged: async (state, row, previous) => {
         changedCalls.push({ state, rowData: row.rowData, oldRowData: previous.rowData, previousTrigger: previous.nextTriggerTime?.getTime() ?? null });
+        if (row.rowData === "C") {
+          return { newState: Number(state) + 1000, nextTriggerTime: null, appendRowData: `${row.rowData}:changed` };
+        }
         return { newState: Number(state) + 100, nextTriggerTime: new Date(secondTrigger) };
       },
     });
@@ -479,6 +482,20 @@ describe("Bulldozer", () => {
       { groupKey: null, rowIdentifier: JSON.stringify(["a", 0]), rowSortKey: null, rowData: "A:initial" },
       { groupKey: null, rowIdentifier: JSON.stringify(["a", 1]), rowSortKey: null, rowData: "A:2" },
       { groupKey: null, rowIdentifier: JSON.stringify(["a", 2]), rowSortKey: null, rowData: "B:103" },
+    ]);
+
+    // The hook can append one output row synchronously in the same write (appendRowData),
+    // while everything previously emitted still survives verbatim.
+    snapshot = await set(snapshot, "store", "a", "C");
+    expect(await rows(snapshot, "time")).toEqual([
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 0]), rowSortKey: null, rowData: "A:initial" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 1]), rowSortKey: null, rowData: "A:2" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 2]), rowSortKey: null, rowData: "B:103" },
+      { groupKey: null, rowIdentifier: JSON.stringify(["a", 3]), rowSortKey: null, rowData: "C:changed" },
+    ]);
+    expect(changedCalls).toEqual([
+      { state: 2, rowData: "B", oldRowData: "A", previousTrigger: null },
+      { state: 103, rowData: "C", oldRowData: "B", previousTrigger: null },
     ]);
 
     // Deleting the source row still removes everything.

--- a/apps/bulldozer-js/src/databases/bulldozer/index.ts
+++ b/apps/bulldozer-js/src/databases/bulldozer/index.ts
@@ -2233,8 +2233,10 @@ export function declareLeftFoldTable(options: {
  *   and past trigger times replay (against the *new* row data) on subsequent ticks.
  * - With `onSourceRowChanged`, an update keeps the row's emitted outputs, fold state, and timer
  *   progress; the hook folds the new row data into the existing state and returns the next
- *   trigger time. Use this when emitted outputs are append-only facts (e.g. a ledger) that a
- *   source rewrite must not retract or rederive.
+ *   trigger time, optionally appending one emitted output row (`appendRowData`) in the same
+ *   write — for events the update itself implies (e.g. an immediate end) that same-transaction
+ *   readers must see without waiting for a tick. Use this when emitted outputs are append-only
+ *   facts (e.g. a ledger) that a source rewrite must not retract or rederive.
  */
 export function declareTimeFoldTable(options: {
   initialState: PiledriverObject,
@@ -2247,7 +2249,7 @@ export function declareTimeFoldTable(options: {
     state: PiledriverObject,
     row: { groupKey: PiledriverObject, rowIdentifier: string, rowSortKey: PiledriverObject, rowData: PiledriverObject },
     previous: { rowData: PiledriverObject, nextTriggerTime: Date | null },
-  ) => Promise<{ newState: PiledriverObject, nextTriggerTime: Date | null }>,
+  ) => Promise<{ newState: PiledriverObject, nextTriggerTime: Date | null, appendRowData?: PiledriverObject }>,
 }): BulldozerTableImplementation {
   type SourceRow = { groupKey: PiledriverObject, rowIdentifier: string, rowSortKey: PiledriverObject, rowData: PiledriverObject };
   type RowState = SourceRow & {
@@ -2386,10 +2388,13 @@ export function declareTimeFoldTable(options: {
       rowData: oldRow.rowData,
       nextTriggerTime: oldRow.nextTriggerTimeMs === null ? null : new Date(oldRow.nextTriggerTimeMs),
     });
-    const newRow: RowState = { ...row, state: result.newState, nextTriggerTimeMs: toTimestampMs(result.nextTriggerTime), emittedRows: oldRow.emittedRows };
+    const emittedRows = result.appendRowData === undefined ? oldRow.emittedRows : [...oldRow.emittedRows, result.appendRowData];
+    const newRow: RowState = { ...row, state: result.newState, nextTriggerTimeMs: toTimestampMs(result.nextTriggerTime), emittedRows };
     state = { ...state, rows: await state.rows.set(row.rowIdentifier, newRow) };
-    // emittedRows are carried over verbatim (and modified rows never change group), so the
-    // materialized output rows are untouched and no output changes are emitted.
+    // Prior emittedRows are carried over verbatim (and modified rows never change group), so the
+    // only possible output change is the appended row; without one, the materialized output rows
+    // are untouched and no output changes are emitted.
+    if (result.appendRowData !== undefined) state = await replaceOutputs(state, oldRow, newRow, outputChanges);
     return await addQueuedTrigger(state, newRow);
   };
   const deleteSourceRow = async (state: State, rowIdentifier: string, outputChanges: TableChanges) => {

--- a/apps/bulldozer-js/src/payments/schema/index.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.test.ts
@@ -367,6 +367,43 @@ describe("payments schema", () => {
     expect(txnIdsAfter).toEqual([`igr:sub-seal:${firstRepeatMillis}`, "sub-end:sub-seal", "sub-start:sub-seal"]);
   });
 
+  it("emits the end synchronously when a rewrite ends a no-repeat subscription (plan switch)", async () => {
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    // Plan-switch shape: no included items (so no repeat schedule), replaced mid-period by
+    // rewriting the row with endedAtMillis = "now". The switch endpoint reads owned products in
+    // the same request, so the revocation must land in the same write — not on the next tick.
+    const subEndMillis = Date.UTC(1970, 0, 10);
+    const subRow = (overrides: Partial<Parameters<typeof subscription>[1]> = {}) => subscription("sub-switch", {
+      customerId: "u-switch",
+      productId: "prod-basic",
+      product: product(),
+      currentPeriodEndMillis: Date.UTC(1970, 1, 1),
+      ...overrides,
+    }) as unknown as PiledriverObject;
+    snapshot = await set(snapshot, schema.subscriptions, "sub-switch", subRow());
+
+    const group = customerGroup("u-switch");
+    const ownedQuantity = async () => {
+      const owned = asRecord((await rowsBySortKey(snapshot, schema.ownedProducts, group)).at(-1)?.rowData ?? null);
+      return Number(asRecord(asRecord(owned.ownedProducts)["prod-basic"]).quantity);
+    };
+    expect(await ownedQuantity()).toBe(1);
+
+    // End the subscription via rewrite; no tick in between.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-switch", subRow({ status: "canceled", endedAtMillis: subEndMillis, canceledAtMillis: subEndMillis }));
+    const txns = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[])
+      .sort((a, b) => a.effectiveAtMillis - b.effectiveAtMillis || stringCompare(a.txnId, b.txnId));
+    expect(txns.map(txn => txn.txnId)).toEqual(["sub-start:sub-switch", "sub-end:sub-switch"]);
+    expect(await ownedQuantity()).toBe(0);
+
+    // The fold is sealed: later rewrites and ticks add nothing (no duplicate end).
+    snapshot = await set(snapshot, schema.subscriptions, "sub-switch", subRow({ status: "canceled", endedAtMillis: subEndMillis, canceledAtMillis: subEndMillis, currentPeriodStartMillis: subEndMillis }));
+    snapshot = await snapshot.tick(new Date(Date.UTC(1970, 2, 1)));
+    const txnIdsAfter = ((await rowDatas(snapshot, schema.transactions, group)) as unknown as TransactionRow[]).map(txn => txn.txnId).sort(stringCompare);
+    expect(txnIdsAfter).toEqual(["sub-end:sub-switch", "sub-start:sub-switch"]);
+  });
+
   it("treats a manual item quantity change whose expiry is at/before its grant as a no-op", async () => {
     const schema = createPaymentsSchema();
     let snapshot = await initializedSnapshot();

--- a/apps/bulldozer-js/src/payments/schema/index.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.ts
@@ -735,12 +735,22 @@ export function createPaymentsSchema() {
       onSourceRowChanged: async (_state, row, previous) => {
         const state = rowObject<SubscriptionFoldState>(_state);
         // A quiet fold (no queued trigger) with an end date has already emitted subscription-end
-        // (via the timed end step or the immediate-end shortcut at creation). Re-arming it would
-        // append a duplicate end event, so the fold stays sealed regardless of the rewrite.
+        // (via the timed end step or the immediate-end shortcut). Re-arming it would append a
+        // duplicate end event, so the fold stays sealed regardless of the rewrite.
         if (state.endedAtMillis !== null && previous.nextTriggerTime === null) {
           return { newState: _state, nextTriggerTime: null };
         }
-        const updated = subscriptionUpdatedState(state, rowObject<SubscriptionRow>(row.rowData));
+        const sub = rowObject<SubscriptionRow>(row.rowData);
+        const updated = subscriptionUpdatedState(state, sub);
+        // Mirror the initial reducer's immediate-end shortcut for ends introduced by a rewrite:
+        // plan switching ends the replaced subscription by rewriting its row and expects the
+        // revocation to be visible in the same write (e.g. the switch endpoint's one-time-purchase
+        // guard reads owned products right after) — waiting for the next tick would leave the old
+        // product transiently granted.
+        const hasRepeat = Object.values(updated.itemRepeatSchedule).some(schedule => schedule.nextRepeatMillis !== null);
+        if (updated.endedAtMillis !== null && !hasRepeat && updated.endedAtMillis < sub.currentPeriodEndMillis) {
+          return { newState: toPiledriverObject(updated), nextTriggerTime: null, appendRowData: toPiledriverObject([subscriptionEndEvent(updated)]) };
+        }
         return { newState: toPiledriverObject(updated), nextTriggerTime: dateFromMillis(soonestNextMillis(updated, updated.endedAtMillis)) };
       },
     }), { input: "payments-subscriptions" }),


### PR DESCRIPTION
Follow-up to #1711.

## The regression

#1711 made subscription timefold history immutable across source-row rewrites: instead of resetting the fold, \`onSourceRowChanged\` merges the new row into the existing state and re-arms the timer. That fixed the ledger-corruption bugs, but it turned one previously-synchronous behavior into a tick-driven one: **ending a subscription by rewriting its row**.

Before #1711, a rewrite that set \`endedAtMillis\` on a no-repeat subscription re-ran the initial reducer, whose immediate-end shortcut emitted the \`subscription-end\` event (and its \`product-revocation\`) **in the same write**. After #1711, the hook only armed the timer, so the end event landed on the **next 1-second tick**.

Plan switching depends on the same-write behavior:

1. \`grantProductToCustomer\` ends the replaced subscription by rewriting its row (\`endedAt: now\`) and dual-writing to bulldozer.
2. The switch endpoint's one-time-purchase guard then reads two bulldozer views: the subscription map (raw rows — sees the end **synchronously**) and \`ownedProducts\` (ledger-derived — only updates once the end **event** lands).
3. In the tick window, the replaced product is still granted in the ledger but no longer an active subscription, so the guard's "owned ∧ not an active sub ⇒ one-time purchase" inference misfires and rejects the switch:

\`\`\`
400 "Customer already has a one-time purchase in this product line"
\`\`\`

This is exactly what \`switch-plans.test.ts\`'s "two rapid sequential test-mode switches" hits — the second switch arrives milliseconds after the first, well inside the window.

## The fix

- **Engine:** \`onSourceRowChanged\` may now return an optional \`appendRowData\` — one output row appended in the same write, with everything previously emitted still preserved verbatim. This is for events the update itself implies, which same-request readers must see without waiting for a tick.
- **Payments schema:** the subscription hook mirrors the initial reducer's immediate-end shortcut. When a rewrite sets an end on a fold with no pending repeats before the period end, it emits \`subscription-end\` synchronously — built from the *preserved* fold state, so \`outstandingGrants\`/\`startTxnId\` refs point at the transactions that actually happened — and seals the fold (no duplicate end on later rewrites or ticks).

This restores the exact pre-#1711 semantics for the no-repeat end-by-rewrite case, without giving up the history preservation #1711 introduced. Repeat-item subscriptions keep ending via the timed step, the same gate the immediate-end shortcut has always had.

## Testing

- New engine test: \`appendRowData\` appends exactly one output row in the same write; prior outputs, fold state, and hook call sequence all preserved; deletion still clears everything.
- New payments-schema test replicating the switch shape: a no-repeat sub ended via rewrite shows the \`sub-end\` transaction and \`ownedProducts\` quantity 0 **immediately, with no tick in between**, and further rewrites + ticks add nothing.
- \`bulldozer-js\` suites, \`pnpm typecheck\`, \`pnpm lint\` green.

Notes:
- The payments performance test ("runs the comparable schema workload") times out at 120s on pristine \`bulldozerjs\` as well — pre-existing, unrelated to this change.
- \`switch-plans.test.ts\` currently carries an inline snapshot of the 400 response; once this lands, that snapshot should be updated to the 200 path.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Emit subscription-end synchronously when a rewrite ends a no-repeat subscription, restoring same-write behavior needed by plan switches and eliminating the tick window that caused 400s. Also adds `appendRowData` to the `bulldozer` engine to support same-write event emission without resetting history.

- **Bug Fixes**
  - Payments: when a rewrite sets `endedAtMillis` on a no-repeat subscription before period end, emit `subscription-end` (and its revocation) in the same write and seal the fold; restores pre-#1711 semantics so plan switches see revocations immediately.

- **New Features**
  - `bulldozer`: `onSourceRowChanged` may return `appendRowData` to append one output row in the same write while preserving prior outputs and timers.

<sup>Written for commit 849e13eda6f6087e812665e3582cf53628f6bef5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1712?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

