### PR TITLE
Add 7/3/26 changelog entry

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 ---
 
+## 7/3/26
+
+- New navigation funnel graph, sign-up rule triggers card, and platform analytics leaderboard on the dashboard.
+- Unified payments customers table with idempotent Stripe webhooks and improved checkout error handling.
+- Faster project onboarding via a preview pool, redesigned setup page, and new Usage settings page.
+- CLI fetches RDE dashboard from GitHub Releases; local emulator removed in favor of remote development environments.
+- Session replay gzip compression, custom emails on shared server, and TypeScript 6.0 upgrade.
+
 ## 6/19/26
 
 - New clickmap heatmaps for route analytics — visualize where users click on any page.


### PR DESCRIPTION
## Summary

Weekly changelog entry for 7/3/26 covering commits since 6/19/26.

Link to Devin session: https://app.devin.ai/sessions/b95f31171b61463395b1be4bc87e33af
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add the 7/3/26 entry to CHANGELOG.md. It summarizes new dashboard analytics (navigation funnel, sign-up rule triggers, leaderboard), payments reliability (unified customers table, idempotent `Stripe` webhooks, better checkout errors), faster onboarding (preview pool, redesigned setup, new Usage settings), CLI RDE changes (fetch from GitHub Releases, remove local emulator), session replay gzip, custom emails on shared server, and a `TypeScript` 6.0 upgrade.

<sup>Written for commit b73f9d80b934eb7a16c5f1100817575e6187985c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1723?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

