### PR TITLE
Silence spurious import.meta CJS warning during pnpm run dev

### DIFF
--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -1,6 +1,6 @@
 import fs from 'fs';
 import path from 'path';
-import { defineConfig, type Rolldown } from 'tsdown';
+import { defineConfig, type NormalizedFormat, type Rolldown } from 'tsdown';
 import { createBasePlugin } from './plugins.ts';
 
 
@@ -60,6 +60,30 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
     // and CJS dist isn't needed during development.
     dts: inlineConfig.watch ? false : true,
     onSuccess: _options.onSuccess,
+    // Some source files use `import.meta` inside platform-specific branches (e.g.
+    // `import.meta.env?.SSR` for the TanStack Start build in src/lib/cookie.ts).
+    // `import.meta` isn't valid in CJS, so rolldown emits an [EMPTY_IMPORT_META]
+    // warning for it once per package during the dual-format build, spamming the
+    // dev output. Only the ESM build is ever loaded by the runtimes that read
+    // `import.meta`; the CJS build's auto-replacement of `import.meta` with `{}`
+    // is exactly the behaviour we want, so silence just that warning for CJS.
+    inputOptions: (options: Rolldown.InputOptions, format: NormalizedFormat) => {
+      if (format !== 'cjs') {
+        return options;
+      }
+      const previousOnLog = options.onLog;
+      options.onLog = (level, log, defaultHandler) => {
+        if (log.code === 'EMPTY_IMPORT_META') {
+          return;
+        }
+        if (previousOnLog != null) {
+          previousOnLog(level, log, defaultHandler);
+        } else {
+          defaultHandler(level, log);
+        }
+      };
+      return options;
+    },
     ...(inlineConfig.watch ? {
       format: 'esm',
       outDir: 'dist/esm',


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Tooling-only change to build log filtering; no runtime application logic or security paths are modified.
> 
> **Overview**
> **Build config** in `configs/tsdown/js-library.ts` now hooks Rolldown **`inputOptions`** for the **CJS** leg of the dual-format library build so **`EMPTY_IMPORT_META`** log entries are dropped. ESM builds are unchanged; other log levels and codes still go through any existing **`onLog`** handler or the default handler.
> 
> This targets noisy dev/build output when library sources use **`import.meta`** in branches that only matter at runtime in ESM (e.g. TanStack Start **`import.meta.env?.SSR`**), where CJS output already replaces **`import.meta`** with **`{}`** as intended.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8b72cf83d9f631b5d6e9046e091e195a356914fe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Suppresses the CJS `EMPTY_IMPORT_META` warning emitted by `tsdown` during dev to remove noisy logs. Adds a CJS-only `inputOptions.onLog` filter in the library build config; ESM is unaffected and all other logs pass through.

<sup>Written for commit 8b72cf83d9f631b5d6e9046e091e195a356914fe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1752?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Reduced unnecessary build warnings for CommonJS output by suppressing empty `import.meta` notices.
  * Preserved all other build messages and warning handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->