### PR TITLE
Upgrade typechecking to TypeScript 7 (tsgo native compiler)

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf src/generated && rimraf .next && rimraf node_modules",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "with-env": "dotenv -c --",
     "with-env:dev": "dotenv -c development --",
     "with-env:prod": "dotenv -c production --",

--- a/apps/bulldozer-js/package.json
+++ b/apps/bulldozer-js/package.json
@@ -11,7 +11,7 @@
     "profile:performance": "tsx scripts/profile-bulldozer-performance.ts",
     "test": "vitest run",
     "test:watch": "vitest watch",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "eslint --ext .ts .",
     "clean": "rimraf dist && rimraf node_modules"
   },

--- a/apps/dashboard/package.json
+++ b/apps/dashboard/package.json
@@ -5,7 +5,7 @@
   "private": true,
   "scripts": {
     "clean": "rimraf .next .next-development-environment node_modules",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "with-env": "dotenv -c development --",
     "with-env:prod": "dotenv -c --",
     "dev": "concurrently -n \"dev,bundle-type-defs\" -k \"next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_LOCAL_DASHBOARD_PORT:-${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}01}\" \"pnpm run bundle-type-definitions:watch\"",

--- a/apps/dashboard/src/components/form-dialog.tsx
+++ b/apps/dashboard/src/components/form-dialog.tsx
@@ -8,11 +8,15 @@ import { FieldValues, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { SmartForm } from "./smart-form";
 
-export function SmartFormDialog<S extends yup.ObjectSchema<any, any, any, any>>(
+// Parametrize on the schema's inferred shape `F` rather than the whole schema type `S`
+// (see SmartForm): TypeScript 7 checks yup's `concat` method contravariantly, so a
+// concrete `ObjectSchema` is no longer assignable to `ObjectSchema<any, ...>`. The
+// default/flags params are left as `any` so `.default()` schemas (flag `"d"`) are accepted.
+export function SmartFormDialog<F extends FieldValues>(
   props: Omit<ActionDialogProps, 'children'> & {
-    formSchema: S,
-    defaultValues?: Partial<yup.InferType<S>>,
-    onSubmit: (values: yup.InferType<S>) => Promise<void | 'prevent-close'> | void | 'prevent-close',
+    formSchema: yup.ObjectSchema<F, yup.AnyObject, any, any>,
+    defaultValues?: Partial<F>,
+    onSubmit: (values: F) => Promise<void | 'prevent-close'> | void | 'prevent-close',
   },
 ) {
   const formId = `${useId()}-form`;
@@ -28,7 +32,7 @@ export function SmartFormDialog<S extends yup.ObjectSchema<any, any, any, any>>(
       ...((typeof props.okButton === "boolean") ? {} : props.okButton?.props),
     },
   };
-  const handleSubmit = async (values: yup.InferType<S>) => {
+  const handleSubmit = async (values: F) => {
     const res = await props.onSubmit(values);
     if (res !== 'prevent-close') {
       setOpenState(false);

--- a/apps/dashboard/src/components/smart-form.tsx
+++ b/apps/dashboard/src/components/smart-form.tsx
@@ -5,7 +5,7 @@ import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { Form } from "@/components/ui";
 import React, { useCallback, useEffect, useRef, useState } from "react";
-import { useForm } from "react-hook-form";
+import { FieldValues, useForm } from "react-hook-form";
 import * as yup from "yup";
 import { CheckboxField, DateField, InputField, NumberField, TextAreaField } from "./form-fields";
 
@@ -21,12 +21,18 @@ declare module 'yup' {
   }
 }
 
-export function SmartForm<S extends yup.ObjectSchema<any>>(props: {
-  formSchema: S,
-  onSubmit: (values: yup.InferType<S>) => Promise<void>,
+// Parametrize on the schema's inferred shape `F` rather than the whole schema type `S`
+// (mirrors FormDialog below). TypeScript 7 checks yup's `concat` method contravariantly,
+// so a concrete `ObjectSchema` is no longer assignable to `ObjectSchema<any, ...>`;
+// inferring `F` makes that comparison concrete-to-concrete instead. The default/flags
+// params are left as `any` so schemas built with `.default()` (flag `"d"`) are accepted
+// and still satisfy `yupResolver`, which expects the default flag `""`.
+export function SmartForm<F extends FieldValues>(props: {
+  formSchema: yup.ObjectSchema<F, yup.AnyObject, any, any>,
+  onSubmit: (values: F) => Promise<void>,
   formId?: string,
   onChangeIsSubmitting?: (isSubmitting: boolean) => void,
-  defaultValues?: Partial<yup.InferType<S>>,
+  defaultValues?: Partial<F>,
   isOpen?: boolean,
 }) {
   const resolvedDefaultValues = props.defaultValues ?? props.formSchema.getDefault();
@@ -40,7 +46,7 @@ export function SmartForm<S extends yup.ObjectSchema<any>>(props: {
     props.onChangeIsSubmitting?.(true);
     setIsSubmitting(true);
     try {
-      await form.handleSubmit(async (values: yup.InferType<S>, e?: React.BaseSyntheticEvent) => {
+      await form.handleSubmit(async (values: F, e?: React.BaseSyntheticEvent) => {
         e!.preventDefault();
         await props.onSubmit(values);
         form.reset(resolvedDefaultValues);

--- a/apps/e2e/package.json
+++ b/apps/e2e/package.json
@@ -9,7 +9,7 @@
     "test": "vitest run",
     "lint": "eslint --ext .tsx,.ts .",
     "clean": "rimraf dist && rimraf node_modules",
-    "typecheck": "tsc --noEmit"
+    "typecheck": "tsgo --noEmit"
   },
   "dependencies": {
     "@oslojs/otp": "^1.1.0",

--- a/apps/hosted-components/package.json
+++ b/apps/hosted-components/package.json
@@ -8,7 +8,7 @@
     "build": "vite build",
     "start": "node .output/server/index.mjs",
     "lint": "eslint --ext .ts,.tsx .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .output && rimraf node_modules"
   },
   "dependencies": {

--- a/apps/internal-tool/package.json
+++ b/apps/internal-tool/package.json
@@ -7,7 +7,7 @@
     "dev": "node scripts/pre-dev.mjs && next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}41",
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}41",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "eslint --ext .ts,.tsx .",
     "clean": "rimraf .next && rimraf node_modules",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb",

--- a/apps/mcp/package.json
+++ b/apps/mcp/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf .next && rimraf node_modules",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "dev": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}44",
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}44",

--- a/apps/mock-oauth-server/package.json
+++ b/apps/mock-oauth-server/package.json
@@ -7,7 +7,7 @@
   "scripts": {
     "start": "tsx src/index.ts",
     "dev": "tsx watch --clear-screen=false src/index.ts",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "eslint .",
     "clean": "rimraf dist && rimraf node_modules"
   },

--- a/apps/skills/package.json
+++ b/apps/skills/package.json
@@ -6,7 +6,7 @@
   "type": "module",
   "scripts": {
     "clean": "rimraf .next && rimraf node_modules",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "dev": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}45",
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}45",

--- a/docs/package.json
+++ b/docs/package.json
@@ -11,7 +11,7 @@
     "build": "next build",
     "dev": "next dev --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}26",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}26",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "lint": "eslint .",
     "lint:fix": "eslint . --fix",
     "postinstall": "fumadocs-mdx",

--- a/examples/cjs-test/package.json
+++ b/examples/cjs-test/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}10",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules"
   },
   "dependencies": {

--- a/examples/convex/package.json
+++ b/examples/convex/package.json
@@ -14,7 +14,7 @@
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}27",
     "build": "next build",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules"
   },
   "dependencies": {

--- a/examples/demo/package.json
+++ b/examples/demo/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules",
     "dev": "NEXT_PUBLIC_HEXCLAVE_LOCAL_DASHBOARD_PORT=${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}42 node scripts/dev-with-retry.mjs",
     "dev:inner": "next dev --turbopack --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}03",

--- a/examples/docs-examples/package.json
+++ b/examples/docs-examples/package.json
@@ -5,7 +5,7 @@
   "description": "",
   "private": true,
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules",
     "dev": "next dev --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}08",
     "build": "next build",

--- a/examples/e-commerce/package.json
+++ b/examples/e-commerce/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}11",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules"
   },
   "dependencies": {

--- a/examples/middleware/package.json
+++ b/examples/middleware/package.json
@@ -8,7 +8,7 @@
     "build": "next build",
     "start": "next start --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}12",
     "lint": "next lint",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .next && rimraf node_modules"
   },
   "dependencies": {

--- a/examples/react-example/package.json
+++ b/examples/react-example/package.json
@@ -8,7 +8,7 @@
     "dev": "vite --force --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}20",
     "build": "tsc -b && vite build",
     "clean": "rimraf dist && rimraf node_modules",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "preview": "vite preview"
   },
   "dependencies": {

--- a/examples/tanstack-start-demo/package.json
+++ b/examples/tanstack-start-demo/package.json
@@ -6,7 +6,7 @@
   "private": true,
   "type": "module",
   "scripts": {
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf .output && rimraf node_modules",
     "dev": "vite dev --port ${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}43",
     "build": "vite build",

--- a/package.json
+++ b/package.json
@@ -100,6 +100,7 @@
     "turbo": "^2.8.15",
     "unrun": "^0.2.39",
     "typescript": "6.0.3",
+    "@typescript/native-preview": "7.0.0-dev.20260707.2",
     "vite-tsconfig-paths": "^4.3.2",
     "vitest": "^1.6.0",
     "wait-on": "^8.0.1"

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -13,7 +13,7 @@
     "build": "tsdown",
     "package-dashboard-release": "node scripts/package-dashboard-release.mjs",
     "lint": "eslint --ext .tsx,.ts .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run"
   },
   "files": [

--- a/packages/dashboard-ui-components/package.json
+++ b/packages/dashboard-ui-components/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rimraf dist && tsdown && pnpm run build-iife && pnpm run copy-iife",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf dist && rimraf node_modules",
     "build-iife": "tsx scripts/build-iife.ts",
     "copy-iife": "tsx scripts/copy-iife.ts",

--- a/packages/sc/package.json
+++ b/packages/sc/package.json
@@ -35,7 +35,7 @@
   },
   "scripts": {
     "build": "rimraf dist && tsdown",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf dist && rimraf node_modules",
     "lint": "eslint --ext .tsx,.ts ."
   },

--- a/packages/shared-backend/package.json
+++ b/packages/shared-backend/package.json
@@ -24,7 +24,7 @@
     "build": "rimraf dist && tsdown",
     "clean": "rimraf dist && rimraf node_modules",
     "lint": "eslint --ext .tsx,.ts .",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run"
   },
   "files": [

--- a/packages/shared/package.json
+++ b/packages/shared/package.json
@@ -4,7 +4,7 @@
   "repository": "https://github.com/hexclave/hexclave",
   "scripts": {
     "build": "rimraf dist && tsdown",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "test": "vitest run",
     "clean": "rimraf dist && rimraf node_modules",
     "lint": "eslint --ext .tsx,.ts ."

--- a/packages/ui/package.json
+++ b/packages/ui/package.json
@@ -7,7 +7,7 @@
   "sideEffects": false,
   "scripts": {
     "build": "rimraf dist && tsdown",
-    "typecheck": "tsc --noEmit",
+    "typecheck": "tsgo --noEmit",
     "clean": "rimraf dist && rimraf node_modules",
     "lint": "eslint --ext .tsx,.ts ."
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1661,10 +1661,10 @@ importers:
         version: link:../../packages/next
       '@supabase/ssr':
         specifier: latest
-        version: 0.12.0(@supabase/supabase-js@2.110.0)
+        version: 0.12.0(@supabase/supabase-js@2.108.2)
       '@supabase/supabase-js':
         specifier: latest
-        version: 2.110.0
+        version: 2.108.2
       jose:
         specifier: ^5.2.2
         version: 5.6.3
@@ -9191,37 +9191,37 @@ packages:
     resolution: {integrity: sha512-SXuhqhuR5FXaYgKTXzZJeqtVA6JKb9IZWaGeEUxHHiOcFy2p51wccO72bYpXwoK4D5pzQOIYLTuAc7etxyMmwg==}
     engines: {node: '>=12.16'}
 
-  '@supabase/auth-js@2.110.0':
-    resolution: {integrity: sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/auth-js@2.108.2':
+    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
+    engines: {node: '>=20.0.0'}
 
-  '@supabase/functions-js@2.110.0':
-    resolution: {integrity: sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/functions-js@2.108.2':
+    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
+    engines: {node: '>=20.0.0'}
 
-  '@supabase/phoenix@0.4.4':
-    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
+  '@supabase/phoenix@0.4.2':
+    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
 
-  '@supabase/postgrest-js@2.110.0':
-    resolution: {integrity: sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/postgrest-js@2.108.2':
+    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
+    engines: {node: '>=20.0.0'}
 
-  '@supabase/realtime-js@2.110.0':
-    resolution: {integrity: sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/realtime-js@2.108.2':
+    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
+    engines: {node: '>=20.0.0'}
 
   '@supabase/ssr@0.12.0':
     resolution: {integrity: sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==}
     peerDependencies:
       '@supabase/supabase-js': ^2.108.0
 
-  '@supabase/storage-js@2.110.0':
-    resolution: {integrity: sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/storage-js@2.108.2':
+    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
+    engines: {node: '>=20.0.0'}
 
-  '@supabase/supabase-js@2.110.0':
-    resolution: {integrity: sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==}
-    engines: {node: '>=22.0.0'}
+  '@supabase/supabase-js@2.108.2':
+    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
+    engines: {node: '>=20.0.0'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -27847,42 +27847,42 @@ snapshots:
 
   '@stripe/stripe-js@7.7.0': {}
 
-  '@supabase/auth-js@2.110.0':
+  '@supabase/auth-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.110.0':
+  '@supabase/functions-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.4': {}
+  '@supabase/phoenix@0.4.2': {}
 
-  '@supabase/postgrest-js@2.110.0':
+  '@supabase/postgrest-js@2.108.2':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.110.0':
+  '@supabase/realtime-js@2.108.2':
     dependencies:
-      '@supabase/phoenix': 0.4.4
+      '@supabase/phoenix': 0.4.2
       tslib: 2.8.1
 
-  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.110.0)':
+  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.108.2)':
     dependencies:
-      '@supabase/supabase-js': 2.110.0
+      '@supabase/supabase-js': 2.108.2
       cookie: 1.0.2
 
-  '@supabase/storage-js@2.110.0':
+  '@supabase/storage-js@2.108.2':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.110.0':
+  '@supabase/supabase-js@2.108.2':
     dependencies:
-      '@supabase/auth-js': 2.110.0
-      '@supabase/functions-js': 2.110.0
-      '@supabase/postgrest-js': 2.110.0
-      '@supabase/realtime-js': 2.110.0
-      '@supabase/storage-js': 2.110.0
+      '@supabase/auth-js': 2.108.2
+      '@supabase/functions-js': 2.108.2
+      '@supabase/postgrest-js': 2.108.2
+      '@supabase/realtime-js': 2.108.2
+      '@supabase/storage-js': 2.108.2
 
   '@swc/counter@0.1.3': {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -45,6 +45,9 @@ importers:
       '@typescript-eslint/parser':
         specifier: ^8.56.1
         version: 8.56.1(eslint@8.57.1)(typescript@6.0.3)
+      '@typescript/native-preview':
+        specifier: 7.0.0-dev.20260707.2
+        version: 7.0.0-dev.20260707.2
       '@vitejs/plugin-react':
         specifier: ^4.3.3
         version: 4.3.3(vite@7.3.1(@types/node@20.17.6)(jiti@2.6.1)(lightningcss@1.32.0)(terser@5.44.0)(tsx@4.19.3)(yaml@2.6.0))
@@ -83,7 +86,7 @@ importers:
         version: 5.0.10
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.19.3)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.19.3)(typescript@6.0.3)(unrun@0.2.39)
       turbo:
         specifier: ^2.8.15
         version: 2.8.17
@@ -327,7 +330,7 @@ importers:
         version: 5.0.7
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.15.5)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.15.5)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.7.2
         version: 4.15.5
@@ -1658,10 +1661,10 @@ importers:
         version: link:../../packages/next
       '@supabase/ssr':
         specifier: latest
-        version: 0.12.0(@supabase/supabase-js@2.108.2)
+        version: 0.12.0(@supabase/supabase-js@2.110.0)
       '@supabase/supabase-js':
         specifier: latest
-        version: 2.108.2
+        version: 2.110.0
       jose:
         specifier: ^5.2.2
         version: 5.6.3
@@ -1784,7 +1787,7 @@ importers:
         version: 6.1.2
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       typescript:
         specifier: 6.0.3
         version: 6.0.3
@@ -1930,7 +1933,7 @@ importers:
         version: 3.4.14
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -2075,7 +2078,7 @@ importers:
         version: 3.4.18(tsx@4.21.0)(yaml@2.8.0)
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -2214,7 +2217,7 @@ importers:
         version: 3.4.14
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -2485,7 +2488,7 @@ importers:
         version: 3.4.18(tsx@4.21.0)(yaml@2.8.0)
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -2636,7 +2639,7 @@ importers:
         version: 3.4.14
       tsdown:
         specifier: ^0.22.3
-        version: 0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
+        version: 0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39)
       tsx:
         specifier: ^4.21.0
         version: 4.21.0
@@ -9188,37 +9191,37 @@ packages:
     resolution: {integrity: sha512-SXuhqhuR5FXaYgKTXzZJeqtVA6JKb9IZWaGeEUxHHiOcFy2p51wccO72bYpXwoK4D5pzQOIYLTuAc7etxyMmwg==}
     engines: {node: '>=12.16'}
 
-  '@supabase/auth-js@2.108.2':
-    resolution: {integrity: sha512-tNaQmBgodDZwgB40mRwVbxFy8IDYwjdpcZ0BYrWiwlULCSQoJj4QoG4zgJT7QRPXcqipefNOzvO/qAu4dF98ag==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/auth-js@2.110.0':
+    resolution: {integrity: sha512-Mi288WCTp6wxMFCOu/UgzgHEXODjdl2uVTLqK11eanzGZaldU3RyP8Am+ZbNuVzFP+5+iOvppxzv7N5Ym84xTg==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/functions-js@2.108.2':
-    resolution: {integrity: sha512-RNUX8EiBy3iLwAX19jtRzLyePnl11/fHcgwDHLnpKcDSXt/5qBnh3LUwAtIjT21Q66QsmNUR2esrHziLCpNubw==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/functions-js@2.110.0':
+    resolution: {integrity: sha512-Fde5wlY8ZZy+9yqrWlQHo8MacSyUBArBEtN2boB4thJQigPnQD/cc61qZN0n3I1L0gwhWtHYwIMnOBKxSvF6Hw==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/phoenix@0.4.2':
-    resolution: {integrity: sha512-YSAGnmDAfuleFCVt3CeurQZAhxRfXWeZIIkwp7NhYzQ1UwW6ePSnzsFAiUm/mbCkfoCf70QQHKW/K6RKh52a4A==}
+  '@supabase/phoenix@0.4.4':
+    resolution: {integrity: sha512-Gt0pqoXuIqX/8dvG0OKp/wMCobXNH3klNbUPBNyOfN0YA1IswrM3HyWFMOPk1Jy+BRaIyDPcFx4jLBwHNmlyfQ==}
 
-  '@supabase/postgrest-js@2.108.2':
-    resolution: {integrity: sha512-GQ28/Y8hk3CFmkb3kXH1h/AQx6JIYSQfO0CJMRVBcEKZoNy6C45cXAZ4fcJvRC5Id0cs6xnkUV0+c0rIocigsw==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/postgrest-js@2.110.0':
+    resolution: {integrity: sha512-ZbC1QZL3jcvBUfVKjJbgRM27G4Mg3Zzqdm44m5pJafe1e52Cli793EOnwQucomBAGEUDd03Nzaf7XV3ji/XexQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/realtime-js@2.108.2':
-    resolution: {integrity: sha512-aAGxCSUemZvQIibnCdvNvgaKib28I4rfrNjKbQ9cG1uBLwUsI7hVpGXgEbypCCDhLjQlDTAiJlu7rgljYUT73g==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/realtime-js@2.110.0':
+    resolution: {integrity: sha512-Wn2AWpneZuDFTkp/65tqctvoh+3JvyTjMam8sTMqVWy5BgkU8zAvFwilPYPPPhkINeKF8NAJKP7FclJ2iGCUMw==}
+    engines: {node: '>=22.0.0'}
 
   '@supabase/ssr@0.12.0':
     resolution: {integrity: sha512-d9XV5XzJvzzZbeAIM7fWTCUYxQJZ2Ru6ny3dJHmHGp/LIrJ+o9FpD7N9Rf/UhhWEvHXSoDe8SI32Z2ouOdMjBg==}
     peerDependencies:
       '@supabase/supabase-js': ^2.108.0
 
-  '@supabase/storage-js@2.108.2':
-    resolution: {integrity: sha512-TVZPQxXGxY2+A6yTtm77zUHsh70lBhYUEaJL8RQC+BghcX/ygiMG/rmXrNVBce30/WAeNPa8FiG8HbqlGeV05g==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/storage-js@2.110.0':
+    resolution: {integrity: sha512-71+gU3HrhiylAhftY6FmO5PPdcsScnVcS766CVD+vTYK9qTDLbrx8FhgBYbqGm3iV/wkTfzrNJfjGsMeFRkJRQ==}
+    engines: {node: '>=22.0.0'}
 
-  '@supabase/supabase-js@2.108.2':
-    resolution: {integrity: sha512-hFhnPveb5JQg4a0QYicM0swT253YHMdfeRAl2BKHOlI5VAzuHxUGSr8RbwNLYNPauWOgQMS1H8sz8bvYlgwUfQ==}
-    engines: {node: '>=20.0.0'}
+  '@supabase/supabase-js@2.110.0':
+    resolution: {integrity: sha512-8yI84VJiEVW4zxZpLUmxXmjzQ7O2St9X/ymzlBETDHTURPWG3LmvbSiibq+7dqAJmyoUfxZnSfXeM4HCM8s4XQ==}
+    engines: {node: '>=22.0.0'}
 
   '@swc/counter@0.1.3':
     resolution: {integrity: sha512-e2BR4lsJkkRlKZ/qCHPw9ZaSxc0MVUd7gtbtaB7aMvHeJVYe8sOB8DBZkP2DtISHGSku9sCK6T6cnY0CtXrOCQ==}
@@ -10092,6 +10095,53 @@ packages:
   '@typescript-eslint/visitor-keys@8.56.1':
     resolution: {integrity: sha512-KiROIzYdEV85YygXw6BI/Dx4fnBlFQu6Mq4QE4MOH9fFnhohw6wX/OAvDY2/C+ut0I3RSPKenvZJIVYqJNkhEw==}
     engines: {node: ^18.18.0 || ^20.9.0 || >=21.1.0}
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-wny2pgKjGbiZtnOIHVa3tXC1UfDqxNEFzyPGmiqybedG8hipG2Nfp0l5UxbaKCjkLacUpH/W5bP2hBOMVhCOzg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-Afc7M5zOwo+GpfcYwz5Z8HMB2tPVsui7nNIqEuuFB73MPdVqNn/Wmpe4tP4MRri0AtJnJknoHBaTJ/VDAp/Jhw==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-iITBa2WjjTI5N9t5l7Z4KoOSI+2zBlhbvFzsD/f8qX8QoKjz/Y4DPyBDgezYi8nkqjjksbgSOJ3/ykzhwrB9cg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [linux]
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-hJm/UOqZTr9FHmR7uNm8VGX4oKtfWk0Jem0zPeJFNC8ckGUfSBueyiEYMZB+XmRc1aG4x1E46y3CplP4CLHvGQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm]
+    os: [linux]
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-du0dzi6y97Po5vDNdPJTyyijHCpaS22JLRnKZEJXBDaO9gCIymOv/5QQokFRuOlQm0bWl3i9PF4OVdGP6uAOQA==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [linux]
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-SsAwfhyHJ1akgBc+99z4+hwdbHsdWaKB8EwCNIMA6JfSLMeUjffrYvxu+vfMyxVtOVOz7RrRXRoiDiu4a2sCtg==}
+    engines: {node: '>=16.20.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-DL4u27stv0fo71sVhOzHSwE+YMZsbBijVI+kg5dLDLilSH79WFTJ8RSQ46vJrCMt+Gjlv/JOZP1PuLJDfioYeQ==}
+    engines: {node: '>=16.20.0'}
+    cpu: [x64]
+    os: [win32]
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    resolution: {integrity: sha512-oUGp+Rep/hqMhPunyinsALUwSlzHINSxitifPiSaeqoKOKD2OlR9NE3TaPqwsl4NlGslsOSUXI1JotWQzpYCPg==}
+    engines: {node: '>=16.20.0'}
+    hasBin: true
 
   '@typescript/vfs@1.6.4':
     resolution: {integrity: sha512-PJFXFS4ZJKiJ9Qiuix6Dz/OwEIqHD7Dme1UwZhTK11vR+5dqW2ACbdndWQexBzCx+CPuMe5WBYQWCsFyGlQLlQ==}
@@ -27797,42 +27847,42 @@ snapshots:
 
   '@stripe/stripe-js@7.7.0': {}
 
-  '@supabase/auth-js@2.108.2':
+  '@supabase/auth-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/functions-js@2.108.2':
+  '@supabase/functions-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/phoenix@0.4.2': {}
+  '@supabase/phoenix@0.4.4': {}
 
-  '@supabase/postgrest-js@2.108.2':
+  '@supabase/postgrest-js@2.110.0':
     dependencies:
       tslib: 2.8.1
 
-  '@supabase/realtime-js@2.108.2':
+  '@supabase/realtime-js@2.110.0':
     dependencies:
-      '@supabase/phoenix': 0.4.2
+      '@supabase/phoenix': 0.4.4
       tslib: 2.8.1
 
-  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.108.2)':
+  '@supabase/ssr@0.12.0(@supabase/supabase-js@2.110.0)':
     dependencies:
-      '@supabase/supabase-js': 2.108.2
+      '@supabase/supabase-js': 2.110.0
       cookie: 1.0.2
 
-  '@supabase/storage-js@2.108.2':
+  '@supabase/storage-js@2.110.0':
     dependencies:
       iceberg-js: 0.8.1
       tslib: 2.8.1
 
-  '@supabase/supabase-js@2.108.2':
+  '@supabase/supabase-js@2.110.0':
     dependencies:
-      '@supabase/auth-js': 2.108.2
-      '@supabase/functions-js': 2.108.2
-      '@supabase/postgrest-js': 2.108.2
-      '@supabase/realtime-js': 2.108.2
-      '@supabase/storage-js': 2.108.2
+      '@supabase/auth-js': 2.110.0
+      '@supabase/functions-js': 2.110.0
+      '@supabase/postgrest-js': 2.110.0
+      '@supabase/realtime-js': 2.110.0
+      '@supabase/storage-js': 2.110.0
 
   '@swc/counter@0.1.3': {}
 
@@ -29218,6 +29268,37 @@ snapshots:
     dependencies:
       '@typescript-eslint/types': 8.56.1
       eslint-visitor-keys: 5.0.1
+
+  '@typescript/native-preview-darwin-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-darwin-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-arm@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-linux-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-arm64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview-win32-x64@7.0.0-dev.20260707.2':
+    optional: true
+
+  '@typescript/native-preview@7.0.0-dev.20260707.2':
+    optionalDependencies:
+      '@typescript/native-preview-darwin-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-darwin-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-linux-x64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-arm64': 7.0.0-dev.20260707.2
+      '@typescript/native-preview-win32-x64': 7.0.0-dev.20260707.2
 
   '@typescript/vfs@1.6.4(typescript@6.0.3)':
     dependencies:
@@ -37701,7 +37782,7 @@ snapshots:
 
   robust-predicates@3.0.2: {}
 
-  rolldown-plugin-dts@0.26.0(rolldown@1.1.2)(typescript@6.0.3):
+  rolldown-plugin-dts@0.26.0(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.1.2)(typescript@6.0.3):
     dependencies:
       '@babel/generator': 8.0.0
       '@babel/helper-validator-identifier': 8.0.2
@@ -37713,6 +37794,7 @@ snapshots:
       obug: 2.1.3
       rolldown: 1.1.2
     optionalDependencies:
+      '@typescript/native-preview': 7.0.0-dev.20260707.2
       typescript: 6.0.3
     transitivePeerDependencies:
       - oxc-resolver
@@ -39114,7 +39196,7 @@ snapshots:
       minimist: 1.2.8
       strip-bom: 3.0.0
 
-  tsdown@0.22.3(tsx@4.15.5)(typescript@6.0.3)(unrun@0.2.39):
+  tsdown@0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.15.5)(typescript@6.0.3)(unrun@0.2.39):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -39125,7 +39207,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.4
       rolldown: 1.1.2
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.2)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.1.2)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -39141,7 +39223,7 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.22.3(tsx@4.19.3)(typescript@6.0.3)(unrun@0.2.39):
+  tsdown@0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.19.3)(typescript@6.0.3)(unrun@0.2.39):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -39152,7 +39234,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.4
       rolldown: 1.1.2
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.2)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.1.2)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17
@@ -39168,7 +39250,7 @@ snapshots:
       - oxc-resolver
       - vue-tsc
 
-  tsdown@0.22.3(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39):
+  tsdown@0.22.3(@typescript/native-preview@7.0.0-dev.20260707.2)(tsx@4.21.0)(typescript@6.0.3)(unrun@0.2.39):
     dependencies:
       ansis: 4.3.1
       cac: 7.0.0
@@ -39179,7 +39261,7 @@ snapshots:
       obug: 2.1.3
       picomatch: 4.0.4
       rolldown: 1.1.2
-      rolldown-plugin-dts: 0.26.0(rolldown@1.1.2)(typescript@6.0.3)
+      rolldown-plugin-dts: 0.26.0(@typescript/native-preview@7.0.0-dev.20260707.2)(rolldown@1.1.2)(typescript@6.0.3)
       semver: 7.8.5
       tinyexec: 1.2.4
       tinyglobby: 0.2.17

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -9,6 +9,13 @@ packages:
 
 minimumReleaseAge: 10080
 
+# @typescript/native-preview ships the TypeScript 7 native compiler (tsgo), which we
+# use for typechecking. Its dev builds are published daily and are always within the
+# 7-day minimumReleaseAge window, so it must be excluded from that policy.
+minimumReleaseAgeExclude:
+  - '@typescript/native-preview'
+  - '@typescript/native-preview-*'
+
 blockExoticSubdeps: true
 
 overrides:


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wide toolchain change affects CI typecheck for the whole monorepo on a dev TS7 native build; dashboard form typings are adjusted but runtime behavior should be unchanged.
> 
> **Overview**
> **Monorepo typechecking** now runs through **`tsgo --noEmit`** (from `@typescript/native-preview`) instead of **`tsc --noEmit`**, across apps, packages, docs, and examples. The root **`package.json`** adds **`@typescript/native-preview@7.0.0-dev.20260707.2`**; **`pnpm-workspace.yaml`** exempts that package from **`minimumReleaseAge`** so daily dev builds can install. Lockfile updates wire **`tsdown` / `rolldown-plugin-dts`** to the native preview compiler and bump **`@supabase/supabase-js`** in the **`examples/supabase`** tree.
> 
> **Dashboard yup forms:** **`SmartForm`** and **`SmartFormDialog`** are re-genericized from schema type **`S`** to inferred shape **`F extends FieldValues`**, with **`formSchema: yup.ObjectSchema<F, yup.AnyObject, any, any>`**, so TypeScript 7’s stricter (contravariant) checks on yup’s **`concat`** still accept concrete schemas and **`.default()`** schemas with **`yupResolver`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 219f4ef8e85b50df64abb788954a290c221ca8db. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Upgrades monorepo typechecking to TypeScript 7’s native compiler `tsgo` for faster checks, and updates form types to satisfy TS 7’s stricter `yup` variance.

- **Dependencies**
  - Added `@typescript/native-preview` and switched all `typecheck` scripts to `tsgo --noEmit`.
  - Updated `pnpm-workspace.yaml` to exclude `@typescript/native-preview` from `minimumReleaseAge`.
  - Reverted accidental `@supabase/supabase-js` lockfile bump; remain on `2.108.2`.

- **Refactors**
  - `SmartForm` and `SmartFormDialog`: parametrize on form values (`F extends FieldValues`) and use `yup.ObjectSchema<F, yup.AnyObject, any, any>`; replace `yup.InferType<S>` with `F` to handle TS 7 `yup.concat` variance and accept `.default()` schemas.

<sup>Written for commit 0abf8768531da3aa50b45f39a9cea2e177888292. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1747?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated type-checking across the repo to use the newer TypeScript preview tool.
  * Added the latest TypeScript preview package and adjusted workspace release-age handling for it.

* **Bug Fixes**
  * Improved form component typing so submitted values and default values are handled more consistently, helping reduce validation and type-related issues in dashboard forms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->