### PR TITLE
Fix DataGrid virtualization in page-scroll mode to prevent large-list crashes

### DIFF
--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.test.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.test.tsx
@@ -10,6 +10,7 @@ import {
   type DataGridColumnDef,
   type DataGridProps,
 } from "./index";
+import { findScrollParent } from "./data-grid";
 
 type Row = {
   id: string,
@@ -263,6 +264,54 @@ describe("DataGrid infinite scroll observer", () => {
     });
 
     expect(intersectionObserverRecords.at(-1)?.options?.root ?? null).toBeNull();
+  });
+});
+
+describe("findScrollParent", () => {
+  // In page-scroll mode the virtualizer must measure against the nearest
+  // scrollable ancestor (not the grid's own non-scrolling container), otherwise
+  // it renders every row and long infinite lists exhaust memory and crash.
+  afterEach(() => cleanup());
+
+  it("returns the nearest ancestor with a scrollable overflow", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "auto";
+    const middle = document.createElement("div");
+    const leaf = document.createElement("div");
+    scroller.append(middle);
+    middle.append(leaf);
+    document.body.append(scroller);
+
+    expect(findScrollParent(leaf)).toBe(scroller);
+
+    scroller.remove();
+  });
+
+  it("treats overflowY:scroll as scrollable", () => {
+    const scroller = document.createElement("div");
+    scroller.style.overflowY = "scroll";
+    const leaf = document.createElement("div");
+    scroller.append(leaf);
+    document.body.append(scroller);
+
+    expect(findScrollParent(leaf)).toBe(scroller);
+
+    scroller.remove();
+  });
+
+  it("returns null when no ancestor scrolls", () => {
+    const outer = document.createElement("div");
+    const leaf = document.createElement("div");
+    outer.append(leaf);
+    document.body.append(outer);
+
+    expect(findScrollParent(leaf)).toBeNull();
+
+    outer.remove();
+  });
+
+  it("returns null for a null start element", () => {
+    expect(findScrollParent(null)).toBeNull();
   });
 });
 

--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
@@ -951,11 +951,17 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
     setAncestorScrollEl(findScrollParent(gridRef.current));
   }, [usesAncestorScroll]);
 
-  const activeScrollMargin = usesAncestorScroll ? scrollMargin : 0;
+  // Only offset by the margin once we've actually resolved (and measured) an
+  // ancestor scroller. Until then — and when no scrollable ancestor exists
+  // (e.g. a window-scrolled page, which this app's shell never produces) — we
+  // fall back to the grid's own container so the virtualizer always has a real
+  // scroll element to measure and `scrollMargin` stays consistent with it.
+  const hasAncestorScroll = usesAncestorScroll && ancestorScrollEl != null;
+  const activeScrollMargin = hasAncestorScroll ? scrollMargin : 0;
 
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => (usesAncestorScroll ? ancestorScrollEl : scrollContainerRef.current),
+    getScrollElement: () => (hasAncestorScroll ? ancestorScrollEl : scrollContainerRef.current),
     estimateSize: () => estimatedRowHeight,
     overscan,
     scrollMargin: activeScrollMargin,
@@ -967,9 +973,11 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
   });
 
   // Keep `scrollMargin` synced with the row list's offset inside the ancestor
-  // scroller. The list sits below the sticky toolbar/header, so its offset is
-  // stable as rows load, but we re-measure on resize and row-count changes to
-  // stay correct across layout shifts.
+  // scroller. The offset is scroll-invariant (it subtracts the scroller's own
+  // rect and adds back scrollTop), so only *layout* above the list changes it:
+  // the sticky toolbar/header growing (e.g. filter chips wrapping) pushes the
+  // list down without resizing the list itself. We therefore observe the
+  // scroller, the grid, the sticky chrome, and the list, plus window resizes.
   useLayoutEffect(() => {
     if (!usesAncestorScroll || !ancestorScrollEl) return;
     const listEl = rowsContainerRef.current;
@@ -984,6 +992,8 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
     const observer = new ResizeObserver(update);
     observer.observe(ancestorScrollEl);
     observer.observe(listEl);
+    if (gridRef.current) observer.observe(gridRef.current);
+    if (stickyChromeRef.current) observer.observe(stickyChromeRef.current);
     window.addEventListener("resize", update);
     return () => {
       observer.disconnect();

--- a/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
+++ b/packages/dashboard-ui-components/src/components/data-grid/data-grid.tsx
@@ -439,6 +439,30 @@ function SelectionCheckbox({
   );
 }
 
+// ─── Scroll parent detection ─────────────────────────────────────────
+
+// When the grid does NOT own its own vertical scroll (`fillHeight={false}`
+// and no `maxHeight`), rows scroll inside the nearest scrollable ancestor —
+// the page shell — not inside the grid's own container. The virtualizer must
+// measure against THAT element; otherwise it treats the grid's own unbounded,
+// non-scrolling container as the viewport, computes a viewport height equal to
+// the full content height, and renders every single row. For long
+// infinite-scroll lists (transactions, customers, users) that means the DOM
+// grows without bound as more pages load, until the tab runs out of memory and
+// crashes/reloads. Walking up to the real scroller lets the virtualizer window
+// rows correctly in page-scroll mode too.
+export function findScrollParent(start: HTMLElement | null): HTMLElement | null {
+  let el = start?.parentElement ?? null;
+  while (el) {
+    const overflowY = getComputedStyle(el).overflowY;
+    if (overflowY === "auto" || overflowY === "scroll" || overflowY === "overlay") {
+      return el;
+    }
+    el = el.parentElement;
+  }
+  return null;
+}
+
 // ─── Infinite scroll sentinel ────────────────────────────────────────
 
 const NOOP = () => {};
@@ -907,20 +931,65 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
   const headerScrollRef = useRef<HTMLDivElement>(null);
   const stickyChromeRef = useRef<HTMLDivElement>(null);
   const rowsClipRef = useRef<HTMLDivElement>(null);
+  const rowsContainerRef = useRef<HTMLDivElement>(null);
   const gridRef = useRef<HTMLDivElement>(null);
   const measureElementFn = useCallback((el: Element) => el.getBoundingClientRect().height, []);
 
+  // In page-scroll mode (see findScrollParent) the virtualizer measures against
+  // the nearest scrollable ancestor, offset by how far the row list sits below
+  // that scroller's top (`scrollMargin`). In grid-owned-scroll mode the grid's
+  // own container is the scroller and there is no offset.
+  const usesAncestorScroll = !(fillHeight || maxHeight != null);
+  const [ancestorScrollEl, setAncestorScrollEl] = useState<HTMLElement | null>(null);
+  const [scrollMargin, setScrollMargin] = useState(0);
+
+  useLayoutEffect(() => {
+    if (!usesAncestorScroll) {
+      setAncestorScrollEl(null);
+      return;
+    }
+    setAncestorScrollEl(findScrollParent(gridRef.current));
+  }, [usesAncestorScroll]);
+
+  const activeScrollMargin = usesAncestorScroll ? scrollMargin : 0;
+
   const rowVirtualizer = useVirtualizer({
     count: rows.length,
-    getScrollElement: () => scrollContainerRef.current,
+    getScrollElement: () => (usesAncestorScroll ? ancestorScrollEl : scrollContainerRef.current),
     estimateSize: () => estimatedRowHeight,
     overscan,
+    scrollMargin: activeScrollMargin,
     getItemKey: (index) => {
       const row = rows[index];
       return row != null ? String(getRowId(row)) : index;
     },
     ...(isDynamicRowHeight ? { measureElement: measureElementFn } : {}),
   });
+
+  // Keep `scrollMargin` synced with the row list's offset inside the ancestor
+  // scroller. The list sits below the sticky toolbar/header, so its offset is
+  // stable as rows load, but we re-measure on resize and row-count changes to
+  // stay correct across layout shifts.
+  useLayoutEffect(() => {
+    if (!usesAncestorScroll || !ancestorScrollEl) return;
+    const listEl = rowsContainerRef.current;
+    if (!listEl) return;
+    const update = () => {
+      const offset = listEl.getBoundingClientRect().top
+        - ancestorScrollEl.getBoundingClientRect().top
+        + ancestorScrollEl.scrollTop;
+      setScrollMargin((prev) => (Math.abs(prev - offset) > 0.5 ? offset : prev));
+    };
+    update();
+    const observer = new ResizeObserver(update);
+    observer.observe(ancestorScrollEl);
+    observer.observe(listEl);
+    window.addEventListener("resize", update);
+    return () => {
+      observer.disconnect();
+      window.removeEventListener("resize", update);
+    };
+  }, [usesAncestorScroll, ancestorScrollEl, rows.length, isLoading]);
 
   // ── Sticky chrome clipping ───────────────────────────────────
   useLayoutEffect(() => {
@@ -1134,6 +1203,7 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
 
             {!isLoading && rows.length > 0 && (
               <div
+                ref={rowsContainerRef}
                 style={{
                   height: rowVirtualizer.getTotalSize(),
                   width: "100%",
@@ -1168,7 +1238,7 @@ export function DataGrid<TRow>(props: DataGridProps<TRow>) {
                         ...(isDynamicRowHeight
                           ? { minHeight: estimatedRowHeight }
                           : { height: fixedRowHeight }),
-                        transform: `translateY(${virtualRow.start}px)`,
+                        transform: `translateY(${virtualRow.start - activeScrollMargin}px)`,
                       }}
                       onClick={(e) => { if (!shouldIgnoreRowClick(e)) handleRowClick(row, rowId, e); }}
                       onDoubleClick={(e) => { if (!shouldIgnoreRowClick(e)) onRowDoubleClick?.(row, rowId, e); }}


### PR DESCRIPTION
## Summary

Infinite-scroll DataGrids that use `fillHeight={false}` (the payments **Transactions** table, the **Customers** list, and the users/teams lists) crash and reload the tab once they load a lot of rows. Root cause: in page-scroll mode the grid's own container does not scroll — the page shell does — but the virtualizer was measuring the grid's own container:

```ts
getScrollElement: () => scrollContainerRef.current
```

That container is unbounded (`h-auto`, no overflow scroll), so its measured "viewport" height equals the full content height. The virtualizer therefore treats *every* row as visible and renders the entire list into the DOM. As more pages load (and, for transactions, each visible row also spins up a per-row `useUser`/`useTeam` fetch), the DOM and memory grow without bound until the tab OOMs and reloads.

Fix: when the grid does not own its scroll (`!(fillHeight || maxHeight != null)`), virtualize against the nearest scrollable **ancestor** instead, offset by the row list's position within that scroller (`scrollMargin`):

```ts
const usesAncestorScroll = !(fillHeight || maxHeight != null);
// walk up to the real scroller (overflowY: auto|scroll|overlay)
getScrollElement: () => usesAncestorScroll ? ancestorScrollEl : scrollContainerRef.current
scrollMargin:      usesAncestorScroll ? measuredOffset : 0
// item positioning subtracts the margin
transform: `translateY(${virtualRow.start - activeScrollMargin}px)`
```

`scrollMargin` is measured (and kept in sync via `ResizeObserver` + resize) as the row list's top relative to the scroller's scroll origin. Grid-owned-scroll mode (`fillHeight` / `maxHeight`) is unchanged — `scrollMargin` stays `0` and the scroller stays the grid's own container. No call sites change; every page-scroll grid now windows its rows.

## Tests
- New `findScrollParent` unit tests (nearest scrollable ancestor, `overflowY: scroll`, no-scroll → `null`, `null` input → `null`). jsdom can't faithfully reproduce unbounded layout for a row-count assertion, so windowing is validated in-browser.
- Existing DataGrid tests still pass (infinite-scroll observer root, controlled callbacks, horizontal sticky clipping).


Link to Devin session: https://app.devin.ai/sessions/ece2b2ff5ce646b8b44ed953556ddca6
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes `DataGrid` virtualization when the page scrolls instead of the grid, preventing large-list crashes and OOM reloads in Transactions, Customers, and Users/Teams. Rows are now windowed correctly in page-scroll mode with stable positioning.

- **Bug Fixes**
  - In page-scroll mode (`fillHeight={false}` and no `maxHeight`), measure the nearest scrollable ancestor and apply a `scrollMargin` offset; row transforms subtract this margin. Fall back to the grid container if no scrollable ancestor exists.
  - Keep the margin in sync via `ResizeObserver`, window resize, and observing sticky chrome/header; grid-owned-scroll mode is unchanged.
  - Adds unit tests for `findScrollParent`; existing `DataGrid` tests still pass.

<sup>Written for commit baa07e51b60a13da32ae9f12e866387d6febf582. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1733?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced DataGrid virtualization to better support “page scroll” and other externally-driven scrolling, keeping virtualized rows correctly aligned.
  * Added automatic detection of the nearest vertical scroll container to drive virtualization behavior.

* **Bug Fixes**
  * Fixed virtual row positioning when the DataGrid is not constrained to its own internal scroll area.

* **Tests**
  * Added unit test coverage for nearest scrollable parent detection, including nested containers and edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->