### PR TITLE
Silence spurious import.meta CJS warning during pnpm run dev

### DIFF
--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { defineConfig, type Rolldown } from 'tsdown';
+import { defineConfig, type NormalizedFormat, type Rolldown } from 'tsdown';
 import { createBasePlugin } from './plugins.ts';
 
 
@@ -60,6 +60,30 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
     // and CJS dist isn't needed during development.
     dts: inlineConfig.watch ? false : true,
     onSuccess: _options.onSuccess,
+    // Some source files use `import.meta` inside platform-specific branches (e.g.
+    // `import.meta.env?.SSR` for the TanStack Start build in src/lib/cookie.ts).
+    // `import.meta` isn't valid in CJS, so rolldown emits an [EMPTY_IMPORT_META]
+    // warning for it once per package during the dual-format build, spamming the
+    // dev output. Only the ESM build is ever loaded by the runtimes that read
+    // `import.meta`; the CJS build's auto-replacement of `import.meta` with `{}`
+    // is exactly the behaviour we want, so silence just that warning for CJS.
+    inputOptions: (options: Rolldown.InputOptions, format: NormalizedFormat) => {
+      if (format !== 'cjs') {
+        return options;
+      }
+      const previousOnLog = options.onLog;
+      options.onLog = (level, log, defaultHandler) => {
+        if (log.code === 'EMPTY_IMPORT_META') {
+          return;
+        }
+        if (previousOnLog != null) {
+          previousOnLog(level, log, defaultHandler);
+        } else {
+          defaultHandler(level, log);
+        }
+      };
+      return options;
+    },
     ...(inlineConfig.watch ? {
       format: 'esm',
       outDir: 'dist/esm',


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Build-tool logging only; no runtime or application logic changes.
> 
> **Overview**
> Dual-format library builds were flooding dev output with Rolldown **`EMPTY_IMPORT_META`** warnings because some sources use `import.meta` in branches that only matter for ESM (e.g. TanStack Start SSR checks).
> 
> The shared **`configs/tsdown/js-library.ts`** config now hooks **`inputOptions`** for the **CJS** format only and filters logs with code **`EMPTY_IMPORT_META`**, while preserving any existing **`onLog`** handler for other messages. ESM builds are unchanged; CJS still gets the intended `{}` replacement for `import.meta`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b72cf83d9f631b5d6e9046e091e195a356914fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Silences the noisy `EMPTY_IMPORT_META` warning from the CJS build during `pnpm run dev`, keeping dev output clean. ESM behavior and build outputs are unchanged.

- **Bug Fixes**
  - For `cjs` builds, overrides `tsdown`/`rolldown` `onLog` to ignore `EMPTY_IMPORT_META` only, preserving all other logs and the expected `{}` replacement for `import.meta`.

<sup>Written for commit 8b72cf83d9f631b5d6e9046e091e195a356914fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1751?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CommonJS build compatibility by suppressing a specific non-user-facing build warning, while keeping all other warnings intact.
  * Non-CommonJS builds remain unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->