### PR TITLE
Preserve the caught error in the billing-degradation error boundaries

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
@@ -333,16 +333,16 @@ export function ErrorDisplay({ error, onRetry }: { error: unknown, onRetry: () =
  * error escape to the page. `Suspense` keeps the banner from blocking the page
  * while its data loads.
  */
-function BillingBannerErrorFallback({ error }: { error: Error }) {
+function BillingBannerErrorFallback({ location, error }: { location: string, error: unknown }) {
   useEffect(() => {
-    captureError("analytics-limit-banner:billing-read-failed", error);
-  }, [error]);
+    captureError(location, error);
+  }, [location, error]);
   return null;
 }
 
-function ResilientBillingBanner(props: { children: ReactNode }) {
+function ResilientBillingBanner(props: { children: ReactNode, location: string }) {
   return (
-    <ErrorBoundary errorComponent={BillingBannerErrorFallback}>
+    <ErrorBoundary errorComponent={({ error }) => <BillingBannerErrorFallback location={props.location} error={error} />}>
       <Suspense fallback={null}>
         {props.children}
       </Suspense>
@@ -356,7 +356,7 @@ function ResilientBillingBanner(props: { children: ReactNode }) {
  */
 export function AnalyticsEventLimitBanner() {
   return (
-    <ResilientBillingBanner>
+    <ResilientBillingBanner location="analytics-limit-banner:billing-read-failed">
       <AnalyticsEventLimitBannerContent />
     </ResilientBillingBanner>
   );
@@ -387,7 +387,7 @@ function AnalyticsEventLimitBannerContent() {
  */
 export function SessionReplayLimitBanner() {
   return (
-    <ResilientBillingBanner>
+    <ResilientBillingBanner location="session-replay-limit-banner:billing-read-failed">
       <SessionReplayLimitBannerContent />
     </ResilientBillingBanner>
   );

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/shared.tsx
@@ -333,10 +333,10 @@ export function ErrorDisplay({ error, onRetry }: { error: unknown, onRetry: () =
  * error escape to the page. `Suspense` keeps the banner from blocking the page
  * while its data loads.
  */
-function BillingBannerErrorFallback() {
+function BillingBannerErrorFallback({ error }: { error: Error }) {
   useEffect(() => {
-    captureError("analytics-limit-banner:billing-read-failed", new Error("Failed to load plan-limit banner data; hiding the banner"));
-  }, []);
+    captureError("analytics-limit-banner:billing-read-failed", error);
+  }, [error]);
   return null;
 }
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
@@ -207,7 +207,7 @@ function AddCustomOidcButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-function AddCustomOidcButtonPlanReadFailed({ onClick, error }: { onClick: () => void, error: Error }) {
+function AddCustomOidcButtonPlanReadFailed({ onClick, error }: { onClick: () => void, error: unknown }) {
   useEffect(() => {
     captureError("auth-methods:custom-oidc-plan-gate", error);
   }, [error]);

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/page-client.tsx
@@ -199,7 +199,7 @@ function AddCustomOidcButton({ onClick }: { onClick: () => void }) {
   // read failure (or while it loads) we report it and fall back to the locked
   // (non-Team) state, which is the same safe default as having no owner team.
   return (
-    <ErrorBoundary errorComponent={() => <AddCustomOidcButtonPlanReadFailed onClick={onClick} />}>
+    <ErrorBoundary errorComponent={({ error }) => <AddCustomOidcButtonPlanReadFailed onClick={onClick} error={error} />}>
       <Suspense fallback={<AddCustomOidcButtonDisabled onClick={onClick} isTeamPlanOrAbove={false} />}>
         <AddCustomOidcButtonInner team={ownerTeam} onClick={onClick} />
       </Suspense>
@@ -207,10 +207,10 @@ function AddCustomOidcButton({ onClick }: { onClick: () => void }) {
   );
 }
 
-function AddCustomOidcButtonPlanReadFailed({ onClick }: { onClick: () => void }) {
+function AddCustomOidcButtonPlanReadFailed({ onClick, error }: { onClick: () => void, error: Error }) {
   useEffect(() => {
-    captureError("auth-methods:custom-oidc-plan-gate", new Error("Failed to load owner team plan for the custom OIDC gate; defaulting to locked"));
-  }, []);
+    captureError("auth-methods:custom-oidc-plan-gate", error);
+  }, [error]);
   return <AddCustomOidcButtonDisabled onClick={onClick} isTeamPlanOrAbove={false} />;
 }
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-json.generated.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/docs-json.generated.ts
@@ -245,9 +245,7 @@ const docsJson = {
     }
   },
   "seo": {
-    "metatags": {
-      "robots": "noindex"
-    }
+    "indexing": "all"
   },
   "settings": {
     "customScripts": [
@@ -255,7 +253,12 @@ const docsJson = {
       "/code-language-labels.js"
     ]
   },
-  "redirects": []
+  "redirects": [
+    {
+      "source": "/guides/going-further/backend-integration",
+      "destination": "/guides/going-further/local-vs-cloud-dashboard"
+    }
+  ]
 } as const;
 
 export default docsJson;


### PR DESCRIPTION
Follow-up to #1740 (Greptile review nits).

The error boundaries that hide billing widgets when bulldozer is down were logging a synthetic `new Error(...)` instead of the exception they caught, so the real status/cause/stack was lost in error reporting. Now the boundaries pass the caught `error` straight through to `captureError`:

- `analytics/shared.tsx`: `BillingBannerErrorFallback({ error })`
- `auth-methods/page-client.tsx`: `AddCustomOidcButtonPlanReadFailed({ onClick, error })`

No behavioral change — the degraded fallbacks still render exactly as before.


Link to Devin session: https://app.devin.ai/sessions/4845ca1bf35c464b9c7a295bbceb7ef8
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preserve the original error in billing-degradation error boundaries and tag each banner with a distinct location for clearer logging; also sync the generated docs config with `docs.json`. No UI or behavior changes.

- **Bug Fixes**
  - `analytics/shared.tsx`: Fallback now takes `{ location, error: unknown }` and calls `captureError(location, error)`; `AnalyticsEventLimitBanner` and `SessionReplayLimitBanner` pass distinct locations.
  - `auth-methods/page-client.tsx`: `ErrorBoundary` passes `{ error }` to `AddCustomOidcButtonPlanReadFailed`, which forwards it to `captureError("auth-methods:custom-oidc-plan-gate", error)`.

<sup>Written for commit d5602f473dca65226f3c03d21ae1e10d07eb12f1. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1741?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved error reporting in dashboard billing/limit banners and custom OIDC plan gating by capturing and logging the real underlying error with clear context.
* **SEO Updates**
  * Adjusted site indexing behavior to allow indexing, and added a redirect for the backend integration guide to its updated local vs cloud dashboard page.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->