### PR TITLE
Swap Do Later and Connect button positions in payments onboarding

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -908,8 +908,17 @@ export function ProjectOnboardingWizard(props: {
           >
             Connect
           </DesignButton>
-        ) : undefined}
-        secondaryAction={
+        ) : (
+          <DesignButton
+            className="rounded-full px-6"
+            disabled={saving || paymentsSetupAction != null}
+            loading={paymentsSetupAction === "defer"}
+            onClick={() => runAsynchronouslyWithAlert(deferPaymentsSetup)}
+          >
+            Do Later
+          </DesignButton>
+        )}
+        secondaryAction={selectedPaymentsCountry === "US" ? (
           <DesignButton
             className="rounded-full px-6"
             variant="outline"
@@ -919,7 +928,7 @@ export function ProjectOnboardingWizard(props: {
           >
             Do Later
           </DesignButton>
-        }
+        ) : undefined}
       >
         <Suspense fallback={<PaymentsSetupStepSkeleton />}>
           <PaymentsSetupAutoComplete

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/project-onboarding-wizard.tsx
@@ -899,20 +899,9 @@ export function ProjectOnboardingWizard(props: {
         onBack={handleBack}
         disabled={saving}
         actionsLayout="inline"
-        primaryAction={
+        primaryAction={selectedPaymentsCountry === "US" ? (
           <DesignButton
             className="rounded-full px-6"
-            disabled={saving || paymentsSetupAction != null}
-            loading={paymentsSetupAction === "defer"}
-            onClick={() => runAsynchronouslyWithAlert(deferPaymentsSetup)}
-          >
-            Do Later
-          </DesignButton>
-        }
-        secondaryAction={selectedPaymentsCountry === "US" ? (
-          <DesignButton
-            className="rounded-full px-6"
-            variant="outline"
             disabled={saving || paymentsSetupAction != null}
             loading={paymentsSetupAction === "connect"}
             onClick={() => runAsynchronouslyWithAlert(connectPaymentsSetup)}
@@ -920,6 +909,17 @@ export function ProjectOnboardingWizard(props: {
             Connect
           </DesignButton>
         ) : undefined}
+        secondaryAction={
+          <DesignButton
+            className="rounded-full px-6"
+            variant="outline"
+            disabled={saving || paymentsSetupAction != null}
+            loading={paymentsSetupAction === "defer"}
+            onClick={() => runAsynchronouslyWithAlert(deferPaymentsSetup)}
+          >
+            Do Later
+          </DesignButton>
+        }
       >
         <Suspense fallback={<PaymentsSetupStepSkeleton />}>
           <PaymentsSetupAutoComplete


### PR DESCRIPTION
## Summary

Swaps the positions of "Do Later" and "Connect" buttons in the payments setup onboarding step for US users. "Connect" is now `primaryAction` (filled, left) and "Do Later" is `secondaryAction` (outline, right).

For non-US users (where "Connect" isn't shown), "Do Later" remains the filled `primaryAction` — preserving the original visual hierarchy.

Link to Devin session: https://app.devin.ai/sessions/a5ff1d4533b54cbc9e1ed06b08334604
Requested by: @Developing-Gamer

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the payment setup step’s action button behavior for a more consistent experience.
  * For US-based setup, **Connect** is now the main action (with matching loading state).
  * For non-US countries, the main action is omitted.
  * **Do Later** is available as the secondary action (with matching loading state).
  * Action buttons are disabled during saving or when a payment setup action is in progress.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->