### PR TITLE
feat(dashboard): add Argide support widget

### DIFF
--- a/apps/dashboard/src/app/layout.tsx
+++ b/apps/dashboard/src/app/layout.tsx
@@ -85,6 +85,16 @@ export default function RootLayout({
           ? "(function(){try{var t=localStorage.getItem('theme');var d=document.documentElement;var r=t==='dark'||t==='light'?t:'light';d.classList.add(r);d.style.colorScheme=r}catch(e){}})()"
           : "(function(){try{var t=localStorage.getItem('theme');var d=document.documentElement;var r=t==='dark'||t==='light'?t:window.matchMedia('(prefers-color-scheme:dark)').matches?'dark':'light';d.classList.add(r);d.style.colorScheme=r}catch(e){}})()"
         }} />
+
+        {/* Argide — in-app support agent (browser-use) */}
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script dangerouslySetInnerHTML={{ __html: "window.argide = window.argide || [];" }} />
+        {/* eslint-disable-next-line @next/next/no-sync-scripts */}
+        <script
+          src="https://dashboard.argide.ai/argide-b2b.iife.js"
+          data-product-id="prod_8ea9a04d-ba34-4d1c-a5c7-efd8f792c1f4"
+          data-api-url="https://api.argide.ai"
+        />
       </head>
       <body
         className={cn(


### PR DESCRIPTION
Demo: https://screen.studio/share/k2imCOqc

This adds [Argide](https://argide.ai) to the dashboard.

Argide is a support agent that takes over the cursor when a user gets stuck and finishes the task for them, live in their browser. No API integration.

It's one script tag in `apps/dashboard/src/app/layout.tsx`. The product id sits in a data attribute, so you can point it at your own Argide workspace, or set it through `NEXT_PUBLIC_HEXCLAVE_HEAD_TAGS` instead of hardcoding it.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the Argide in‑app support widget to the dashboard by injecting its script in `apps/dashboard/src/app/layout.tsx`, enabling live, cursor-driven assistance without backend changes.

- **Migration**
  - Product ID is set via the script’s `data-product-id`. You can point it to your own Argide workspace or inject via `NEXT_PUBLIC_HEXCLAVE_HEAD_TAGS`.

<sup>Written for commit 6ce44a6c8e45518de18d3cf789053546fe2f8f29. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1713?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an in-app support assistant to the dashboard, making help access more convenient.
  * The support tool now loads automatically in the app so users can interact with it without leaving the dashboard.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->