### PR TITLE
Keep the dashboard loading when bulldozer is down (internal billing degrades gracefully)

### DIFF
--- a/apps/backend/src/lib/plan-usage.test.ts
+++ b/apps/backend/src/lib/plan-usage.test.ts
@@ -1,6 +1,6 @@
 import { ITEM_IDS, UNLIMITED } from "@hexclave/shared/dist/plans";
 import type { SubscriptionRow } from "./payments/schema/types";
-import { buildUsageRow, getNextPlanId, getPlanUsagePeriod } from "./plan-usage";
+import { buildUsageRow, getNextPlanId, getPlanUsagePeriod, readBillingSubscriptionMapOrSkip } from "./plan-usage";
 import { describe, expect, it } from "vitest";
 
 function createSubscriptionPeriod(startMillis: number, endMillis: number): SubscriptionRow {
@@ -131,6 +131,32 @@ describe("plan upgrade targets", () => {
         "team": "growth",
       }
     `);
+  });
+});
+
+describe("readBillingSubscriptionMapOrSkip", () => {
+  it("returns the subscription map when the bulldozer read succeeds", async () => {
+    const start = Date.UTC(2026, 4, 15);
+    const end = Date.UTC(2026, 5, 15);
+    const subMap = { sub_1: createSubscriptionPeriod(start, end) };
+    const result = await readBillingSubscriptionMapOrSkip(() => Promise.resolve(subMap));
+    expect(result).toBe(subMap);
+  });
+
+  it("falls back to an empty map (free plan) instead of throwing when bulldozer is down", async () => {
+    // Regression: plan usage is read on the dashboard's own pages (overview
+    // limit banners, usage page). A bulldozer outage here used to bubble a 500
+    // and take the whole dashboard down. It must now degrade to "no
+    // subscription" (free plan) rather than failing the page.
+    const result = await readBillingSubscriptionMapOrSkip(() => {
+      throw new Error("bulldozer unreachable");
+    });
+    expect(result).toEqual({});
+  });
+
+  it("also swallows async rejections from the bulldozer read", async () => {
+    const result = await readBillingSubscriptionMapOrSkip(() => Promise.reject(new Error("bulldozer timed out")));
+    expect(result).toEqual({});
   });
 });
 

--- a/apps/backend/src/lib/plan-usage.ts
+++ b/apps/backend/src/lib/plan-usage.ts
@@ -12,7 +12,7 @@ import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch, getTenancy, type Te
 import { getPrismaClientForTenancy, getPrismaSchemaForTenancy, globalPrismaClient, sqlQuoteIdent } from "@/prisma-client";
 import { BASE_PLAN_IDS_BY_TIER, ITEM_IDS, PLAN_LIMITS, UNLIMITED, type ItemId, type PlanId } from "@hexclave/shared/dist/plans";
 import type { PlanUsageResponse } from "@hexclave/shared/dist/interface/admin-interface";
-import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { mapWithConcurrency } from "@hexclave/shared/dist/utils/promises";
 import type { SubscriptionRow } from "./payments/schema/types";
 
@@ -134,6 +134,27 @@ function getPlanLabel(planId: PlanId): string {
 
 function getUsageItemLabel(itemId: ItemId): string {
   return USAGE_ITEM_LABELS.get(itemId) ?? throwErr(`Missing usage item label for ${itemId}`);
+}
+
+/**
+ * Reads the billing team's subscription map, but never lets a bulldozer outage
+ * break the caller. Plan usage is surfaced only on the dashboard's own
+ * (internal project) surfaces — the overview/analytics limit banners and the
+ * usage page — so a hard dependency on bulldozer here would take the whole
+ * dashboard down whenever bulldozer is unreachable. On failure we report the
+ * error and fall back to an empty subscription map, which resolves to the free
+ * plan: we skip whatever we would normally bill/enforce rather than failing the
+ * page. The real plan is re-resolved on the next request once bulldozer is back.
+ */
+export async function readBillingSubscriptionMapOrSkip(
+  read: () => Promise<Record<string, SubscriptionRow>>,
+): Promise<Record<string, SubscriptionRow>> {
+  try {
+    return await read();
+  } catch (error) {
+    captureError("plan-usage:subscription-map-unavailable", error);
+    return {};
+  }
 }
 
 function resolveActivePlanSubscription(subscriptions: Record<string, SubscriptionRow>): SubscriptionRow | null {
@@ -394,12 +415,12 @@ export async function getPlanUsageForProject(project: UsageSourceProject, now: D
 
   const internalTenancy = await getInternalBillingTenancy();
   const internalPrisma = await getPrismaClientForTenancy(internalTenancy);
-  const subscriptions = await getSubscriptionMapForCustomer({
+  const subscriptions = await readBillingSubscriptionMapOrSkip(() => getSubscriptionMapForCustomer({
     prisma: internalPrisma,
     tenancyId: internalTenancy.id,
     customerType: "team",
     customerId: ownerTeamId,
-  });
+  }));
   const activePlanSubscription = resolveActivePlanSubscription(subscriptions);
   const planId = resolveActivePlanId(activePlanSubscription);
   const period = getPlanUsagePeriod(activePlanSubscription, now);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
@@ -18,9 +18,11 @@ import { Alert, AlertDescription, Button } from "@/components/ui";
 import { Link } from "@/components/link";
 import { useDashboardInternalUser } from "@/lib/dashboard-user";
 import { PLAN_LIMITS, resolvePlanId } from "@hexclave/shared/dist/plans";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
 import { useVirtualizer } from "@tanstack/react-virtual";
-import { useMemo, useRef } from "react";
+import { ErrorBoundary } from "next/dist/client/components/error-boundary";
+import { Suspense, useEffect, useMemo, useRef, type ReactNode } from "react";
 import { useAdminApp } from "../use-admin-app";
 
 // ============================================================================
@@ -323,10 +325,44 @@ export function ErrorDisplay({ error, onRetry }: { error: unknown, onRetry: () =
 }
 
 /**
+ * The plan-limit banners live on core dashboard pages (overview, analytics,
+ * session replays) but read the internal project's billing state from
+ * bulldozer (plan usage, owned products, item quantities). Billing is not
+ * essential to those pages, so a bulldozer outage must not take them down:
+ * on any read failure we report it and render nothing rather than letting the
+ * error escape to the page. `Suspense` keeps the banner from blocking the page
+ * while its data loads.
+ */
+function BillingBannerErrorFallback() {
+  useEffect(() => {
+    captureError("analytics-limit-banner:billing-read-failed", new Error("Failed to load plan-limit banner data; hiding the banner"));
+  }, []);
+  return null;
+}
+
+function ResilientBillingBanner(props: { children: ReactNode }) {
+  return (
+    <ErrorBoundary errorComponent={BillingBannerErrorFallback}>
+      <Suspense fallback={null}>
+        {props.children}
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+/**
  * Shows a warning banner when analytics event usage is at 80%+ or 100%.
  * Fetches the billing team's analytics_events item and computes usage against the plan's total allocation.
  */
 export function AnalyticsEventLimitBanner() {
+  return (
+    <ResilientBillingBanner>
+      <AnalyticsEventLimitBannerContent />
+    </ResilientBillingBanner>
+  );
+}
+
+function AnalyticsEventLimitBannerContent() {
   const adminApp = useAdminApp();
   const project = adminApp.useProject();
   const planUsage = adminApp.usePlanUsage();
@@ -350,6 +386,14 @@ export function AnalyticsEventLimitBanner() {
  * Since the limit is the same across all plans, no upgrade button is shown.
  */
 export function SessionReplayLimitBanner() {
+  return (
+    <ResilientBillingBanner>
+      <SessionReplayLimitBannerContent />
+    </ResilientBillingBanner>
+  );
+}
+
+function SessionReplayLimitBannerContent() {
   const adminApp = useAdminApp();
   const project = adminApp.useProject();
   const planUsage = adminApp.usePlanUsage();

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
@@ -37,12 +37,13 @@ import type { CompleteConfig } from "@hexclave/shared/dist/config/schema";
 import type { RestrictedReason } from "@hexclave/shared/dist/schema-fields";
 import { urlSchema, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
-import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { allProviders } from "@hexclave/shared/dist/utils/oauth";
 import { typedFromEntries, typedEntries } from "@hexclave/shared/dist/utils/objects";
 import { resolvePlanId } from "@hexclave/shared/dist/plans";
 import { generateUuid } from "@hexclave/shared/dist/utils/uuids";
-import { useId, useMemo, useState } from "react";
+import { ErrorBoundary } from "next/dist/client/components/error-boundary";
+import { Suspense, useEffect, useId, useMemo, useState } from "react";
 import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp } from "../use-admin-app";
@@ -193,7 +194,24 @@ function AddCustomOidcButton({ onClick }: { onClick: () => void }) {
     return <AddCustomOidcButtonDisabled onClick={onClick} isTeamPlanOrAbove={false} />;
   }
 
-  return <AddCustomOidcButtonInner team={ownerTeam} onClick={onClick} />;
+  // The plan check reads the internal project's owned products from bulldozer.
+  // That gate must not break the auth-methods page if bulldozer is down: on a
+  // read failure (or while it loads) we report it and fall back to the locked
+  // (non-Team) state, which is the same safe default as having no owner team.
+  return (
+    <ErrorBoundary errorComponent={() => <AddCustomOidcButtonPlanReadFailed onClick={onClick} />}>
+      <Suspense fallback={<AddCustomOidcButtonDisabled onClick={onClick} isTeamPlanOrAbove={false} />}>
+        <AddCustomOidcButtonInner team={ownerTeam} onClick={onClick} />
+      </Suspense>
+    </ErrorBoundary>
+  );
+}
+
+function AddCustomOidcButtonPlanReadFailed({ onClick }: { onClick: () => void }) {
+  useEffect(() => {
+    captureError("auth-methods:custom-oidc-plan-gate", new Error("Failed to load owner team plan for the custom OIDC gate; defaulting to locked"));
+  }, []);
+  return <AddCustomOidcButtonDisabled onClick={onClick} isTeamPlanOrAbove={false} />;
 }
 
 function AddCustomOidcButtonInner({


### PR DESCRIPTION
## Problem

Several dashboard pages read the **internal project's** billing state (plan usage, owned products, item quantities) from bulldozer during render. When bulldozer is unreachable, those reads throw and take the whole page down — e.g. the overview page renders `<AnalyticsEventLimitBanner />` **outside** its `ErrorBoundary`, so the error escapes to the layout and the dashboard "fails to load".

Internal-project billing should never be a hard dependency for pages that don't directly require payments. When bulldozer is down we should `captureError` and skip whatever we'd normally bill/enforce, rather than break the page.

## Changes

**Backend — `plan-usage.ts`**
- `getPlanUsageForProject` now reads the billing team's subscription map through a new `readBillingSubscriptionMapOrSkip` helper: on failure it `captureError`s and falls back to an empty map, which resolves to the free plan / calendar-month period. Usage counts (from Prisma/ClickHouse) are still returned, so the usage page and the limit banners keep working with a degraded (free) plan instead of 500ing.

**Frontend — degrade the internal-billing widgets instead of crashing the page**
- `analytics/shared.tsx`: `AnalyticsEventLimitBanner` and `SessionReplayLimitBanner` now wrap their data-reading content in an `ErrorBoundary` (renders nothing + `captureError`) and a `Suspense`. A bulldozer outage hides the banner rather than escaping to the page. This covers every call site (overview, analytics tables/queries, session replays).
- `auth-methods/page-client.tsx`: the "Add Custom OIDC" plan gate reads the owner team's products; it now falls back to the locked (non-Team) state on read failure — the same safe default as having no owner team.

Customer-facing payment pages/endpoints (which *do* directly require payments) are unchanged and still surface errors.

## Tests

- `plan-usage.test.ts`: added coverage for `readBillingSubscriptionMapOrSkip` (returns the map on success, falls back to `{}` on sync throw and async rejection).


Link to Devin session: https://app.devin.ai/sessions/4845ca1bf35c464b9c7a295bbceb7ef8
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Keep the dashboard usable when `bulldozer` is down by degrading internal billing reads to safe defaults. Limit banners and plan gates no longer crash pages; they hide or fall back to free/locked behavior. Payment pages are unchanged and still surface errors.

- **Bug Fixes**
  - Backend: added `readBillingSubscriptionMapOrSkip` and wired it into `getPlanUsageForProject`; on read failure we `captureError` and return `{}` (free plan/period) while still computing usage counts.
  - Frontend: wrapped `AnalyticsEventLimitBanner` and `SessionReplayLimitBanner`, plus the Custom OIDC plan gate, with `ErrorBoundary` + `Suspense` to hide on errors or default to locked; all failures are `captureError`’d.
  - Tests: added coverage for success, sync throw, and async rejection in the new subscription-map reader.

<sup>Written for commit 9a3face848f76454d7d009ef8e9958b7e5cc604c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1740?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Plan-related data now fails gracefully instead of breaking project pages, so billing limits and access checks load more reliably.
  * Analytics and session replay limit banners are more resilient and won’t interrupt the page if data loading fails.
  * The “Add Custom OIDC” button now stays safely disabled when plan information can’t be loaded, instead of causing errors.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->