### PR TITLE
Dashboard tab fix in devtool

### DIFF
--- a/apps/dashboard/src/lib/remote-development-environment/manager.ts
+++ b/apps/dashboard/src/lib/remote-development-environment/manager.ts
@@ -396,11 +396,14 @@ function createInternalApp(apiBaseUrl: string, anonymousRefreshToken?: string) {
 function envVarsForProject(project: RemoteDevelopmentEnvironmentProject): Record<string, string> {
   const brands = ["HEXCLAVE", "STACK"];
   const publicPrefixes = ["", "NEXT_PUBLIC_", "VITE_", "EXPO_PUBLIC_"];
+  const dashboardUrl = getPublicEnvVar("NEXT_PUBLIC_STACK_DASHBOARD_URL");
 
   const publicValues: Record<string, string> = {
     PROJECT_ID: project.projectId,
     PUBLISHABLE_CLIENT_KEY: project.publishableClientKey,
     API_URL: project.apiBaseUrl,
+    IS_REMOTE_DEVELOPMENT_ENVIRONMENT: "true",
+    ...(dashboardUrl == null ? {} : { DASHBOARD_URL: dashboardUrl }),
   };
   const secretValues: Record<string, string> = {
     SECRET_SERVER_KEY: project.secretServerKey,

--- a/packages/template/scripts/generate-env.ts
+++ b/packages/template/scripts/generate-env.ts
@@ -28,6 +28,9 @@ const envVarsConfig: Record<string, { allowPublic?: boolean, deprecatedLegacyNam
     allowPublic: true,
     deprecatedLegacyNames: ["HEXCLAVE_URL", "STACK_URL"],
   },
+  HEXCLAVE_DASHBOARD_URL: {
+    allowPublic: true,
+  },
   HEXCLAVE_HOSTED_HANDLER_DOMAIN_SUFFIX: {
     allowPublic: true,
   },
@@ -44,6 +47,9 @@ const envVarsConfig: Record<string, { allowPublic?: boolean, deprecatedLegacyNam
     allowPublic: true,
   },
   HEXCLAVE_IS_LOCAL_EMULATOR: {
+    allowPublic: true,
+  },
+  HEXCLAVE_IS_REMOTE_DEVELOPMENT_ENVIRONMENT: {
     allowPublic: true,
   },
   HEXCLAVE_POSTHOG_KEY: {

--- a/packages/template/src/dev-tool/dev-tool-core.ts
+++ b/packages/template/src/dev-tool/dev-tool-core.ts
@@ -190,8 +190,22 @@ function resolveApiBaseUrl(app: StackClientApp<true>): string {
   return getBaseUrl(opts.baseUrl);
 }
 
+function resolveConfiguredLocalDashboardBaseUrl(): string | undefined {
+  const dashboardUrl = envVars.HEXCLAVE_DASHBOARD_URL;
+  if (dashboardUrl == null || !isLocalhost(dashboardUrl)) return undefined;
+  try {
+    return new URL(dashboardUrl).origin;
+  } catch {
+    return undefined;
+  }
+}
+
 function shouldShowDashboardTab(app: StackClientApp<true>): boolean {
-  return envVars.HEXCLAVE_IS_LOCAL_EMULATOR === "true" && isLocalhost(resolveApiBaseUrl(app));
+  return (
+    envVars.HEXCLAVE_IS_LOCAL_EMULATOR === "true" && isLocalhost(resolveApiBaseUrl(app))
+  ) || (
+    envVars.HEXCLAVE_IS_REMOTE_DEVELOPMENT_ENVIRONMENT === "true" && resolveConfiguredLocalDashboardBaseUrl() != null
+  );
 }
 
 function getTabsForApp(app: StackClientApp<true>): { id: TabId; label: string; icon: string }[] {
@@ -222,7 +236,7 @@ function deriveDashboardBaseUrl(apiBaseUrl: string): string {
 }
 
 function resolveDashboardUrl(app: StackClientApp<true>): string {
-  const base = deriveDashboardBaseUrl(resolveApiBaseUrl(app));
+  const base = resolveConfiguredLocalDashboardBaseUrl() ?? deriveDashboardBaseUrl(resolveApiBaseUrl(app));
   return `${base}/projects/${encodeURIComponent(app.projectId)}`;
 }
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the Dev Tool Dashboard tab visibility and URL resolution for local and remote dev environments. Adds support for a local dashboard URL so the tab always points to the right project.

- **Bug Fixes**
  - Show Dashboard tab when the local emulator is active or when `HEXCLAVE_IS_REMOTE_DEVELOPMENT_ENVIRONMENT=true` and a local `HEXCLAVE_DASHBOARD_URL` is set.
  - Resolve the dashboard base URL from `HEXCLAVE_DASHBOARD_URL` (localhost only), else fall back to the API-derived URL; plumb `DASHBOARD_URL` and `IS_REMOTE_DEVELOPMENT_ENVIRONMENT` to apps launched from the dashboard and add both env keys to the template env generator (public).

<sup>Written for commit 90d795cc9cdcc082aa1efe8e0736ea0f5f1a7179. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1736?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * The dashboard can now use a configured local URL when available.
  * Remote development environments can now show the Dashboard tab and connect to the correct dashboard location.
  * Additional environment settings are now available for dashboard-related configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->