### PR TITLE
Fix CI: externalize AWS SDK from migration bundler + move Bulldozer HTTP calls out of Prisma transactions

### DIFF
--- a/apps/backend/scripts/db-migrations.tsdown.config.ts
+++ b/apps/backend/scripts/db-migrations.tsdown.config.ts
@@ -12,9 +12,15 @@ const backendDir = resolve(__dirname, '..');
 
 const packageJson = JSON.parse(readFileSync(resolve(backendDir, 'package.json'), 'utf-8'));
 
-// Packages that must remain as runtime imports (can't be statically bundled)
+// Packages that must remain as runtime imports (can't be statically bundled).
+// @aws-sdk and @smithy use complex class hierarchies that rolldown mis-scopes,
+// causing "StructureSchema$2 is not defined" at runtime. They're unused by the
+// migration script anyway (pulled in transitively), and node_modules is present
+// in the Docker image, so keeping them external is safe.
 const externalPackages = [
   '@prisma/client',
+  '@aws-sdk',
+  '@smithy',
 ];
 
 const customNoExternal = new Set([

--- a/apps/backend/src/app/api/latest/payments/items/[customer_type]/[customer_id]/[item_id]/update-quantity/route.ts
+++ b/apps/backend/src/app/api/latest/payments/items/[customer_type]/[customer_id]/[item_id]/update-quantity/route.ts
@@ -95,18 +95,24 @@ export const POST = createSmartRouteHandler({
       customerId: req.params.customer_id,
     });
 
+    // Read the current quantity from bulldozer-js BEFORE starting the Prisma
+    // transaction. getItemQuantityForCustomer reads via HTTP from the
+    // bulldozer-js server and does not use the Prisma client; keeping the
+    // call inside the transaction would hold the transaction open for the
+    // full HTTP round-trip, exhausting the interactive-transaction pool
+    // under load and causing "Unable to start a transaction" cascades.
+    const totalQuantity = await getItemQuantityForCustomer({
+      prisma,
+      tenancyId: tenancy.id,
+      itemId: req.params.item_id,
+      customerId: req.params.customer_id,
+      customerType: req.params.customer_type,
+    });
+    if (!allowNegative && (totalQuantity + req.body.delta < 0)) {
+      throw new KnownErrors.ItemQuantityInsufficientAmount(req.params.item_id, req.params.customer_id, req.body.delta);
+    }
+
     const change = await retryTransaction(prisma, async (tx) => {
-      const totalQuantity = await getItemQuantityForCustomer({
-        prisma: tx,
-        tenancyId: tenancy.id,
-        itemId: req.params.item_id,
-        customerId: req.params.customer_id,
-        customerType: req.params.customer_type,
-      });
-      if (!allowNegative && (totalQuantity + req.body.delta < 0)) {
-        throw new KnownErrors.ItemQuantityInsufficientAmount(req.params.item_id, req.params.customer_id, req.body.delta);
-      }
-      // dual write - prisma and bulldozer
       const change = await tx.itemQuantityChange.create({
         data: {
           tenancyId: tenancy.id,

--- a/apps/backend/src/app/api/latest/team-invitations/[id]/accept/route.tsx
+++ b/apps/backend/src/app/api/latest/team-invitations/[id]/accept/route.tsx
@@ -105,31 +105,35 @@ export const POST = createSmartRouteHandler({
       throw new KnownErrors.VerificationCodeNotFound();
     }
 
+    // Read the seat cap from bulldozer-js BEFORE starting the Prisma
+    // transaction. getItemQuantityForCustomer reads via HTTP from the
+    // bulldozer-js server; keeping the call inside the transaction would
+    // hold it open for the full HTTP round-trip, risking transaction
+    // timeouts and connection-pool exhaustion.
+    let maxDashboardAdmins: number | undefined;
+    if (auth.tenancy.project.id === "internal" && arePlanLimitsEnforced()) {
+      try {
+        maxDashboardAdmins = await getItemQuantityForCustomer({
+          prisma,
+          tenancyId: auth.tenancy.id,
+          customerId: invitationData.team_id,
+          itemId: "dashboard_admins",
+          customerType: "team",
+        });
+      } catch (error) {
+        captureError("team-invitations:accept:dashboard-admins-seat-check", error);
+        maxDashboardAdmins = UNLIMITED_ITEM_CAPACITY;
+      }
+    }
+
     await retryTransaction(prisma, async (tx) => {
-      if (auth.tenancy.project.id === "internal" && arePlanLimitsEnforced()) {
+      if (maxDashboardAdmins !== undefined) {
         const currentMemberCount = await tx.teamMember.count({
           where: {
             tenancyId: auth.tenancy.id,
             teamId: invitationData.team_id,
           },
         });
-        // The seat cap lives in bulldozer, but accepting a team invite must not
-        // hard-depend on it: if bulldozer is unreachable, report it and skip the
-        // check this once (treat the cap as unlimited) rather than blocking the
-        // invite. The cap is re-enforced on the next accept once bulldozer is back.
-        let maxDashboardAdmins: number;
-        try {
-          maxDashboardAdmins = await getItemQuantityForCustomer({
-            prisma: tx,
-            tenancyId: auth.tenancy.id,
-            customerId: invitationData.team_id,
-            itemId: "dashboard_admins",
-            customerType: "team",
-          });
-        } catch (error) {
-          captureError("team-invitations:accept:dashboard-admins-seat-check", error);
-          maxDashboardAdmins = UNLIMITED_ITEM_CAPACITY;
-        }
         if (currentMemberCount + 1 > maxDashboardAdmins) {
           throw new KnownErrors.ItemQuantityInsufficientAmount("dashboard_admins", invitationData.team_id, -1);
         }


### PR DESCRIPTION
## Summary

Two fixes for CI failures on `dev`:

**1. Docker build: `StructureSchema$2 is not defined`**

Rolldown mis-scopes `@aws-sdk`/`@smithy` class hierarchies when bundling `db-migrations.ts`. These packages are pulled in transitively but unused by the migration script. Externalizing them keeps them as runtime imports from `node_modules` (already present in the Docker image).

```diff
// db-migrations.tsdown.config.ts
 const externalPackages = [
   '@prisma/client',
+  '@aws-sdk',
+  '@smithy',
 ];
```

**2. E2E tests: Prisma transaction timeouts / pool exhaustion**

`getItemQuantityForCustomer()` reads from Bulldozer JS via HTTP but was called *inside* `retryTransaction()` in two routes. The HTTP round-trip holds the interactive transaction open, exceeding the 5s timeout and exhausting the connection pool — cascading into "Unable to start a transaction" failures across unrelated tests.

Fix: move the HTTP calls before the transaction in both `update-quantity/route.ts` and `team-invitations/accept/route.tsx`. The calls don't use the Prisma transaction client (they're pure HTTP), so this is safe.

Link to Devin session: https://app.devin.ai/sessions/fe63d086b8ad4844a75e7588395a9c02
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes CI by stopping the migrations bundler from crashing and removing Prisma transaction timeouts in E2E. Docker builds now pass and tests no longer exhaust the connection pool.

- **Bug Fixes**
  - Externalized `@aws-sdk` and `@smithy` in `db-migrations.tsdown.config.ts` to avoid rolldown mis-scoping (“StructureSchema$2 is not defined”); these stay as runtime imports from `node_modules`.
  - Moved `getItemQuantityForCustomer` HTTP reads out of Prisma `retryTransaction` in update-quantity and team-invitations accept routes; fetch values before starting the transaction to prevent timeouts and pool exhaustion.

<sup>Written for commit b27aa85e6a8323c37d00d46ddb872211d9136db5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1716?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved quantity updates so stock and balance checks happen before the database transaction, reducing failed requests during slower network round trips.
  * Adjusted team invitation acceptance for internal projects to handle seat-limit checks more reliably and avoid transaction timeouts.
  * Kept certain build-time packages external to prevent bundling-related runtime issues in the backend environment.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->