### PR TITLE
mock/mission control

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/incident-evidence.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/incident-evidence.tsx
@@ -1,0 +1,567 @@
+"use client";
+
+import {
+  DesignAlert,
+  DesignAnalyticsCard,
+  DesignAnalyticsCardHeader,
+  DesignBadge,
+  DesignButton,
+  DesignCard,
+  DesignDialog,
+  DesignDialogClose,
+} from "@/components/design-components";
+import {
+  ArrowRightIcon,
+  BrowserIcon,
+  BugIcon,
+  CheckCircleIcon,
+  ClockCounterClockwiseIcon,
+  CodeIcon,
+  CursorClickIcon,
+  FlagIcon,
+  GitCommitIcon,
+  GitPullRequestIcon,
+  LightbulbFilamentIcon,
+  PulseIcon,
+  RobotIcon,
+  SparkleIcon,
+  TrendDownIcon,
+  UserCircleIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import { AnimatePresence, motion, useReducedMotion } from "motion/react";
+import { useMemo, useState } from "react";
+import type { IncidentStory, MetricUnit } from "./stories";
+
+export type IncidentEvidenceProps = {
+  story: IncidentStory,
+  activeStageIndex: number,
+  selectedRemediationId: string | null,
+  onSelectRemediation: (id: string) => void,
+};
+
+type EvidenceDetail = {
+  id: string,
+  label: string,
+  detail: string,
+  strength: string,
+};
+
+type ReplayFrame = {
+  id: string,
+  caption: string,
+  action: string,
+  url: string,
+  cursorX: number,
+  cursorY: number,
+  severity: string,
+};
+
+type MetricComparison = {
+  id: string,
+  label: string,
+  before: string,
+  during: string,
+  recovered: string,
+};
+
+type RemediationChoice = {
+  id: string,
+  title: string,
+  description: string,
+  recovery: string,
+  risk: string,
+  recommended: boolean,
+};
+
+function toPercent(value: number): string {
+  const percent = value <= 1 ? value * 100 : value;
+  return `${Math.round(percent)}%`;
+}
+
+function storyDisplayName(story: IncidentStory): string {
+  return story.title;
+}
+
+function buildReplayFrames(story: IncidentStory): readonly ReplayFrame[] {
+  if (story.replayFrames.length === 0) {
+    return [
+      {
+        id: "fallback-replay",
+        caption: "User retries the blocked action after the interface stops responding.",
+        action: "Repeated click detected",
+        url: "/checkout/confirm",
+        cursorX: 68,
+        cursorY: 66,
+        severity: "error",
+      },
+    ];
+  }
+
+  return story.replayFrames.map((frame) => ({
+    id: frame.id,
+    caption: frame.description,
+    action: frame.title,
+    url: frame.route,
+    cursorX: Math.min(92, Math.max(8, frame.cursorX)),
+    cursorY: Math.min(88, Math.max(12, frame.cursorY)),
+    severity: frame.highlightedSelector == null ? "warning" : "error",
+  }));
+}
+
+function buildEvidence(story: IncidentStory): readonly EvidenceDetail[] {
+  if (story.rootCauseEvidence.length === 0) {
+    return [
+      { id: "release", label: "Release boundary", detail: "Error onset aligns with the latest production change.", strength: "Strong" },
+      { id: "cohort", label: "Affected cohort", detail: "Failures concentrate in one client and action path.", strength: "Strong" },
+      { id: "trace", label: "Trace signature", detail: "Healthy requests diverge at the same operation.", strength: "Moderate" },
+    ];
+  }
+
+  return story.rootCauseEvidence.map((row) => ({
+    id: row.id,
+    label: row.signal,
+    detail: row.explanation,
+    strength: row.confidence >= 0.9 ? "Strong" : row.confidence >= 0.75 ? "Moderate" : "Supporting",
+  }));
+}
+
+function formatIncidentMetric(value: number, unit: MetricUnit): string {
+  switch (unit) {
+    case "percent": {
+      return `${value.toFixed(value < 10 ? 2 : 1)}%`;
+    }
+    case "milliseconds": {
+      return value >= 1000 ? `${(value / 1000).toFixed(1)} s` : `${Math.round(value)} ms`;
+    }
+    case "count": {
+      return Math.round(value).toLocaleString();
+    }
+    case "requests-per-minute": {
+      return `${Math.round(value).toLocaleString()} rpm`;
+    }
+    case "dollars": {
+      return `$${Math.round(value).toLocaleString()}`;
+    }
+    default: {
+      const exhaustiveUnit: never = unit;
+      return exhaustiveUnit;
+    }
+  }
+}
+
+function buildMetrics(story: IncidentStory): readonly MetricComparison[] {
+  if (story.metrics.length === 0) {
+    return [
+      { id: "success", label: "Success rate", before: "99.4%", during: "71.8%", recovered: "99.2%" },
+      { id: "latency", label: "p95 latency", before: "420 ms", during: "4.8 s", recovered: "460 ms" },
+      { id: "users", label: "Affected users", before: "0", during: "2,847", recovered: "12" },
+    ];
+  }
+
+  return story.metrics.slice(0, 4).map((metric) => ({
+    id: metric.id,
+    label: metric.label,
+    before: formatIncidentMetric(metric.baseline, metric.unit),
+    during: formatIncidentMetric(metric.current, metric.unit),
+    recovered: formatIncidentMetric(metric.recovered, metric.unit),
+  }));
+}
+
+function buildRemediations(story: IncidentStory): readonly RemediationChoice[] {
+  if (story.remediationActions.length === 0) {
+    return [
+      {
+        id: "rollback",
+        title: "Rollback implicated change",
+        description: "Restore the last known-good production behavior.",
+        recovery: "~8 min",
+        risk: "Low",
+        recommended: true,
+      },
+      {
+        id: "disable-flag",
+        title: "Disable affected feature flag",
+        description: "Contain impact for the affected cohort while preserving the release.",
+        recovery: "~3 min",
+        risk: "Low",
+        recommended: false,
+      },
+    ];
+  }
+
+  return story.remediationActions.map((remediation, index) => ({
+    id: remediation.id,
+    title: remediation.title,
+    description: remediation.details,
+    recovery: remediation.status === "completed" ? "Recovered" : remediation.status === "in-progress" ? "~5 min" : "~15 min",
+    risk: index === 0 ? "Low" : "Medium",
+    recommended: index === 0,
+  }));
+}
+
+function strengthColor(strength: string): "green" | "orange" | "blue" {
+  const normalized = strength.toLowerCase();
+  if (normalized.includes("strong") || normalized.includes("high")) return "green";
+  if (normalized.includes("weak") || normalized.includes("low")) return "orange";
+  return "blue";
+}
+
+function SessionReplay({
+  story,
+  activeStageIndex,
+}: {
+  story: IncidentStory,
+  activeStageIndex: number,
+}) {
+  const reducedMotion = useReducedMotion();
+  const frames = useMemo(() => buildReplayFrames(story), [story]);
+  const activeStage = story.stages.at(Math.min(activeStageIndex, story.stages.length - 1));
+  const stageFrame = activeStage == null
+    ? undefined
+    : frames.find((candidate) => story.replayFrames.find((source) => source.id === candidate.id)?.stageId === activeStage.id);
+  const frame = stageFrame ?? frames[Math.min(activeStageIndex, frames.length - 1)];
+  const isRageClick = frame.action.toLowerCase().includes("click") || frame.severity.toLowerCase().includes("error");
+
+  return (
+    <DesignAnalyticsCard gradient="cyan" className="overflow-hidden">
+      <DesignAnalyticsCardHeader
+        label="User-impact replay"
+        right={<DesignBadge label={`Stage ${activeStageIndex + 1}`} color="cyan" size="sm" />}
+      />
+      <div className="p-4">
+        <div className="overflow-hidden rounded-xl border border-border bg-background shadow-sm">
+          <div className="flex h-8 items-center gap-2 border-b border-border bg-foreground/[0.03] px-3">
+            <div className="flex gap-1.5" aria-hidden="true">
+              <span className="size-2 rounded-full bg-red-500/70" />
+              <span className="size-2 rounded-full bg-orange-500/70" />
+              <span className="size-2 rounded-full bg-emerald-500/70" />
+            </div>
+            <div className="min-w-0 flex-1 truncate rounded-md bg-foreground/[0.05] px-2 py-1 text-[10px] text-muted-foreground">
+              {frame.url}
+            </div>
+          </div>
+          <div className="relative h-44 overflow-hidden bg-gradient-to-br from-background via-background to-cyan-500/[0.05]">
+            <div className="absolute inset-x-5 top-5 h-8 rounded-lg bg-foreground/[0.05]" />
+            <div className="absolute left-5 right-[42%] top-16 h-3 rounded bg-foreground/[0.08]" />
+            <div className="absolute left-5 right-[58%] top-24 h-3 rounded bg-foreground/[0.05]" />
+            <div className="absolute bottom-5 right-5 rounded-lg bg-cyan-500/15 px-5 py-2 text-[10px] font-semibold text-cyan-700 dark:text-cyan-300">
+              Confirm action
+            </div>
+            <AnimatePresence mode="wait">
+              <motion.div
+                key={frame.id}
+                className="absolute"
+                initial={reducedMotion ? false : { opacity: 0, scale: 0.75 }}
+                animate={{ opacity: 1, scale: 1, left: `${frame.cursorX}%`, top: `${frame.cursorY}%` }}
+                exit={reducedMotion ? undefined : { opacity: 0 }}
+                transition={{ duration: reducedMotion ? 0 : 0.22 }}
+              >
+                {isRageClick && !reducedMotion && (
+                  <>
+                    <motion.span
+                      className="absolute -left-3 -top-3 size-7 rounded-full border border-red-500/70"
+                      animate={{ opacity: [0.8, 0], scale: [0.5, 1.8] }}
+                      transition={{ duration: 0.7, repeat: Infinity }}
+                    />
+                    <motion.span
+                      className="absolute -left-3 -top-3 size-7 rounded-full border border-red-500/50"
+                      animate={{ opacity: [0.7, 0], scale: [0.5, 2.2] }}
+                      transition={{ duration: 0.7, delay: 0.2, repeat: Infinity }}
+                    />
+                  </>
+                )}
+                <CursorClickIcon className="relative size-6 -rotate-12 text-red-500 drop-shadow-sm" weight="fill" />
+              </motion.div>
+            </AnimatePresence>
+          </div>
+          <div className="flex items-start gap-3 border-t border-border bg-foreground/[0.02] px-3 py-2.5">
+            <PulseIcon className="mt-0.5 size-4 shrink-0 text-cyan-600 dark:text-cyan-400" />
+            <div className="min-w-0">
+              <p className="text-xs font-semibold text-foreground">{frame.action}</p>
+              <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{frame.caption}</p>
+            </div>
+          </div>
+        </div>
+      </div>
+    </DesignAnalyticsCard>
+  );
+}
+
+function ImpactMetrics({ story }: { story: IncidentStory }) {
+  const metrics = useMemo(() => buildMetrics(story), [story]);
+  const impact = `${story.userImpact} ${story.businessImpact}`;
+
+  return (
+    <DesignAnalyticsCard gradient="orange">
+      <DesignAnalyticsCardHeader label="Before / incident / recovered" />
+      <div className="grid grid-cols-[minmax(0,1.4fr)_repeat(3,minmax(0,1fr))] border-b border-border px-4 py-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+        <span>Signal</span><span>Before</span><span>Incident</span><span>Projected</span>
+      </div>
+      <div className="divide-y divide-border">
+        {metrics.map((metric) => (
+          <div key={metric.id} className="grid grid-cols-[minmax(0,1.4fr)_repeat(3,minmax(0,1fr))] items-center px-4 py-2.5 text-xs tabular-nums">
+            <span className="truncate font-medium text-foreground">{metric.label}</span>
+            <span className="text-muted-foreground">{metric.before}</span>
+            <span className="font-semibold text-red-600 dark:text-red-400">{metric.during}</span>
+            <span className="font-semibold text-emerald-600 dark:text-emerald-400">{metric.recovered}</span>
+          </div>
+        ))}
+      </div>
+      <div className="flex gap-2 px-4 py-3 text-xs text-muted-foreground">
+        <TrendDownIcon className="mt-0.5 size-4 shrink-0 text-orange-500" />
+        <span>{impact}</span>
+      </div>
+    </DesignAnalyticsCard>
+  );
+}
+
+export function IncidentEvidence({
+  story,
+  activeStageIndex,
+  selectedRemediationId,
+  onSelectRemediation,
+}: IncidentEvidenceProps) {
+  const reducedMotion = useReducedMotion();
+  const [selectedEvidence, setSelectedEvidence] = useState<EvidenceDetail | null>(null);
+  const evidence = useMemo(() => buildEvidence(story), [story]);
+  const remediations = useMemo(() => buildRemediations(story), [story]);
+
+  const confidence = story.rootCauseEvidence.length === 0
+    ? 0.92
+    : story.rootCauseEvidence.reduce((sum, item) => sum + item.confidence, 0) / story.rootCauseEvidence.length;
+  const rootCause = story.rootCauseEvidence.map((item) => item.explanation).join(" ");
+  const release = `${story.change.deployment.version} · ${story.change.deployment.service}`;
+  const configChange = story.change.configChanges.at(0);
+  const change = configChange == null
+    ? story.suspect.commitTitle
+    : `${configChange.key}: ${configChange.previousValue} → ${configChange.nextValue}`;
+  const featureFlag = story.change.featureFlags.at(0);
+  const flag = featureFlag == null
+    ? "No feature flag changed"
+    : `${featureFlag.key} · ${featureFlag.rolloutPercent}% rollout`;
+  const commit = story.suspect.commitSha;
+  const pullRequest = `#${story.suspect.pullRequestNumber} · ${story.suspect.pullRequestTitle}`;
+  const author = story.suspect.author;
+  const owner = story.suspect.owner;
+  const changedLines = story.suspect.changedLines;
+  const timeline = story.stages;
+  const selectedRemediation = remediations.find((item) => item.id === selectedRemediationId) ?? null;
+  const generatedFix = selectedRemediation == null || changedLines.length === 0
+    ? ""
+    : [
+      `// Generated remediation preview: ${selectedRemediation.title}`,
+      ...changedLines.map((line) => `// ${line.file}:${line.startLine}-${line.endLine}\n// ${line.summary}`),
+    ].join("\n");
+
+  return (
+    <div className="space-y-4">
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.05fr)_minmax(0,0.95fr)]">
+        <SessionReplay story={story} activeStageIndex={activeStageIndex} />
+        <DesignCard title="AI root-cause brief" subtitle={storyDisplayName(story)} icon={RobotIcon} gradient="purple">
+          <div className="space-y-4">
+            <DesignAlert
+              variant="warning"
+              title={`${toPercent(confidence)} confidence`}
+              description={rootCause}
+              glassmorphic
+            />
+            <div className="space-y-2">
+              {evidence.map((row, index) => (
+                <motion.button
+                  key={row.id}
+                  type="button"
+                  className="flex w-full items-center gap-3 rounded-xl border border-border bg-foreground/[0.025] p-3 text-left transition-colors duration-150 hover:bg-foreground/[0.055] hover:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500"
+                  onClick={() => setSelectedEvidence(row)}
+                  initial={reducedMotion ? false : { opacity: 0, x: 8 }}
+                  animate={{ opacity: 1, x: 0 }}
+                  transition={{ duration: reducedMotion ? 0 : 0.18, delay: reducedMotion ? 0 : index * 0.035 }}
+                >
+                  <CheckCircleIcon className="size-4 shrink-0 text-emerald-500" weight="fill" />
+                  <span className="min-w-0 flex-1">
+                    <span className="block truncate text-xs font-semibold text-foreground">{row.label}</span>
+                    <span className="mt-0.5 block truncate text-[11px] text-muted-foreground">{row.detail}</span>
+                  </span>
+                  <DesignBadge label={row.strength} color={strengthColor(row.strength)} size="sm" />
+                  <ArrowRightIcon className="size-3.5 shrink-0 text-muted-foreground" />
+                </motion.button>
+              ))}
+            </div>
+          </div>
+        </DesignCard>
+      </div>
+
+      <div className="grid gap-4 lg:grid-cols-3">
+        <DesignCard title="Correlated change" icon={FlagIcon} gradient="orange">
+          <div className="space-y-3">
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Release</p>
+              <p className="mt-1 text-sm font-semibold text-foreground">{release}</p>
+            </div>
+            <div>
+              <p className="text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">Change</p>
+              <p className="mt-1 text-xs leading-5 text-foreground">{change}</p>
+            </div>
+            <div className="flex items-center justify-between rounded-xl bg-orange-500/[0.08] px-3 py-2">
+              <span className="text-xs font-medium text-foreground">{flag}</span>
+              <DesignBadge label="Correlated" color="orange" size="sm" />
+            </div>
+          </div>
+        </DesignCard>
+
+        <DesignCard title="Suspect ownership" icon={GitCommitIcon} gradient="default">
+          <div className="space-y-2.5 text-xs">
+            <div className="flex items-center justify-between gap-3">
+              <span className="flex items-center gap-2 text-muted-foreground"><GitCommitIcon className="size-4" />Commit</span>
+              <code className="font-semibold text-foreground">{commit}</code>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="flex items-center gap-2 text-muted-foreground"><GitPullRequestIcon className="size-4" />Pull request</span>
+              <span className="font-semibold text-foreground">{pullRequest}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="flex items-center gap-2 text-muted-foreground"><UserCircleIcon className="size-4" />Author</span>
+              <span className="font-semibold text-foreground">{author}</span>
+            </div>
+            <div className="flex items-center justify-between gap-3">
+              <span className="flex items-center gap-2 text-muted-foreground"><BugIcon className="size-4" />CODEOWNERS</span>
+              <span className="font-semibold text-foreground">{owner}</span>
+            </div>
+          </div>
+        </DesignCard>
+
+        <DesignCard title="Changed-line diff" icon={CodeIcon} gradient="default" contentClassName="p-0">
+          <div className="max-h-44 overflow-auto bg-foreground/[0.025] py-2 font-mono text-[10px] leading-5">
+            {(changedLines.length > 0 ? changedLines.slice(0, 8) : [
+              "- previousBehavior(input)",
+              "+ guardedBehavior(input, cohort)",
+              "+ emitTelemetry(\"decision\")",
+            ]).map((line, index) => {
+              const content = typeof line === "string"
+                ? line
+                : `~ ${line.file}:${line.startLine}-${line.endLine} ${line.summary}`;
+              const addition = content.trimStart().startsWith("+");
+              const removal = content.trimStart().startsWith("-");
+              return (
+                <div
+                  key={`${index}-${content}`}
+                  className={addition ? "bg-emerald-500/10 text-emerald-700 dark:text-emerald-300" : removal ? "bg-red-500/10 text-red-700 dark:text-red-300" : "text-muted-foreground"}
+                >
+                  <span className="inline-block w-8 select-none pr-2 text-right text-muted-foreground/60">{index + 1}</span>
+                  {content}
+                </div>
+              );
+            })}
+          </div>
+        </DesignCard>
+      </div>
+
+      <ImpactMetrics story={story} />
+
+      <DesignCard title="Recovery options" subtitle="Selection only — no production mutation is performed" icon={LightbulbFilamentIcon} gradient="green">
+        <div className="grid gap-3 lg:grid-cols-3">
+          {remediations.map((remediation) => {
+            const selected = remediation.id === selectedRemediationId;
+            return (
+              <div
+                key={remediation.id}
+                className={`flex min-h-44 flex-col rounded-xl border p-3 transition-colors duration-150 hover:transition-none ${
+                  selected ? "border-emerald-500/60 bg-emerald-500/[0.08]" : "border-border bg-foreground/[0.025] hover:bg-foreground/[0.05]"
+                }`}
+              >
+                <div className="flex items-start justify-between gap-2">
+                  <p className="text-sm font-semibold text-foreground">{remediation.title}</p>
+                  {remediation.recommended && <DesignBadge label="Recommended" color="green" size="sm" />}
+                </div>
+                <p className="mt-2 flex-1 text-xs leading-5 text-muted-foreground">{remediation.description}</p>
+                <div className="mb-3 mt-2 flex items-center gap-2 text-[11px] text-muted-foreground">
+                  <ClockCounterClockwiseIcon className="size-4 text-emerald-500" />
+                  <span>{remediation.recovery} projected</span>
+                  <span>·</span>
+                  <span>{remediation.risk} risk</span>
+                </div>
+                <DesignButton
+                  size="sm"
+                  variant={selected ? "secondary" : remediation.recommended ? "default" : "outline"}
+                  onClick={() => onSelectRemediation(remediation.id)}
+                >
+                  {selected ? "Selected for review" : "Select action"}
+                </DesignButton>
+              </div>
+            );
+          })}
+        </div>
+        {generatedFix.length > 0 && (
+          <div className="mt-4 overflow-hidden rounded-xl border border-border">
+            <div className="flex items-center justify-between border-b border-border bg-foreground/[0.03] px-3 py-2">
+              <span className="flex items-center gap-2 text-xs font-semibold text-foreground">
+                <SparkleIcon className="size-4 text-purple-500" weight="fill" />
+                Generated fix preview
+              </span>
+              <DesignBadge label="Preview only" color="purple" size="sm" />
+            </div>
+            <pre className="max-h-52 overflow-auto whitespace-pre-wrap p-3 text-[11px] leading-5 text-muted-foreground">{generatedFix}</pre>
+          </div>
+        )}
+      </DesignCard>
+
+      <DesignCard title="Incident timeline & postmortem evidence" icon={ClockCounterClockwiseIcon} gradient="cyan">
+        <div className="relative space-y-1 before:absolute before:bottom-4 before:left-[7px] before:top-4 before:w-px before:bg-border">
+          {(timeline.length > 0 ? timeline : [
+            { title: "Release completed", description: "Production change reaches the affected cohort." },
+            { title: "Impact detected", description: "User outcome and service signals cross alert thresholds." },
+            { title: "Cause isolated", description: "Replay, traces, and release evidence converge." },
+            { title: "Recovery projected", description: "Selected containment restores the baseline path." },
+          ]).map((event, index) => {
+            const title = event.title;
+            const description = "summary" in event ? event.summary : event.description;
+            const active = index === Math.min(activeStageIndex, timeline.length > 0 ? timeline.length - 1 : 3);
+            return (
+              <motion.div
+                key={`${index}-${title}`}
+                className="relative flex gap-3 py-2"
+                animate={{ opacity: index <= activeStageIndex ? 1 : 0.48 }}
+                transition={{ duration: reducedMotion ? 0 : 0.18 }}
+              >
+                <span className={`relative z-10 mt-1 size-3.5 shrink-0 rounded-full border-2 border-background ${active ? "bg-cyan-500 ring-4 ring-cyan-500/15" : index < activeStageIndex ? "bg-emerald-500" : "bg-muted-foreground/40"}`} />
+                <div>
+                  <p className="text-xs font-semibold text-foreground">{title}</p>
+                  <p className="mt-0.5 text-[11px] leading-4 text-muted-foreground">{description}</p>
+                </div>
+              </motion.div>
+            );
+          })}
+        </div>
+      </DesignCard>
+
+      <DesignDialog
+        open={selectedEvidence != null}
+        onOpenChange={(open) => {
+          if (!open) setSelectedEvidence(null);
+        }}
+        size="md"
+        icon={BrowserIcon}
+        title={selectedEvidence?.label ?? "Evidence detail"}
+        description="Read-only incident evidence used by the root-cause model."
+        footer={
+          <DesignDialogClose asChild>
+            <DesignButton variant="secondary" size="sm">Close</DesignButton>
+          </DesignDialogClose>
+        }
+      >
+        <div className="space-y-3">
+          <DesignAlert
+            variant="info"
+            title={selectedEvidence?.strength ?? "Evidence"}
+            description={selectedEvidence?.detail ?? "No evidence selected."}
+            glassmorphic
+          />
+          <p className="flex items-center gap-2 text-xs text-muted-foreground">
+            <WarningCircleIcon className="size-4" />
+            Correlation supports diagnosis but does not independently prove causation.
+          </p>
+        </div>
+      </DesignDialog>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/incident-playback.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/incident-playback.tsx
@@ -1,0 +1,297 @@
+"use client";
+
+import {
+  ArrowCounterClockwiseIcon,
+  BrainIcon,
+  CheckCircleIcon,
+  PauseIcon,
+  PlayIcon,
+  RocketLaunchIcon,
+  SirenIcon,
+  WrenchIcon,
+} from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "motion/react";
+import { useId, type ChangeEvent, type ElementType } from "react";
+
+import {
+  DesignBadge,
+  DesignButton,
+  DesignCard,
+  type DesignBadgeColor,
+} from "@/components/design-components";
+import { cn } from "@/lib/utils";
+
+import {
+  formatPlaybackTime,
+  getPlaybackStage,
+  type IncidentStage,
+  type IncidentStory,
+} from "./stories";
+
+export type IncidentPlaybackProps = {
+  story: IncidentStory,
+  elapsedMs: number,
+  isPlaying: boolean,
+  onElapsedChange: (elapsedMs: number) => void,
+  onPlayingChange: (playing: boolean) => void,
+};
+
+type StagePresentation = {
+  icon: ElementType,
+  color: DesignBadgeColor,
+  label: string,
+};
+
+const stagePresentations = new Map<IncidentStage["kind"], StagePresentation>([
+  ["healthy", { icon: CheckCircleIcon, color: "green", label: "Baseline" }],
+  ["change", { icon: RocketLaunchIcon, color: "purple", label: "Change" }],
+  ["impact", { icon: SirenIcon, color: "red", label: "Alert" }],
+  ["diagnosis", { icon: BrainIcon, color: "cyan", label: "Diagnosis" }],
+  ["mitigation", { icon: WrenchIcon, color: "orange", label: "Remediation" }],
+  ["recovery", { icon: CheckCircleIcon, color: "green", label: "Recovery" }],
+]);
+
+function getStagePresentation(kind: IncidentStage["kind"]): StagePresentation {
+  const presentation = stagePresentations.get(kind);
+  if (presentation == null) {
+    throw new Error(`Missing incident playback presentation for stage kind "${kind}".`);
+  }
+  return presentation;
+}
+
+function clampElapsed(elapsedMs: number, durationMs: number): number {
+  return Math.min(Math.max(elapsedMs, 0), durationMs);
+}
+
+function getActiveStage(story: IncidentStory, elapsedMs: number): IncidentStage {
+  const stage = getPlaybackStage(story, elapsedMs);
+  if (stage == null) {
+    throw new Error(`Incident story "${story.id}" must contain at least one playback stage.`);
+  }
+  return stage;
+}
+
+function getActiveStageIndex(story: IncidentStory, activeStage: IncidentStage): number {
+  const index = story.stages.findIndex((stage) => stage.id === activeStage.id);
+  if (index < 0) {
+    throw new Error(`Active stage "${activeStage.id}" is missing from incident story "${story.id}".`);
+  }
+  return index;
+}
+
+export function IncidentPlayback({
+  story,
+  elapsedMs,
+  isPlaying,
+  onElapsedChange,
+  onPlayingChange,
+}: IncidentPlaybackProps) {
+  const shouldReduceMotion = useReducedMotion();
+  const rangeId = useId();
+  const safeElapsedMs = clampElapsed(elapsedMs, story.durationMs);
+  const activeStage = getActiveStage(story, safeElapsedMs);
+  const activeStageIndex = getActiveStageIndex(story, activeStage);
+  const progressPercent = story.durationMs === 0
+    ? 0
+    : (safeElapsedMs / story.durationMs) * 100;
+  const activePresentation = getStagePresentation(activeStage.kind);
+  const ActiveIcon = activePresentation.icon;
+
+  const handleRangeChange = (event: ChangeEvent<HTMLInputElement>) => {
+    onElapsedChange(Number(event.currentTarget.value));
+  };
+
+  const handleRestart = () => {
+    onElapsedChange(0);
+  };
+
+  const handleStageSelect = (stage: IncidentStage) => {
+    onElapsedChange(stage.offsetMs);
+  };
+
+  return (
+    <DesignCard
+      title="Incident playback"
+      subtitle="Replay every signal from change to recovery"
+      icon={PlayIcon}
+      gradient="cyan"
+      contentClassName="space-y-5"
+      actions={(
+        <DesignBadge
+          label={isPlaying ? "Live playback" : "Paused"}
+          color={isPlaying ? "green" : "orange"}
+          icon={isPlaying ? PlayIcon : PauseIcon}
+          size="sm"
+        />
+      )}
+    >
+      <div className="flex flex-col gap-4 rounded-xl bg-foreground/[0.03] p-3 ring-1 ring-foreground/[0.06] sm:p-4">
+        <div className="flex items-center gap-2">
+          <DesignButton
+            type="button"
+            size="icon"
+            variant="secondary"
+            className="h-9 w-9 rounded-xl transition-opacity duration-150 hover:transition-none"
+            aria-label={isPlaying ? "Pause incident playback" : "Play incident playback"}
+            aria-pressed={isPlaying}
+            onClick={() => onPlayingChange(!isPlaying)}
+          >
+            {isPlaying
+              ? <PauseIcon className="h-4 w-4" weight="fill" />
+              : <PlayIcon className="h-4 w-4" weight="fill" />}
+          </DesignButton>
+          <DesignButton
+            type="button"
+            size="icon"
+            variant="ghost"
+            className="h-9 w-9 rounded-xl transition-opacity duration-150 hover:transition-none"
+            aria-label="Restart incident playback"
+            disabled={safeElapsedMs === 0}
+            onClick={handleRestart}
+          >
+            <ArrowCounterClockwiseIcon className="h-4 w-4" />
+          </DesignButton>
+
+          <div className="ml-auto flex items-baseline gap-1 font-mono text-xs tabular-nums">
+            <span className="font-semibold text-foreground">{formatPlaybackTime(safeElapsedMs)}</span>
+            <span className="text-muted-foreground">/ {formatPlaybackTime(story.durationMs)}</span>
+          </div>
+        </div>
+
+        <div className="relative pb-1 pt-5">
+          <label htmlFor={rangeId} className="sr-only">
+            Incident playback position
+          </label>
+          <div
+            aria-hidden
+            className="pointer-events-none absolute left-0 right-0 top-[1.625rem] h-1 overflow-hidden rounded-full bg-foreground/10"
+          >
+            <motion.div
+              className="h-full origin-left rounded-full bg-cyan-500"
+              animate={{ scaleX: progressPercent / 100 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.18, ease: "easeOut" }}
+            />
+          </div>
+          <input
+            id={rangeId}
+            type="range"
+            min={0}
+            max={story.durationMs}
+            step={100}
+            value={safeElapsedMs}
+            onChange={handleRangeChange}
+            aria-valuemin={0}
+            aria-valuemax={story.durationMs}
+            aria-valuenow={safeElapsedMs}
+            aria-valuetext={`${formatPlaybackTime(safeElapsedMs)} of ${formatPlaybackTime(story.durationMs)}`}
+            className="relative z-10 h-4 w-full cursor-pointer appearance-none bg-transparent accent-cyan-500 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 focus-visible:ring-offset-4 focus-visible:ring-offset-background disabled:cursor-not-allowed [&::-moz-range-thumb]:h-4 [&::-moz-range-thumb]:w-4 [&::-moz-range-thumb]:rounded-full [&::-moz-range-thumb]:border-2 [&::-moz-range-thumb]:border-background [&::-moz-range-thumb]:bg-cyan-500 [&::-webkit-slider-runnable-track]:h-1 [&::-webkit-slider-runnable-track]:bg-transparent [&::-webkit-slider-thumb]:mt-[-6px] [&::-webkit-slider-thumb]:h-4 [&::-webkit-slider-thumb]:w-4 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:border-2 [&::-webkit-slider-thumb]:border-background [&::-webkit-slider-thumb]:bg-cyan-500 [&::-webkit-slider-thumb]:shadow-sm"
+          />
+
+          <div className="absolute inset-x-0 top-0 h-5" aria-hidden>
+            {story.stages.map((stage, index) => {
+              const markerPercent = story.durationMs === 0 ? 0 : (stage.offsetMs / story.durationMs) * 100;
+              const isReached = index <= activeStageIndex;
+              return (
+                <span
+                  key={stage.id}
+                  className={cn(
+                    "absolute top-0 h-2 w-px -translate-x-1/2 rounded-full",
+                    isReached ? "bg-cyan-500" : "bg-foreground/20",
+                  )}
+                  style={{ left: `${markerPercent}%` }}
+                />
+              );
+            })}
+          </div>
+        </div>
+      </div>
+
+      <div
+        className="relative grid grid-cols-2 gap-x-2 gap-y-3 sm:grid-cols-3 lg:grid-cols-6"
+        role="list"
+        aria-label="Incident stages"
+      >
+        <div
+          aria-hidden
+          className="absolute left-3 right-3 top-3 hidden h-px bg-foreground/10 lg:block"
+        />
+        {story.stages.map((stage, index) => {
+          const presentation = getStagePresentation(stage.kind);
+          const StageIcon = presentation.icon;
+          const isActive = stage.id === activeStage.id;
+          const isReached = index <= activeStageIndex;
+
+          return (
+            <div key={stage.id} role="listitem" className="relative z-10 min-w-0">
+              <button
+                type="button"
+                aria-current={isActive ? "step" : undefined}
+                aria-label={`Jump to ${stage.title} at ${formatPlaybackTime(stage.offsetMs)}`}
+                onClick={() => handleStageSelect(stage)}
+                className={cn(
+                  "group/stage w-full rounded-xl p-2 text-left outline-none ring-offset-background transition-[background-color,opacity] duration-150 hover:transition-none focus-visible:ring-2 focus-visible:ring-cyan-500/60 focus-visible:ring-offset-2",
+                  isActive ? "bg-foreground/[0.07]" : "hover:bg-foreground/[0.04]",
+                  !isReached && "opacity-55 hover:opacity-100",
+                )}
+              >
+                <span
+                  className={cn(
+                    "mb-2 flex h-6 w-6 items-center justify-center rounded-full ring-4 ring-background transition-colors duration-150 group-hover/stage:transition-none",
+                    isReached
+                      ? "bg-cyan-500 text-primary-foreground"
+                      : "bg-foreground/10 text-muted-foreground",
+                  )}
+                >
+                  <StageIcon className="h-3.5 w-3.5" weight={isActive ? "fill" : "regular"} />
+                </span>
+                <span className="block truncate text-[10px] font-semibold uppercase tracking-wider text-foreground">
+                  {stage.title}
+                </span>
+                <span className="mt-0.5 block font-mono text-[10px] tabular-nums text-muted-foreground">
+                  {formatPlaybackTime(stage.offsetMs)}
+                </span>
+              </button>
+            </div>
+          );
+        })}
+      </div>
+
+      <motion.div
+        key={activeStage.id}
+        initial={shouldReduceMotion ? false : { opacity: 0, y: 6 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ duration: shouldReduceMotion ? 0 : 0.2, ease: "easeOut" }}
+        className="relative overflow-hidden rounded-xl bg-foreground/[0.035] p-4 ring-1 ring-foreground/[0.07]"
+        aria-live="polite"
+        aria-atomic="true"
+      >
+        <div
+          aria-hidden
+          className="absolute inset-y-0 left-0 w-1 bg-cyan-500"
+        />
+        <div className="flex items-start gap-3">
+          <div className="flex h-9 w-9 shrink-0 items-center justify-center rounded-xl bg-cyan-500/10 text-cyan-700 ring-1 ring-cyan-500/20 dark:text-cyan-300">
+            <ActiveIcon className="h-4 w-4" weight="duotone" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex flex-wrap items-center gap-2">
+              <DesignBadge
+                label={activePresentation.label}
+                color={activePresentation.color}
+                icon={ActiveIcon}
+                size="sm"
+              />
+              <span className="font-mono text-[10px] tabular-nums text-muted-foreground">
+                Stage {activeStageIndex + 1} of {story.stages.length}
+              </span>
+            </div>
+            <h3 className="mt-2 text-sm font-semibold text-foreground">{activeStage.title}</h3>
+            <p className="mt-1 max-w-3xl text-sm leading-6 text-muted-foreground">
+              {activeStage.summary}
+            </p>
+          </div>
+        </div>
+      </motion.div>
+    </DesignCard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/page-client.tsx
@@ -1,0 +1,184 @@
+"use client";
+
+import {
+  DesignAlert,
+  DesignBadge,
+  DesignCategoryTabs,
+} from "@/components/design-components";
+import { AppEnabledGuard } from "../../app-enabled-guard";
+import { PageLayout } from "../../page-layout";
+import { StickyPageHeader } from "../../sticky-page-header";
+import { IncidentEvidence } from "./incident-evidence";
+import { IncidentPlayback } from "./incident-playback";
+import {
+  INCIDENT_STORIES,
+  getPlaybackStage,
+  type IncidentStory,
+} from "./stories";
+import { TelemetryInvestigation } from "./telemetry-investigation";
+import { useEffect, useMemo, useRef, useState } from "react";
+
+const PLAYBACK_RATE = 24;
+
+function getInitialStory(): IncidentStory {
+  return INCIDENT_STORIES[0];
+}
+
+function getStory(storyId: string): IncidentStory {
+  const story = INCIDENT_STORIES.find((candidate) => candidate.id === storyId);
+  if (story == null) {
+    throw new Error(`Mission Control story "${storyId}" is not registered.`);
+  }
+  return story;
+}
+
+export default function PageClient() {
+  const initialStory = getInitialStory();
+  const [storyId, setStoryId] = useState(initialStory.id);
+  const [elapsedMs, setElapsedMs] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [selectedSpanId, setSelectedSpanId] = useState<string | null>(
+    initialStory.waterfallSpans[0]?.id ?? null,
+  );
+  const [selectedRemediationId, setSelectedRemediationId] = useState<string | null>(null);
+  const elapsedMsRef = useRef(0);
+  const playbackAnchorRef = useRef<{ elapsedMs: number, startedAt: number } | null>(null);
+
+  const story = useMemo(() => getStory(storyId), [storyId]);
+  const storyCategories = useMemo(
+    () => INCIDENT_STORIES.map((candidate) => ({
+      id: candidate.id,
+      label: candidate.shortTitle,
+      badgeCount: candidate.affectedUsers,
+    })),
+    [],
+  );
+  const activeStage = getPlaybackStage(story, elapsedMs);
+  const activeStageIndex = activeStage == null ? 0 : story.stages.indexOf(activeStage);
+
+  useEffect(() => {
+    if (!isPlaying) {
+      playbackAnchorRef.current = null;
+      return;
+    }
+
+    playbackAnchorRef.current = {
+      elapsedMs: elapsedMsRef.current,
+      startedAt: performance.now(),
+    };
+    let animationFrameId = 0;
+
+    const advancePlayback = (now: number) => {
+      const anchor = playbackAnchorRef.current;
+      if (anchor == null) return;
+      const nextElapsedMs = Math.min(
+        story.durationMs,
+        anchor.elapsedMs + (now - anchor.startedAt) * PLAYBACK_RATE,
+      );
+      elapsedMsRef.current = nextElapsedMs;
+      setElapsedMs(nextElapsedMs);
+      if (nextElapsedMs >= story.durationMs) {
+        setIsPlaying(false);
+        return;
+      }
+      animationFrameId = requestAnimationFrame(advancePlayback);
+    };
+
+    animationFrameId = requestAnimationFrame(advancePlayback);
+    return () => cancelAnimationFrame(animationFrameId);
+  }, [isPlaying, story.durationMs]);
+
+  const selectStory = (nextStoryId: string) => {
+    const nextStory = getStory(nextStoryId);
+    setStoryId(nextStoryId);
+    elapsedMsRef.current = 0;
+    setElapsedMs(0);
+    setIsPlaying(false);
+    setSelectedSpanId(nextStory.waterfallSpans[0]?.id ?? null);
+    setSelectedRemediationId(null);
+  };
+
+  const setPlaybackElapsed = (nextElapsedMs: number) => {
+    const clampedElapsedMs = Math.min(Math.max(nextElapsedMs, 0), story.durationMs);
+    elapsedMsRef.current = clampedElapsedMs;
+    setElapsedMs(clampedElapsedMs);
+    if (isPlaying) {
+      playbackAnchorRef.current = {
+        elapsedMs: clampedElapsedMs,
+        startedAt: performance.now(),
+      };
+    }
+  };
+
+  return (
+    <AppEnabledGuard appId="analytics">
+      <PageLayout fillWidth allowContentOverflow>
+        <div className="flex flex-col gap-4">
+          <StickyPageHeader
+            title="Mission Control"
+            description="Playback real user impact from first symptom to verified recovery."
+            sticky
+            layoutGroupId="mission-control-sticky-header"
+            actions={
+              <div className="flex items-center gap-2">
+                <DesignBadge
+                  label={story.severity}
+                  color={story.severity === "SEV-1" ? "red" : "orange"}
+                  size="sm"
+                />
+                <DesignBadge label="Synthetic incident" color="cyan" size="sm" />
+              </div>
+            }
+          />
+
+          <DesignCategoryTabs
+            categories={storyCategories}
+            selectedCategory={story.id}
+            onSelect={selectStory}
+            showBadge
+            gradient="cyan"
+            glassmorphic
+          />
+
+          <DesignAlert
+            variant={
+              activeStage?.kind === "impact"
+                ? "error"
+                : activeStage?.kind === "mitigation"
+                  ? "warning"
+                  : activeStage?.kind === "recovery"
+                    ? "success"
+                    : "info"
+            }
+            title={activeStage?.title ?? story.title}
+            description={activeStage?.summary ?? story.summary}
+            glassmorphic
+          />
+
+          <IncidentPlayback
+            story={story}
+            elapsedMs={elapsedMs}
+            isPlaying={isPlaying}
+            onElapsedChange={setPlaybackElapsed}
+            onPlayingChange={setIsPlaying}
+          />
+
+          <div className="grid min-w-0 gap-4 2xl:grid-cols-[minmax(0,1.35fr)_minmax(24rem,0.65fr)]">
+            <TelemetryInvestigation
+              story={story}
+              activeStageIndex={activeStageIndex}
+              selectedSpanId={selectedSpanId}
+              onSelectSpan={setSelectedSpanId}
+            />
+            <IncidentEvidence
+              story={story}
+              activeStageIndex={activeStageIndex}
+              selectedRemediationId={selectedRemediationId}
+              onSelectRemediation={setSelectedRemediationId}
+            />
+          </div>
+        </div>
+      </PageLayout>
+    </AppEnabledGuard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/page.tsx
@@ -1,0 +1,9 @@
+import PageClient from "./page-client";
+
+export const metadata = {
+  title: "Mission Control",
+};
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/stories.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/stories.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from "vitest";
+import { formatPlaybackTime, getPlaybackStage, INCIDENT_STORIES, interpolateMetric } from "./stories";
+
+describe("INCIDENT_STORIES", () => {
+  it("provides four deterministic selectable scenarios", () => {
+    expect(INCIDENT_STORIES.map((story) => story.id)).toEqual([
+      "safari-webcrypto-checkout",
+      "mfa-retry-storm",
+      "webhook-poison-message",
+      "ai-agent-wrong-refund",
+    ]);
+  });
+});
+
+describe("getPlaybackStage", () => {
+  const story = INCIDENT_STORIES[0];
+
+  it("selects the latest stage whose boundary has been reached", () => {
+    expect(getPlaybackStage(story, 299_999)?.id).toBe("safari-impact");
+    expect(getPlaybackStage(story, 300_000)?.id).toBe("safari-diagnosis");
+    expect(getPlaybackStage(story, 300_001)?.id).toBe("safari-diagnosis");
+  });
+
+  it("uses the first stage before playback starts and the final stage after playback ends", () => {
+    expect(getPlaybackStage(story, -1)?.id).toBe("safari-healthy");
+    expect(getPlaybackStage(story, story.durationMs + 1)?.id).toBe("safari-recovery");
+  });
+
+  it("returns undefined when a story has no stages", () => {
+    expect(getPlaybackStage({ ...story, stages: [] }, 0)).toBeUndefined();
+  });
+});
+
+describe("interpolateMetric", () => {
+  it("interpolates within the range in either direction", () => {
+    expect(interpolateMetric(10, 30, 0.25)).toBe(15);
+    expect(interpolateMetric(30, 10, 0.25)).toBe(25);
+  });
+
+  it("clamps progress at both boundaries", () => {
+    expect(interpolateMetric(10, 30, -0.5)).toBe(10);
+    expect(interpolateMetric(10, 30, 1.5)).toBe(30);
+  });
+});
+
+describe("formatPlaybackTime", () => {
+  it("formats elapsed milliseconds as minute playback time", () => {
+    expect(formatPlaybackTime(0)).toBe("0:00");
+    expect(formatPlaybackTime(65_999)).toBe("1:05");
+  });
+
+  it("clamps invalid or negative elapsed time to zero", () => {
+    expect(formatPlaybackTime(-1)).toBe("0:00");
+    expect(formatPlaybackTime(Number.NaN)).toBe("0:00");
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/stories.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/stories.ts
@@ -1,0 +1,688 @@
+export type IncidentSeverity = "SEV-1" | "SEV-2";
+
+export type IncidentStageKind = "healthy" | "change" | "impact" | "diagnosis" | "mitigation" | "recovery";
+
+export type MetricUnit = "percent" | "milliseconds" | "count" | "requests-per-minute" | "dollars";
+
+export type IncidentMetric = {
+  id: string,
+  label: string,
+  unit: MetricUnit,
+  higherIsWorse: boolean,
+  baseline: number,
+  current: number,
+  recovered: number,
+};
+
+export type StageMetricValue = {
+  metricId: string,
+  value: number,
+};
+
+export type IncidentStage = {
+  id: string,
+  kind: IncidentStageKind,
+  offsetMs: number,
+  title: string,
+  summary: string,
+  metricValues: StageMetricValue[],
+  evidenceIds: string[],
+};
+
+export type StackFrame = {
+  functionName: string,
+  file: string,
+  line: number,
+  column: number,
+  inApplication: boolean,
+};
+
+export type Breadcrumb = {
+  offsetMs: number,
+  category: "navigation" | "ui" | "http" | "console" | "queue" | "ai",
+  message: string,
+  level: "info" | "warning" | "error",
+};
+
+export type IncidentError = {
+  id: string,
+  stageId: string,
+  fingerprint: string,
+  title: string,
+  message: string,
+  count: number,
+  affectedUsers: number,
+  traceId: string,
+  spanId: string,
+  stackFrames: StackFrame[],
+  breadcrumbs: Breadcrumb[],
+};
+
+export type LogAttribute = {
+  key: string,
+  value: string | number | boolean,
+};
+
+export type StructuredLog = {
+  id: string,
+  stageId: string,
+  offsetMs: number,
+  timestamp: string,
+  level: "debug" | "info" | "warn" | "error",
+  service: string,
+  message: string,
+  traceId: string,
+  spanId: string,
+  attributes: LogAttribute[],
+};
+
+export type WaterfallSpan = {
+  id: string,
+  parentId: string | null,
+  traceId: string,
+  service: string,
+  operation: string,
+  startOffsetMs: number,
+  durationMs: number,
+  status: "ok" | "error",
+  attributes: LogAttribute[],
+};
+
+export type ReplayFrame = {
+  id: string,
+  stageId: string,
+  offsetMs: number,
+  route: string,
+  title: string,
+  description: string,
+  cursorX: number,
+  cursorY: number,
+  viewportWidth: number,
+  viewportHeight: number,
+  highlightedSelector: string | null,
+};
+
+export type DeploymentMetadata = {
+  id: string,
+  environment: "production",
+  service: string,
+  version: string,
+  startedAt: string,
+  completedAt: string,
+  status: "succeeded" | "rolled-back",
+};
+
+export type ConfigChange = {
+  key: string,
+  previousValue: string,
+  nextValue: string,
+  changedAt: string,
+  changedBy: string,
+};
+
+export type FeatureFlagMetadata = {
+  key: string,
+  previousVariant: string,
+  currentVariant: string,
+  rolloutPercent: number,
+  changedAt: string,
+};
+
+export type ChangeMetadata = {
+  deployment: DeploymentMetadata,
+  configChanges: ConfigChange[],
+  featureFlags: FeatureFlagMetadata[],
+};
+
+export type ChangedLine = {
+  file: string,
+  startLine: number,
+  endLine: number,
+  summary: string,
+};
+
+export type SuspectChange = {
+  commitSha: string,
+  commitTitle: string,
+  pullRequestNumber: number,
+  pullRequestTitle: string,
+  author: string,
+  owner: string,
+  mergedAt: string,
+  changedLines: ChangedLine[],
+};
+
+export type RootCauseEvidence = {
+  id: string,
+  stageId: string,
+  signal: string,
+  explanation: string,
+  confidence: number,
+  supportingEvidenceIds: string[],
+};
+
+export type RemediationAction = {
+  id: string,
+  title: string,
+  owner: string,
+  status: "completed" | "in-progress" | "planned",
+  completedAt: string | null,
+  details: string,
+};
+
+export type SloData = {
+  objective: string,
+  targetPercent: number,
+  windowDays: number,
+  observedPercent: number,
+  burnRate: number,
+  budgetRemainingBeforePercent: number,
+  budgetRemainingCurrentPercent: number,
+  projectedMinutesToExhaustion: number,
+};
+
+export type TopologyNode = {
+  id: string,
+  label: string,
+  kind: "browser" | "edge" | "service" | "database" | "queue" | "provider" | "ai-model",
+  health: "healthy" | "degraded" | "critical",
+  requestRate: number,
+  errorRatePercent: number,
+  latencyP95Ms: number,
+};
+
+export type TopologyEdge = {
+  id: string,
+  source: string,
+  target: string,
+  protocol: "HTTPS" | "gRPC" | "SQL" | "queue" | "tool-call",
+  health: "healthy" | "degraded" | "critical",
+  requestsPerMinute: number,
+};
+
+export type ServiceTopology = {
+  nodes: TopologyNode[],
+  edges: TopologyEdge[],
+};
+
+export type IncidentStory = {
+  id: string,
+  title: string,
+  shortTitle: string,
+  severity: IncidentSeverity,
+  status: "resolved",
+  startedAt: string,
+  resolvedAt: string,
+  durationMs: number,
+  summary: string,
+  userImpact: string,
+  businessImpact: string,
+  affectedUsers: number,
+  affectedRegion: string,
+  metrics: IncidentMetric[],
+  stages: IncidentStage[],
+  errors: IncidentError[],
+  logs: StructuredLog[],
+  waterfallSpans: WaterfallSpan[],
+  replayFrames: ReplayFrame[],
+  change: ChangeMetadata,
+  suspect: SuspectChange,
+  rootCauseEvidence: RootCauseEvidence[],
+  remediationActions: RemediationAction[],
+  slo: SloData,
+  topology: ServiceTopology,
+};
+
+export function getPlaybackStage(story: IncidentStory, elapsedMs: number): IncidentStage | undefined {
+  let selected = story.stages[0];
+  for (const stage of story.stages) {
+    if (stage.offsetMs > elapsedMs) break;
+    selected = stage;
+  }
+  return selected;
+}
+
+export function interpolateMetric(from: number, to: number, progress: number): number {
+  const clampedProgress = Math.min(Math.max(progress, 0), 1);
+  return from + (to - from) * clampedProgress;
+}
+
+export function formatPlaybackTime(elapsedMs: number): string {
+  const clampedMs = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+  const totalSeconds = Math.floor(clampedMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+const safariStory: IncidentStory = {
+  id: "safari-webcrypto-checkout",
+  title: "Safari checkout failures after WebCrypto rollout",
+  shortTitle: "Safari checkout",
+  severity: "SEV-1",
+  status: "resolved",
+  startedAt: "2026-06-18T14:02:00.000Z",
+  resolvedAt: "2026-06-18T14:14:00.000Z",
+  durationMs: 720_000,
+  summary: "A WebCrypto tokenization path enabled by a production flag rejected Safari checkout sessions.",
+  userImpact: "Safari shoppers saw payment confirmation fail after submitting otherwise valid card details.",
+  businessImpact: "An estimated $184,200 in checkout volume was delayed; recovered carts were offered a retry.",
+  affectedUsers: 4_812,
+  affectedRegion: "Global, Safari 17.4–17.5",
+  metrics: [
+    { id: "checkout-error-rate", label: "Checkout error rate", unit: "percent", higherIsWorse: true, baseline: 0.7, current: 31.8, recovered: 0.9 },
+    { id: "checkout-p95", label: "Checkout p95", unit: "milliseconds", higherIsWorse: true, baseline: 820, current: 4_900, recovered: 880 },
+    { id: "revenue-at-risk", label: "Revenue at risk", unit: "dollars", higherIsWorse: true, baseline: 0, current: 184_200, recovered: 12_400 },
+  ],
+  stages: [
+    { id: "safari-healthy", kind: "healthy", offsetMs: 0, title: "Healthy baseline", summary: "Checkout conversion and latency are within objective.", metricValues: [{ metricId: "checkout-error-rate", value: 0.7 }, { metricId: "checkout-p95", value: 820 }], evidenceIds: [] },
+    { id: "safari-change", kind: "change", offsetMs: 60_000, title: "WebCrypto flag reaches 100%", summary: "Deploy checkout-web 8.42.0 completes and secure-token-v2 expands globally.", metricValues: [{ metricId: "checkout-error-rate", value: 1.1 }, { metricId: "checkout-p95", value: 900 }], evidenceIds: ["log-safari-deploy"] },
+    { id: "safari-impact", kind: "impact", offsetMs: 150_000, title: "Safari failures spike", summary: "SubtleCrypto rejects a legacy key encoding used only by the Safari adapter.", metricValues: [{ metricId: "checkout-error-rate", value: 31.8 }, { metricId: "checkout-p95", value: 4_900 }], evidenceIds: ["err-safari-crypto", "span-safari-tokenize", "replay-safari-error"] },
+    { id: "safari-diagnosis", kind: "diagnosis", offsetMs: 300_000, title: "Browser correlation isolated", summary: "AI analysis links the failures to Safari, the flag cohort, and the rollout commit.", metricValues: [{ metricId: "checkout-error-rate", value: 28.4 }, { metricId: "checkout-p95", value: 4_500 }], evidenceIds: ["rc-safari-correlation"] },
+    { id: "safari-mitigation", kind: "mitigation", offsetMs: 480_000, title: "Flag rolled back", summary: "Safari traffic returns to the previous tokenization implementation.", metricValues: [{ metricId: "checkout-error-rate", value: 8.2 }, { metricId: "checkout-p95", value: 1_600 }], evidenceIds: ["log-safari-rollback"] },
+    { id: "safari-recovery", kind: "recovery", offsetMs: 660_000, title: "Checkout recovered", summary: "Error rate and conversion return to baseline.", metricValues: [{ metricId: "checkout-error-rate", value: 0.9 }, { metricId: "checkout-p95", value: 880 }], evidenceIds: [] },
+  ],
+  errors: [{
+    id: "err-safari-crypto",
+    stageId: "safari-impact",
+    fingerprint: "checkout-webcrypto-dataerror-safari",
+    title: "DataError: invalid keyData",
+    message: "Failed to execute 'importKey' on 'SubtleCrypto': The provided data is invalid.",
+    count: 6_204,
+    affectedUsers: 4_812,
+    traceId: "trace-safari-7d2c",
+    spanId: "span-safari-tokenize",
+    stackFrames: [
+      { functionName: "importCheckoutKey", file: "src/crypto/webcrypto-tokenizer.ts", line: 118, column: 24, inApplication: true },
+      { functionName: "tokenizePaymentMethod", file: "src/checkout/payment-session.ts", line: 204, column: 17, inApplication: true },
+      { functionName: "confirmOrder", file: "src/checkout/confirm-order.ts", line: 77, column: 11, inApplication: true },
+    ],
+    breadcrumbs: [
+      { offsetMs: 143_000, category: "ui", message: "Customer clicked Place order", level: "info" },
+      { offsetMs: 143_180, category: "http", message: "POST /payment-session returned 200", level: "info" },
+      { offsetMs: 143_240, category: "console", message: "WebCrypto key import failed", level: "error" },
+    ],
+  }],
+  logs: [
+    { id: "log-safari-deploy", stageId: "safari-change", offsetMs: 60_000, timestamp: "2026-06-18T14:03:00.000Z", level: "info", service: "release-controller", message: "Production rollout completed", traceId: "trace-deploy-8420", spanId: "span-deploy-complete", attributes: [{ key: "version", value: "8.42.0" }, { key: "flag.secure-token-v2", value: "enabled" }] },
+    { id: "log-safari-error", stageId: "safari-impact", offsetMs: 151_000, timestamp: "2026-06-18T14:04:31.000Z", level: "error", service: "checkout-web", message: "Payment tokenization failed", traceId: "trace-safari-7d2c", spanId: "span-safari-tokenize", attributes: [{ key: "browser", value: "Safari 17.5" }, { key: "crypto.provider", value: "WebCrypto" }, { key: "flag.variant", value: "enabled" }] },
+    { id: "log-safari-rollback", stageId: "safari-mitigation", offsetMs: 480_000, timestamp: "2026-06-18T14:10:00.000Z", level: "warn", service: "flag-controller", message: "Feature flag rolled back", traceId: "trace-flag-rollback", spanId: "span-flag-write", attributes: [{ key: "flag", value: "secure-token-v2" }, { key: "rollout_percent", value: 0 }] },
+  ],
+  waterfallSpans: [
+    { id: "span-safari-checkout", parentId: null, traceId: "trace-safari-7d2c", service: "checkout-web", operation: "POST /checkout/confirm", startOffsetMs: 143_000, durationMs: 1_240, status: "error", attributes: [{ key: "browser", value: "Safari" }] },
+    { id: "span-safari-session", parentId: "span-safari-checkout", traceId: "trace-safari-7d2c", service: "payment-api", operation: "create payment session", startOffsetMs: 143_140, durationMs: 210, status: "ok", attributes: [{ key: "status_code", value: 200 }] },
+    { id: "span-safari-tokenize", parentId: "span-safari-checkout", traceId: "trace-safari-7d2c", service: "checkout-web", operation: "webcrypto.importKey", startOffsetMs: 143_360, durationMs: 24, status: "error", attributes: [{ key: "exception.type", value: "DataError" }] },
+  ],
+  replayFrames: [
+    { id: "replay-safari-submit", stageId: "safari-impact", offsetMs: 143_000, route: "/checkout/payment", title: "Order submitted", description: "A fictional shopper submits valid payment details.", cursorX: 904, cursorY: 691, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-action='place-order']" },
+    { id: "replay-safari-error", stageId: "safari-impact", offsetMs: 144_300, route: "/checkout/payment", title: "Confirmation fails", description: "The button stops loading and an actionable retry message appears.", cursorX: 904, cursorY: 691, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[role='alert']" },
+  ],
+  change: {
+    deployment: { id: "dep-checkout-8420", environment: "production", service: "checkout-web", version: "8.42.0", startedAt: "2026-06-18T14:01:20.000Z", completedAt: "2026-06-18T14:03:00.000Z", status: "rolled-back" },
+    configChanges: [{ key: "crypto.keyFormat", previousValue: "raw", nextValue: "spki", changedAt: "2026-06-18T14:03:00.000Z", changedBy: "release-controller" }],
+    featureFlags: [{ key: "secure-token-v2", previousVariant: "disabled", currentVariant: "enabled", rolloutPercent: 100, changedAt: "2026-06-18T14:03:00.000Z" }],
+  },
+  suspect: {
+    commitSha: "7d2c9a1",
+    commitTitle: "Use WebCrypto for checkout token wrapping",
+    pullRequestNumber: 4182,
+    pullRequestTitle: "Roll out browser-native payment tokenization",
+    author: "Mira Chen",
+    owner: "Payments Platform",
+    mergedAt: "2026-06-18T13:42:00.000Z",
+    changedLines: [
+      { file: "src/crypto/webcrypto-tokenizer.ts", startLine: 96, endLine: 124, summary: "Selects SPKI key import for the new browser path." },
+      { file: "src/checkout/payment-session.ts", startLine: 198, endLine: 210, summary: "Routes enabled cohorts through WebCrypto." },
+    ],
+  },
+  rootCauseEvidence: [
+    { id: "rc-safari-correlation", stageId: "safari-diagnosis", signal: "Cohort correlation", explanation: "99.2% of failures are Safari sessions in the enabled flag cohort; control traffic remains healthy.", confidence: 0.98, supportingEvidenceIds: ["err-safari-crypto", "log-safari-deploy"] },
+    { id: "rc-safari-code", stageId: "safari-diagnosis", signal: "Stack-to-diff match", explanation: "The top application frame intersects the only changed key-import lines in the suspect commit.", confidence: 0.96, supportingEvidenceIds: ["err-safari-crypto", "span-safari-tokenize"] },
+  ],
+  remediationActions: [
+    { id: "rem-safari-rollback", title: "Disable secure-token-v2", owner: "Payments Platform", status: "completed", completedAt: "2026-06-18T14:10:00.000Z", details: "Returned all browsers to the compatible tokenization path." },
+    { id: "rem-safari-test", title: "Add Safari WebCrypto compatibility suite", owner: "Checkout Quality", status: "in-progress", completedAt: null, details: "Covers key encodings on supported Safari releases before rollout." },
+  ],
+  slo: { objective: "Successful checkout confirmations", targetPercent: 99.9, windowDays: 30, observedPercent: 99.61, burnRate: 18.4, budgetRemainingBeforePercent: 71.2, budgetRemainingCurrentPercent: 52.8, projectedMinutesToExhaustion: 96 },
+  topology: {
+    nodes: [
+      { id: "safari-browser", label: "Safari browser", kind: "browser", health: "critical", requestRate: 8_420, errorRatePercent: 31.8, latencyP95Ms: 4_900 },
+      { id: "checkout-web", label: "Checkout Web", kind: "edge", health: "degraded", requestRate: 24_800, errorRatePercent: 10.9, latencyP95Ms: 2_100 },
+      { id: "payment-api", label: "Payment API", kind: "service", health: "healthy", requestRate: 23_900, errorRatePercent: 0.3, latencyP95Ms: 290 },
+      { id: "payment-provider", label: "Payment Provider", kind: "provider", health: "healthy", requestRate: 23_700, errorRatePercent: 0.2, latencyP95Ms: 340 },
+    ],
+    edges: [
+      { id: "edge-safari-checkout", source: "safari-browser", target: "checkout-web", protocol: "HTTPS", health: "critical", requestsPerMinute: 8_420 },
+      { id: "edge-checkout-payment", source: "checkout-web", target: "payment-api", protocol: "HTTPS", health: "healthy", requestsPerMinute: 23_900 },
+      { id: "edge-payment-provider", source: "payment-api", target: "payment-provider", protocol: "HTTPS", health: "healthy", requestsPerMinute: 23_700 },
+    ],
+  },
+};
+
+const mfaStory: IncidentStory = {
+  id: "mfa-retry-storm",
+  title: "MFA retry policy triggered an authentication storm",
+  shortTitle: "MFA retry storm",
+  severity: "SEV-1",
+  status: "resolved",
+  startedAt: "2026-06-22T09:30:00.000Z",
+  resolvedAt: "2026-06-22T09:48:00.000Z",
+  durationMs: 1_080_000,
+  summary: "A configuration change removed retry jitter and synchronized failed MFA verification attempts.",
+  userImpact: "Users with MFA enabled experienced repeated prompts, delayed verification, and temporary sign-in failures.",
+  businessImpact: "Enterprise login success fell by 22%, delaying access for 7,930 employees across fictional tenants.",
+  affectedUsers: 7_930,
+  affectedRegion: "North America and Europe",
+  metrics: [
+    { id: "mfa-error-rate", label: "MFA verification errors", unit: "percent", higherIsWorse: true, baseline: 0.5, current: 24.6, recovered: 0.7 },
+    { id: "mfa-rpm", label: "MFA verify traffic", unit: "requests-per-minute", higherIsWorse: true, baseline: 12_400, current: 91_000, recovered: 13_100 },
+    { id: "mfa-p95", label: "Verification p95", unit: "milliseconds", higherIsWorse: true, baseline: 410, current: 8_700, recovered: 460 },
+  ],
+  stages: [
+    { id: "mfa-healthy", kind: "healthy", offsetMs: 0, title: "Healthy baseline", summary: "MFA verification is stable with randomized backoff.", metricValues: [{ metricId: "mfa-error-rate", value: 0.5 }, { metricId: "mfa-rpm", value: 12_400 }], evidenceIds: [] },
+    { id: "mfa-change", kind: "change", offsetMs: 90_000, title: "Retry config published", summary: "Retry delay changes from exponential jitter to a fixed 100 ms interval.", metricValues: [{ metricId: "mfa-error-rate", value: 0.8 }, { metricId: "mfa-rpm", value: 13_800 }], evidenceIds: ["log-mfa-config"] },
+    { id: "mfa-impact", kind: "impact", offsetMs: 210_000, title: "Retries synchronize", summary: "Clients retry in lockstep and exhaust verifier capacity.", metricValues: [{ metricId: "mfa-error-rate", value: 24.6 }, { metricId: "mfa-rpm", value: 91_000 }], evidenceIds: ["err-mfa-timeout", "span-mfa-redis"] },
+    { id: "mfa-diagnosis", kind: "diagnosis", offsetMs: 420_000, title: "Retry amplification identified", summary: "Trace fan-out and config history identify the missing jitter.", metricValues: [{ metricId: "mfa-error-rate", value: 20.1 }, { metricId: "mfa-rpm", value: 84_500 }], evidenceIds: ["rc-mfa-amplification"] },
+    { id: "mfa-mitigation", kind: "mitigation", offsetMs: 720_000, title: "Configuration reverted", summary: "Exponential backoff and jitter are restored.", metricValues: [{ metricId: "mfa-error-rate", value: 5.4 }, { metricId: "mfa-rpm", value: 29_000 }], evidenceIds: ["log-mfa-revert"] },
+    { id: "mfa-recovery", kind: "recovery", offsetMs: 1_020_000, title: "Authentication recovered", summary: "Queues drain and successful verification returns to objective.", metricValues: [{ metricId: "mfa-error-rate", value: 0.7 }, { metricId: "mfa-rpm", value: 13_100 }], evidenceIds: [] },
+  ],
+  errors: [{
+    id: "err-mfa-timeout",
+    stageId: "mfa-impact",
+    fingerprint: "mfa-verifier-capacity-timeout",
+    title: "MfaVerificationTimeout",
+    message: "MFA verification exceeded the 5 second request deadline.",
+    count: 28_411,
+    affectedUsers: 7_930,
+    traceId: "trace-mfa-a91e",
+    spanId: "span-mfa-verify",
+    stackFrames: [
+      { functionName: "verifyChallenge", file: "src/auth/mfa/verifier.ts", line: 146, column: 19, inApplication: true },
+      { functionName: "consumeAttempt", file: "src/auth/mfa/rate-limit.ts", line: 88, column: 13, inApplication: true },
+      { functionName: "postMfaVerify", file: "src/routes/mfa.ts", line: 54, column: 9, inApplication: true },
+    ],
+    breadcrumbs: [
+      { offsetMs: 202_000, category: "ui", message: "User submitted authenticator code", level: "info" },
+      { offsetMs: 207_000, category: "http", message: "POST /auth/mfa/verify timed out", level: "error" },
+      { offsetMs: 207_100, category: "http", message: "Client scheduled retry in 100 ms", level: "warning" },
+    ],
+  }],
+  logs: [
+    { id: "log-mfa-config", stageId: "mfa-change", offsetMs: 90_000, timestamp: "2026-06-22T09:31:30.000Z", level: "info", service: "config-controller", message: "Authentication configuration activated", traceId: "trace-config-mfa", spanId: "span-config-publish", attributes: [{ key: "retry.strategy", value: "fixed" }, { key: "retry.delay_ms", value: 100 }, { key: "retry.jitter", value: false }] },
+    { id: "log-mfa-overload", stageId: "mfa-impact", offsetMs: 212_000, timestamp: "2026-06-22T09:33:32.000Z", level: "error", service: "mfa-verifier", message: "Verifier concurrency limit reached", traceId: "trace-mfa-a91e", spanId: "span-mfa-verify", attributes: [{ key: "in_flight", value: 5_000 }, { key: "retry_attempt", value: 4 }] },
+    { id: "log-mfa-revert", stageId: "mfa-mitigation", offsetMs: 720_000, timestamp: "2026-06-22T09:42:00.000Z", level: "warn", service: "config-controller", message: "Authentication configuration reverted", traceId: "trace-config-revert", spanId: "span-config-publish", attributes: [{ key: "retry.strategy", value: "exponential" }, { key: "retry.jitter", value: true }] },
+  ],
+  waterfallSpans: [
+    { id: "span-mfa-request", parentId: null, traceId: "trace-mfa-a91e", service: "auth-edge", operation: "POST /auth/mfa/verify", startOffsetMs: 202_000, durationMs: 5_010, status: "error", attributes: [{ key: "attempt", value: 4 }] },
+    { id: "span-mfa-verify", parentId: "span-mfa-request", traceId: "trace-mfa-a91e", service: "mfa-verifier", operation: "verify TOTP", startOffsetMs: 202_014, durationMs: 4_982, status: "error", attributes: [{ key: "deadline_ms", value: 5_000 }] },
+    { id: "span-mfa-redis", parentId: "span-mfa-verify", traceId: "trace-mfa-a91e", service: "attempt-store", operation: "GET mfa_attempt", startOffsetMs: 202_025, durationMs: 4_120, status: "error", attributes: [{ key: "pool.wait_ms", value: 4_090 }] },
+  ],
+  replayFrames: [
+    { id: "replay-mfa-prompt", stageId: "mfa-impact", offsetMs: 202_000, route: "/auth/mfa", title: "Verification submitted", description: "A fictional user enters a valid authenticator code.", cursorX: 720, cursorY: 566, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-action='verify-mfa']" },
+    { id: "replay-mfa-retry", stageId: "mfa-impact", offsetMs: 207_100, route: "/auth/mfa", title: "Automatic retry starts", description: "The client retries too quickly while the first request is still clearing.", cursorX: 720, cursorY: 566, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-state='retrying']" },
+  ],
+  change: {
+    deployment: { id: "dep-auth-config-119", environment: "production", service: "config-controller", version: "config-119", startedAt: "2026-06-22T09:31:20.000Z", completedAt: "2026-06-22T09:31:30.000Z", status: "rolled-back" },
+    configChanges: [
+      { key: "auth.mfa.retryStrategy", previousValue: "exponential-jitter", nextValue: "fixed", changedAt: "2026-06-22T09:31:30.000Z", changedBy: "auth-config-bot" },
+      { key: "auth.mfa.retryDelayMs", previousValue: "750", nextValue: "100", changedAt: "2026-06-22T09:31:30.000Z", changedBy: "auth-config-bot" },
+    ],
+    featureFlags: [{ key: "mfa-client-retry-v3", previousVariant: "control", currentVariant: "fixed-delay", rolloutPercent: 100, changedAt: "2026-06-22T09:31:30.000Z" }],
+  },
+  suspect: {
+    commitSha: "a91ef04",
+    commitTitle: "Simplify MFA retry configuration",
+    pullRequestNumber: 4219,
+    pullRequestTitle: "Unify authentication retry defaults",
+    author: "Jon Bell",
+    owner: "Identity Reliability",
+    mergedAt: "2026-06-22T08:55:00.000Z",
+    changedLines: [
+      { file: "config/authentication.ts", startLine: 44, endLine: 58, summary: "Replaces randomized backoff with a fixed interval." },
+      { file: "src/auth/mfa/retry-policy.ts", startLine: 71, endLine: 86, summary: "Reads the shared retry delay for MFA verification." },
+    ],
+  },
+  rootCauseEvidence: [
+    { id: "rc-mfa-amplification", stageId: "mfa-diagnosis", signal: "Retry periodicity", explanation: "Request bursts repeat at exactly 100 ms intervals, matching the activated configuration.", confidence: 0.99, supportingEvidenceIds: ["log-mfa-config", "err-mfa-timeout"] },
+    { id: "rc-mfa-capacity", stageId: "mfa-diagnosis", signal: "Trace queue time", explanation: "82% of failed trace duration is waiting for the attempt-store pool rather than computing TOTP.", confidence: 0.94, supportingEvidenceIds: ["span-mfa-redis", "log-mfa-overload"] },
+  ],
+  remediationActions: [
+    { id: "rem-mfa-revert", title: "Restore exponential jitter", owner: "Identity Reliability", status: "completed", completedAt: "2026-06-22T09:42:00.000Z", details: "Reverted retry settings and invalidated the fixed-delay configuration." },
+    { id: "rem-mfa-guardrail", title: "Add retry amplification policy check", owner: "Platform Safety", status: "planned", completedAt: null, details: "Rejects production configuration with synchronized sub-second retries." },
+  ],
+  slo: { objective: "Successful MFA verification", targetPercent: 99.95, windowDays: 30, observedPercent: 99.71, burnRate: 24.2, budgetRemainingBeforePercent: 64.5, budgetRemainingCurrentPercent: 39.8, projectedMinutesToExhaustion: 61 },
+  topology: {
+    nodes: [
+      { id: "auth-edge", label: "Auth Edge", kind: "edge", health: "degraded", requestRate: 91_000, errorRatePercent: 24.6, latencyP95Ms: 8_700 },
+      { id: "mfa-verifier", label: "MFA Verifier", kind: "service", health: "critical", requestRate: 88_400, errorRatePercent: 25.1, latencyP95Ms: 8_200 },
+      { id: "attempt-store", label: "Attempt Store", kind: "database", health: "critical", requestRate: 86_700, errorRatePercent: 9.4, latencyP95Ms: 6_100 },
+      { id: "user-directory", label: "User Directory", kind: "database", health: "healthy", requestRate: 12_900, errorRatePercent: 0.1, latencyP95Ms: 48 },
+    ],
+    edges: [
+      { id: "edge-auth-mfa", source: "auth-edge", target: "mfa-verifier", protocol: "gRPC", health: "critical", requestsPerMinute: 88_400 },
+      { id: "edge-mfa-attempts", source: "mfa-verifier", target: "attempt-store", protocol: "SQL", health: "critical", requestsPerMinute: 86_700 },
+      { id: "edge-mfa-directory", source: "mfa-verifier", target: "user-directory", protocol: "SQL", health: "healthy", requestsPerMinute: 12_900 },
+    ],
+  },
+};
+
+const webhookStory: IncidentStory = {
+  id: "webhook-poison-message",
+  title: "Poison webhook message blocked queue partitions",
+  shortTitle: "Webhook backlog",
+  severity: "SEV-2",
+  status: "resolved",
+  startedAt: "2026-06-25T16:10:00.000Z",
+  resolvedAt: "2026-06-25T16:35:00.000Z",
+  durationMs: 1_500_000,
+  summary: "An unbounded deserialization retry kept a malformed fictional webhook at the head of several queue partitions.",
+  userImpact: "Webhook consumers received account and order events up to 21 minutes late.",
+  businessImpact: "43 fictional merchants experienced delayed fulfillment automation; no events were lost.",
+  affectedUsers: 43,
+  affectedRegion: "us-east queue cluster",
+  metrics: [
+    { id: "webhook-backlog", label: "Queued webhooks", unit: "count", higherIsWorse: true, baseline: 1_200, current: 184_000, recovered: 1_460 },
+    { id: "webhook-oldest", label: "Oldest message age", unit: "milliseconds", higherIsWorse: true, baseline: 8_000, current: 1_260_000, recovered: 11_000 },
+    { id: "webhook-throughput", label: "Delivery throughput", unit: "requests-per-minute", higherIsWorse: false, baseline: 42_000, current: 5_100, recovered: 41_600 },
+  ],
+  stages: [
+    { id: "webhook-healthy", kind: "healthy", offsetMs: 0, title: "Queue healthy", summary: "Workers keep delivery lag below ten seconds.", metricValues: [{ metricId: "webhook-backlog", value: 1_200 }, { metricId: "webhook-throughput", value: 42_000 }], evidenceIds: [] },
+    { id: "webhook-change", kind: "change", offsetMs: 120_000, title: "Worker 5.18.0 deployed", summary: "A parser refactor removes the terminal dead-letter classification.", metricValues: [{ metricId: "webhook-backlog", value: 1_500 }, { metricId: "webhook-throughput", value: 41_700 }], evidenceIds: ["log-webhook-deploy"] },
+    { id: "webhook-impact", kind: "impact", offsetMs: 330_000, title: "Poison message loops", summary: "Malformed payloads are retried indefinitely and block partition progress.", metricValues: [{ metricId: "webhook-backlog", value: 184_000 }, { metricId: "webhook-throughput", value: 5_100 }], evidenceIds: ["err-webhook-schema", "span-webhook-decode"] },
+    { id: "webhook-diagnosis", kind: "diagnosis", offsetMs: 660_000, title: "Partition heads identified", summary: "AI analysis finds identical message IDs at the head of all stalled partitions.", metricValues: [{ metricId: "webhook-backlog", value: 171_000 }, { metricId: "webhook-throughput", value: 7_800 }], evidenceIds: ["rc-webhook-head"] },
+    { id: "webhook-mitigation", kind: "mitigation", offsetMs: 960_000, title: "Messages quarantined", summary: "Poison messages move to the dead-letter queue and workers scale out.", metricValues: [{ metricId: "webhook-backlog", value: 63_000 }, { metricId: "webhook-throughput", value: 68_000 }], evidenceIds: ["log-webhook-quarantine"] },
+    { id: "webhook-recovery", kind: "recovery", offsetMs: 1_440_000, title: "Backlog drained", summary: "Delivery lag and throughput return to normal.", metricValues: [{ metricId: "webhook-backlog", value: 1_460 }, { metricId: "webhook-throughput", value: 41_600 }], evidenceIds: [] },
+  ],
+  errors: [{
+    id: "err-webhook-schema",
+    stageId: "webhook-impact",
+    fingerprint: "webhook-deserialize-missing-event-type",
+    title: "WebhookPayloadSchemaError",
+    message: "Payload field 'event_type' must be a non-empty string.",
+    count: 91_240,
+    affectedUsers: 43,
+    traceId: "trace-webhook-c4b8",
+    spanId: "span-webhook-decode",
+    stackFrames: [
+      { functionName: "decodeEnvelope", file: "src/worker/envelope-parser.ts", line: 92, column: 15, inApplication: true },
+      { functionName: "processDelivery", file: "src/worker/delivery-loop.ts", line: 164, column: 21, inApplication: true },
+      { functionName: "consumePartition", file: "src/worker/consumer.ts", line: 58, column: 13, inApplication: true },
+    ],
+    breadcrumbs: [
+      { offsetMs: 324_000, category: "queue", message: "Dequeued fictional message wh_msg_demo_1042", level: "info" },
+      { offsetMs: 324_020, category: "console", message: "Payload validation failed", level: "error" },
+      { offsetMs: 324_120, category: "queue", message: "Message returned to partition head", level: "warning" },
+    ],
+  }],
+  logs: [
+    { id: "log-webhook-deploy", stageId: "webhook-change", offsetMs: 120_000, timestamp: "2026-06-25T16:12:00.000Z", level: "info", service: "release-controller", message: "Webhook worker deployment completed", traceId: "trace-deploy-5180", spanId: "span-deploy-complete", attributes: [{ key: "version", value: "5.18.0" }, { key: "replicas", value: 48 }] },
+    { id: "log-webhook-poison", stageId: "webhook-impact", offsetMs: 331_000, timestamp: "2026-06-25T16:15:31.000Z", level: "error", service: "webhook-worker", message: "Delivery processing failed; scheduling retry", traceId: "trace-webhook-c4b8", spanId: "span-webhook-decode", attributes: [{ key: "message_id", value: "wh_msg_demo_1042" }, { key: "attempt", value: 4_812 }, { key: "partition", value: 17 }] },
+    { id: "log-webhook-quarantine", stageId: "webhook-mitigation", offsetMs: 960_000, timestamp: "2026-06-25T16:26:00.000Z", level: "warn", service: "queue-operator", message: "Poison messages moved to quarantine", traceId: "trace-queue-remediation", spanId: "span-dlq-move", attributes: [{ key: "messages", value: 6 }, { key: "partitions_unblocked", value: 6 }] },
+  ],
+  waterfallSpans: [
+    { id: "span-webhook-consume", parentId: null, traceId: "trace-webhook-c4b8", service: "webhook-worker", operation: "consume partition 17", startOffsetMs: 324_000, durationMs: 142, status: "error", attributes: [{ key: "message_id", value: "wh_msg_demo_1042" }] },
+    { id: "span-webhook-decode", parentId: "span-webhook-consume", traceId: "trace-webhook-c4b8", service: "webhook-worker", operation: "decode envelope", startOffsetMs: 324_012, durationMs: 8, status: "error", attributes: [{ key: "schema_version", value: "2026-05" }] },
+    { id: "span-webhook-requeue", parentId: "span-webhook-consume", traceId: "trace-webhook-c4b8", service: "event-queue", operation: "NACK requeue", startOffsetMs: 324_025, durationMs: 102, status: "ok", attributes: [{ key: "retry_delay_ms", value: 0 }] },
+  ],
+  replayFrames: [
+    { id: "replay-webhook-queue", stageId: "webhook-impact", offsetMs: 331_000, route: "/operations/webhooks", title: "Queue lag alert", description: "The operations view highlights six stalled queue partitions.", cursorX: 1088, cursorY: 242, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-metric='oldest-message-age']" },
+    { id: "replay-webhook-message", stageId: "webhook-diagnosis", offsetMs: 662_000, route: "/operations/webhooks/partitions/17", title: "Repeated message found", description: "The same fictional message appears in every recent retry.", cursorX: 782, cursorY: 486, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-message-id='wh_msg_demo_1042']" },
+  ],
+  change: {
+    deployment: { id: "dep-webhook-5180", environment: "production", service: "webhook-worker", version: "5.18.0", startedAt: "2026-06-25T16:11:10.000Z", completedAt: "2026-06-25T16:12:00.000Z", status: "rolled-back" },
+    configChanges: [{ key: "webhooks.worker.maxTerminalAttempts", previousValue: "10", nextValue: "unbounded", changedAt: "2026-06-25T16:12:00.000Z", changedBy: "release-controller" }],
+    featureFlags: [{ key: "webhook-envelope-parser-v2", previousVariant: "legacy", currentVariant: "v2", rolloutPercent: 100, changedAt: "2026-06-25T16:12:00.000Z" }],
+  },
+  suspect: {
+    commitSha: "c4b87dd",
+    commitTitle: "Consolidate webhook envelope errors",
+    pullRequestNumber: 4256,
+    pullRequestTitle: "Refactor delivery worker parser",
+    author: "Avery Singh",
+    owner: "Event Delivery",
+    mergedAt: "2026-06-25T15:28:00.000Z",
+    changedLines: [
+      { file: "src/worker/envelope-parser.ts", startLine: 78, endLine: 101, summary: "Maps validation failures to a retryable parser error." },
+      { file: "src/worker/delivery-loop.ts", startLine: 151, endLine: 174, summary: "Requeues all parser errors without an attempt ceiling." },
+    ],
+  },
+  rootCauseEvidence: [
+    { id: "rc-webhook-head", stageId: "webhook-diagnosis", signal: "Partition-head repetition", explanation: "Six stalled partitions repeatedly process one malformed message each without advancing offsets.", confidence: 0.99, supportingEvidenceIds: ["log-webhook-poison", "span-webhook-decode"] },
+    { id: "rc-webhook-diff", stageId: "webhook-diagnosis", signal: "Error classification regression", explanation: "The deployment changed schema failures from terminal to retryable and removed the attempt ceiling.", confidence: 0.97, supportingEvidenceIds: ["err-webhook-schema", "log-webhook-deploy"] },
+  ],
+  remediationActions: [
+    { id: "rem-webhook-quarantine", title: "Quarantine poison messages", owner: "Event Delivery", status: "completed", completedAt: "2026-06-25T16:26:00.000Z", details: "Moved six malformed messages to a durable dead-letter queue." },
+    { id: "rem-webhook-ceiling", title: "Enforce terminal retry ceiling", owner: "Event Delivery", status: "in-progress", completedAt: null, details: "Classifies schema errors as terminal and caps all retryable failures." },
+  ],
+  slo: { objective: "Webhooks delivered within 60 seconds", targetPercent: 99.9, windowDays: 30, observedPercent: 99.72, burnRate: 11.8, budgetRemainingBeforePercent: 78.1, budgetRemainingCurrentPercent: 65.4, projectedMinutesToExhaustion: 188 },
+  topology: {
+    nodes: [
+      { id: "event-api", label: "Event API", kind: "service", health: "healthy", requestRate: 42_400, errorRatePercent: 0.1, latencyP95Ms: 72 },
+      { id: "event-queue", label: "Event Queue", kind: "queue", health: "critical", requestRate: 42_300, errorRatePercent: 0, latencyP95Ms: 1_260_000 },
+      { id: "webhook-worker", label: "Webhook Worker", kind: "service", health: "critical", requestRate: 91_200, errorRatePercent: 94.4, latencyP95Ms: 142 },
+      { id: "merchant-endpoint", label: "Merchant Endpoints", kind: "provider", health: "healthy", requestRate: 5_100, errorRatePercent: 0.8, latencyP95Ms: 310 },
+    ],
+    edges: [
+      { id: "edge-api-queue", source: "event-api", target: "event-queue", protocol: "queue", health: "healthy", requestsPerMinute: 42_300 },
+      { id: "edge-queue-worker", source: "event-queue", target: "webhook-worker", protocol: "queue", health: "critical", requestsPerMinute: 91_200 },
+      { id: "edge-worker-merchant", source: "webhook-worker", target: "merchant-endpoint", protocol: "HTTPS", health: "degraded", requestsPerMinute: 5_100 },
+    ],
+  },
+};
+
+const aiRefundStory: IncidentStory = {
+  id: "ai-agent-wrong-refund",
+  title: "Support agent issued incorrect refunds after tool prompt change",
+  shortTitle: "AI refund error",
+  severity: "SEV-2",
+  status: "resolved",
+  startedAt: "2026-06-29T11:05:00.000Z",
+  resolvedAt: "2026-06-29T11:21:00.000Z",
+  durationMs: 960_000,
+  summary: "A prompt and tool-schema change made a support agent treat store credit amounts as cash refund amounts.",
+  userImpact: "Twenty-seven fictional customers received incorrect cash refunds instead of the intended store credit.",
+  businessImpact: "$8,640 in excess refunds was issued and automatically flagged for finance review.",
+  affectedUsers: 27,
+  affectedRegion: "English-language support queue",
+  metrics: [
+    { id: "ai-refund-errors", label: "Incorrect refund decisions", unit: "count", higherIsWorse: true, baseline: 0, current: 27, recovered: 0 },
+    { id: "ai-tool-confidence", label: "Tool-call confidence", unit: "percent", higherIsWorse: false, baseline: 96.2, current: 61.4, recovered: 97.1 },
+    { id: "ai-refund-value", label: "Refund value at risk", unit: "dollars", higherIsWorse: true, baseline: 0, current: 8_640, recovered: 0 },
+  ],
+  stages: [
+    { id: "ai-healthy", kind: "healthy", offsetMs: 0, title: "Agent healthy", summary: "Refund policy checks and tool arguments agree.", metricValues: [{ metricId: "ai-refund-errors", value: 0 }, { metricId: "ai-tool-confidence", value: 96.2 }], evidenceIds: [] },
+    { id: "ai-change", kind: "change", offsetMs: 75_000, title: "Prompt and tool v7 deployed", summary: "Refund instructions are condensed and credit_amount is renamed amount.", metricValues: [{ metricId: "ai-refund-errors", value: 0 }, { metricId: "ai-tool-confidence", value: 93.1 }], evidenceIds: ["log-ai-deploy"] },
+    { id: "ai-impact", kind: "impact", offsetMs: 180_000, title: "Wrong refund issued", summary: "The agent submits a cash refund using a store-credit recommendation.", metricValues: [{ metricId: "ai-refund-errors", value: 27 }, { metricId: "ai-tool-confidence", value: 61.4 }], evidenceIds: ["err-ai-policy", "span-ai-refund-tool", "replay-ai-tool"] },
+    { id: "ai-diagnosis", kind: "diagnosis", offsetMs: 390_000, title: "Semantic mismatch identified", summary: "AI evaluation traces the decision to ambiguous prompt language and tool naming.", metricValues: [{ metricId: "ai-refund-errors", value: 27 }, { metricId: "ai-tool-confidence", value: 64.8 }], evidenceIds: ["rc-ai-prompt", "rc-ai-tool"] },
+    { id: "ai-mitigation", kind: "mitigation", offsetMs: 600_000, title: "Autonomous refunds paused", summary: "Refund execution requires human confirmation while prompt v6 is restored.", metricValues: [{ metricId: "ai-refund-errors", value: 27 }, { metricId: "ai-tool-confidence", value: 88.9 }], evidenceIds: ["log-ai-disable"] },
+    { id: "ai-recovery", kind: "recovery", offsetMs: 900_000, title: "Agent recovered", summary: "Corrected prompt and typed tool fields pass shadow evaluation.", metricValues: [{ metricId: "ai-refund-errors", value: 0 }, { metricId: "ai-tool-confidence", value: 97.1 }], evidenceIds: [] },
+  ],
+  errors: [{
+    id: "err-ai-policy",
+    stageId: "ai-impact",
+    fingerprint: "support-agent-refund-policy-mismatch",
+    title: "RefundPolicyMismatch",
+    message: "Cash refund amount exceeded policy recommendation for this support case.",
+    count: 27,
+    affectedUsers: 27,
+    traceId: "trace-ai-f39a",
+    spanId: "span-ai-refund-tool",
+    stackFrames: [
+      { functionName: "validateRefundDecision", file: "src/agent/policy/refund-policy.ts", line: 133, column: 18, inApplication: true },
+      { functionName: "executeRefundTool", file: "src/agent/tools/refund.ts", line: 89, column: 14, inApplication: true },
+      { functionName: "runSupportTurn", file: "src/agent/runtime.ts", line: 211, column: 20, inApplication: true },
+    ],
+    breadcrumbs: [
+      { offsetMs: 172_000, category: "ai", message: "Model recommended 320 credits", level: "info" },
+      { offsetMs: 173_200, category: "ai", message: "Tool argument amount=320 currency=USD", level: "warning" },
+      { offsetMs: 174_000, category: "http", message: "Refund provider accepted $320.00", level: "error" },
+    ],
+  }],
+  logs: [
+    { id: "log-ai-deploy", stageId: "ai-change", offsetMs: 75_000, timestamp: "2026-06-29T11:06:15.000Z", level: "info", service: "agent-orchestrator", message: "Support agent definition activated", traceId: "trace-agent-deploy-v7", spanId: "span-agent-activate", attributes: [{ key: "prompt_version", value: "refund-v7" }, { key: "tool_schema", value: "refund-tool-v7" }, { key: "model", value: "fictional-support-model-2" }] },
+    { id: "log-ai-tool", stageId: "ai-impact", offsetMs: 174_000, timestamp: "2026-06-29T11:07:54.000Z", level: "error", service: "refund-service", message: "Refund policy post-check failed", traceId: "trace-ai-f39a", spanId: "span-ai-refund-tool", attributes: [{ key: "recommended_instrument", value: "store_credit" }, { key: "executed_instrument", value: "cash" }, { key: "amount", value: 320 }] },
+    { id: "log-ai-disable", stageId: "ai-mitigation", offsetMs: 600_000, timestamp: "2026-06-29T11:15:00.000Z", level: "warn", service: "agent-orchestrator", message: "Autonomous refund tool disabled", traceId: "trace-agent-mitigation", spanId: "span-flag-write", attributes: [{ key: "flag", value: "support-agent-auto-refund" }, { key: "rollout_percent", value: 0 }] },
+  ],
+  waterfallSpans: [
+    { id: "span-ai-turn", parentId: null, traceId: "trace-ai-f39a", service: "agent-orchestrator", operation: "support turn", startOffsetMs: 170_000, durationMs: 4_860, status: "error", attributes: [{ key: "prompt_version", value: "refund-v7" }] },
+    { id: "span-ai-model", parentId: "span-ai-turn", traceId: "trace-ai-f39a", service: "fictional-support-model-2", operation: "generate response", startOffsetMs: 170_120, durationMs: 2_980, status: "ok", attributes: [{ key: "finish_reason", value: "tool_call" }] },
+    { id: "span-ai-refund-tool", parentId: "span-ai-turn", traceId: "trace-ai-f39a", service: "refund-service", operation: "issue_refund", startOffsetMs: 173_200, durationMs: 800, status: "error", attributes: [{ key: "amount", value: 320 }, { key: "instrument", value: "cash" }] },
+  ],
+  replayFrames: [
+    { id: "replay-ai-recommendation", stageId: "ai-impact", offsetMs: 172_000, route: "/support/cases/demo-204", title: "Credit recommended", description: "The agent correctly reasons that the fictional customer qualifies for store credit.", cursorX: 980, cursorY: 412, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-agent-step='recommendation']" },
+    { id: "replay-ai-tool", stageId: "ai-impact", offsetMs: 173_200, route: "/support/cases/demo-204", title: "Cash refund tool called", description: "The tool preview shows an ambiguous amount field and cash instrument.", cursorX: 1014, cursorY: 588, viewportWidth: 1440, viewportHeight: 900, highlightedSelector: "[data-tool-call='issue_refund']" },
+  ],
+  change: {
+    deployment: { id: "dep-agent-refund-v7", environment: "production", service: "agent-orchestrator", version: "refund-v7", startedAt: "2026-06-29T11:05:50.000Z", completedAt: "2026-06-29T11:06:15.000Z", status: "rolled-back" },
+    configChanges: [
+      { key: "agents.support.refundPrompt", previousValue: "refund-v6", nextValue: "refund-v7", changedAt: "2026-06-29T11:06:15.000Z", changedBy: "agent-release-bot" },
+      { key: "agents.support.refundToolSchema", previousValue: "refund-tool-v6", nextValue: "refund-tool-v7", changedAt: "2026-06-29T11:06:15.000Z", changedBy: "agent-release-bot" },
+    ],
+    featureFlags: [{ key: "support-agent-auto-refund", previousVariant: "prompt-v6", currentVariant: "prompt-v7", rolloutPercent: 100, changedAt: "2026-06-29T11:06:15.000Z" }],
+  },
+  suspect: {
+    commitSha: "f39aa62",
+    commitTitle: "Condense refund instructions and tool schema",
+    pullRequestNumber: 4294,
+    pullRequestTitle: "Reduce support agent refund latency",
+    author: "Nora Reyes",
+    owner: "AI Support Systems",
+    mergedAt: "2026-06-29T10:32:00.000Z",
+    changedLines: [
+      { file: "prompts/support/refund-v7.md", startLine: 22, endLine: 38, summary: "Combines cash refund and store-credit instructions into one amount rule." },
+      { file: "src/agent/tools/refund-schema.ts", startLine: 41, endLine: 59, summary: "Renames credit_amount to amount without retaining instrument semantics." },
+    ],
+  },
+  rootCauseEvidence: [
+    { id: "rc-ai-prompt", stageId: "ai-diagnosis", signal: "Counterfactual prompt evaluation", explanation: "Replaying the same cases with prompt v6 selects store credit in 100% of affected traces.", confidence: 0.97, supportingEvidenceIds: ["log-ai-deploy", "err-ai-policy"] },
+    { id: "rc-ai-tool", stageId: "ai-diagnosis", signal: "Argument semantic mismatch", explanation: "The model copied the store-credit quantity into the newly generic cash amount field.", confidence: 0.95, supportingEvidenceIds: ["span-ai-refund-tool", "log-ai-tool"] },
+  ],
+  remediationActions: [
+    { id: "rem-ai-disable", title: "Require refund confirmation", owner: "AI Support Systems", status: "completed", completedAt: "2026-06-29T11:15:00.000Z", details: "Disabled autonomous execution and restored prompt v6." },
+    { id: "rem-ai-schema", title: "Split cash and credit tool fields", owner: "Support Platform", status: "in-progress", completedAt: null, details: "Uses distinct instrument-specific amounts with policy validation before execution." },
+    { id: "rem-ai-eval", title: "Add refund counterfactual evaluation", owner: "AI Quality", status: "planned", completedAt: null, details: "Blocks prompt releases that change the selected refund instrument." },
+  ],
+  slo: { objective: "Policy-compliant autonomous support actions", targetPercent: 99.99, windowDays: 30, observedPercent: 99.91, burnRate: 9.1, budgetRemainingBeforePercent: 88.4, budgetRemainingCurrentPercent: 79.3, projectedMinutesToExhaustion: 264 },
+  topology: {
+    nodes: [
+      { id: "support-ui", label: "Support Console", kind: "edge", health: "healthy", requestRate: 2_400, errorRatePercent: 0.2, latencyP95Ms: 210 },
+      { id: "agent-orchestrator", label: "Agent Orchestrator", kind: "service", health: "degraded", requestRate: 1_820, errorRatePercent: 1.5, latencyP95Ms: 5_200 },
+      { id: "support-model", label: "Support Model", kind: "ai-model", health: "degraded", requestRate: 1_810, errorRatePercent: 0, latencyP95Ms: 3_100 },
+      { id: "refund-service", label: "Refund Service", kind: "service", health: "critical", requestRate: 180, errorRatePercent: 15, latencyP95Ms: 920 },
+      { id: "payment-ledger", label: "Payment Ledger", kind: "database", health: "healthy", requestRate: 178, errorRatePercent: 0.1, latencyP95Ms: 65 },
+    ],
+    edges: [
+      { id: "edge-ui-agent", source: "support-ui", target: "agent-orchestrator", protocol: "HTTPS", health: "healthy", requestsPerMinute: 1_820 },
+      { id: "edge-agent-model", source: "agent-orchestrator", target: "support-model", protocol: "HTTPS", health: "degraded", requestsPerMinute: 1_810 },
+      { id: "edge-agent-refund", source: "agent-orchestrator", target: "refund-service", protocol: "tool-call", health: "critical", requestsPerMinute: 180 },
+      { id: "edge-refund-ledger", source: "refund-service", target: "payment-ledger", protocol: "SQL", health: "healthy", requestsPerMinute: 178 },
+    ],
+  },
+};
+
+export const INCIDENT_STORIES: [IncidentStory, ...IncidentStory[]] = [
+  safariStory,
+  mfaStory,
+  webhookStory,
+  aiRefundStory,
+];

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/telemetry-investigation.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/analytics/mission-control/telemetry-investigation.tsx
@@ -1,0 +1,719 @@
+"use client";
+
+import {
+  DesignAlert,
+  DesignAnalyticsCard,
+  DesignAnalyticsCardHeader,
+  DesignBadge,
+} from "@/components/design-components";
+import { cn } from "@/lib/utils";
+import {
+  BugIcon,
+  PulseIcon,
+  StackIcon,
+  TerminalWindowIcon,
+  TreeStructureIcon,
+  UsersIcon,
+} from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "motion/react";
+import { useMemo } from "react";
+import type {
+  IncidentError,
+  IncidentMetric,
+  IncidentStory,
+  StructuredLog,
+  TopologyEdge,
+  TopologyNode,
+  WaterfallSpan,
+} from "./stories";
+
+export type TelemetryInvestigationProps = {
+  story: IncidentStory,
+  activeStageIndex: number,
+  selectedSpanId: string | null,
+  onSelectSpan: (spanId: string) => void,
+};
+
+type SemanticState = "healthy" | "degraded" | "critical";
+type BadgeColor = "blue" | "cyan" | "purple" | "green" | "orange" | "red";
+
+const topologyColumns = 3;
+
+function formatMetricValue(metric: IncidentMetric, value: number): string {
+  switch (metric.unit) {
+    case "percent": {
+      return `${value.toLocaleString(undefined, { maximumFractionDigits: 2 })}%`;
+    }
+    case "milliseconds": {
+      return `${value.toLocaleString()} ms`;
+    }
+    case "count": {
+      return value.toLocaleString();
+    }
+    case "requests-per-minute": {
+      return `${value.toLocaleString()} rpm`;
+    }
+    case "dollars": {
+      return value.toLocaleString(undefined, {
+        style: "currency",
+        currency: "USD",
+        maximumFractionDigits: 0,
+      });
+    }
+    default: {
+      const exhaustiveUnit: never = metric.unit;
+      return exhaustiveUnit;
+    }
+  }
+}
+
+function formatDuration(durationMs: number): string {
+  if (durationMs < 1_000) return `${durationMs.toLocaleString()} ms`;
+  return `${(durationMs / 1_000).toLocaleString(undefined, { maximumFractionDigits: 2 })} s`;
+}
+
+function formatOffset(offsetMs: number): string {
+  const minutes = Math.floor(offsetMs / 60_000);
+  const seconds = Math.floor((offsetMs % 60_000) / 1_000);
+  const milliseconds = offsetMs % 1_000;
+  return `+${minutes}:${seconds.toString().padStart(2, "0")}.${milliseconds.toString().padStart(3, "0")}`;
+}
+
+function badgeColorForHealth(health: SemanticState): BadgeColor {
+  switch (health) {
+    case "healthy": {
+      return "green";
+    }
+    case "degraded": {
+      return "orange";
+    }
+    case "critical": {
+      return "red";
+    }
+    default: {
+      const exhaustiveHealth: never = health;
+      return exhaustiveHealth;
+    }
+  }
+}
+
+function badgeColorForLog(level: StructuredLog["level"]): BadgeColor {
+  switch (level) {
+    case "debug": {
+      return "purple";
+    }
+    case "info": {
+      return "blue";
+    }
+    case "warn": {
+      return "orange";
+    }
+    case "error": {
+      return "red";
+    }
+    default: {
+      const exhaustiveLevel: never = level;
+      return exhaustiveLevel;
+    }
+  }
+}
+
+function topologyStateClass(health: SemanticState): string {
+  switch (health) {
+    case "healthy": {
+      return "text-emerald-600 dark:text-emerald-400";
+    }
+    case "degraded": {
+      return "text-amber-600 dark:text-amber-400";
+    }
+    case "critical": {
+      return "text-red-600 dark:text-red-400";
+    }
+    default: {
+      const exhaustiveHealth: never = health;
+      return exhaustiveHealth;
+    }
+  }
+}
+
+function getCriticalPath(spans: WaterfallSpan[], error: IncidentError | undefined): Set<string> {
+  const criticalPath = new Set<string>();
+  let spanId: string | null | undefined = error?.spanId;
+  while (spanId != null) {
+    if (criticalPath.has(spanId)) break;
+    criticalPath.add(spanId);
+    spanId = spans.find((span) => span.id === spanId)?.parentId;
+  }
+  return criticalPath;
+}
+
+function MetricSummary({ metric }: { metric: IncidentMetric }) {
+  const currentDelta = metric.current - metric.baseline;
+  const recoveredNearBaseline = Math.abs(metric.recovered - metric.baseline)
+    <= Math.max(Math.abs(metric.baseline) * 0.1, 0.1);
+
+  return (
+    <div className="min-w-0 border-r border-foreground/[0.06] px-4 py-3 last:border-r-0">
+      <div className="flex items-center justify-between gap-2">
+        <span className="truncate text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+          {metric.label}
+        </span>
+        <DesignBadge
+          label={recoveredNearBaseline ? "Recovered" : "Elevated"}
+          color={recoveredNearBaseline ? "green" : "orange"}
+          size="sm"
+        />
+      </div>
+      <div className="mt-2 flex items-end gap-2">
+        <span className="font-mono text-lg font-semibold tabular-nums text-foreground">
+          {formatMetricValue(metric, metric.current)}
+        </span>
+        <span className={cn(
+          "pb-0.5 font-mono text-[10px] tabular-nums",
+          metric.higherIsWorse === (currentDelta > 0)
+            ? "text-red-600 dark:text-red-400"
+            : "text-emerald-600 dark:text-emerald-400",
+        )}>
+          {currentDelta > 0 ? "+" : ""}{formatMetricValue(metric, currentDelta)}
+        </span>
+      </div>
+      <div className="mt-1 flex items-center justify-between font-mono text-[10px] text-muted-foreground">
+        <span>base {formatMetricValue(metric, metric.baseline)}</span>
+        <span>now {formatMetricValue(metric, metric.recovered)}</span>
+      </div>
+    </div>
+  );
+}
+
+function TraceWaterfall({
+  story,
+  selectedSpanId,
+  onSelectSpan,
+}: {
+  story: IncidentStory,
+  selectedSpanId: string | null,
+  onSelectSpan: (spanId: string) => void,
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const spans = story.waterfallSpans;
+  const traceStart = spans.reduce(
+    (minimum, span) => Math.min(minimum, span.startOffsetMs),
+    spans[0]?.startOffsetMs ?? 0,
+  );
+  const traceEnd = spans.reduce(
+    (maximum, span) => Math.max(maximum, span.startOffsetMs + span.durationMs),
+    traceStart + 1,
+  );
+  const traceDuration = Math.max(traceEnd - traceStart, 1);
+  const relevantError = story.errors.find((error) => error.spanId === selectedSpanId)
+    ?? story.errors[0];
+  const criticalPath = useMemo(
+    () => getCriticalPath(spans, relevantError),
+    [relevantError, spans],
+  );
+
+  return (
+    <DesignAnalyticsCard gradient="cyan" chart={{ type: "none" }}>
+      <DesignAnalyticsCardHeader
+        label="Distributed trace waterfall"
+        right={(
+          <div className="flex items-center gap-2">
+            <DesignBadge label={`${spans.length} spans`} color="cyan" size="sm" />
+            <span className="font-mono text-[10px] text-muted-foreground">
+              {formatDuration(traceDuration)}
+            </span>
+          </div>
+        )}
+      />
+      <div className="overflow-x-auto p-4">
+        <div className="min-w-[680px]" role="tree" aria-label={`Trace waterfall for ${story.shortTitle}`}>
+          <div className="mb-2 grid grid-cols-[220px_1fr_68px] gap-3 px-2 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+            <span>Service · operation</span>
+            <span>Relative duration</span>
+            <span className="text-right">Latency</span>
+          </div>
+          <div className="space-y-1">
+            {spans.map((span, index) => {
+              const left = ((span.startOffsetMs - traceStart) / traceDuration) * 100;
+              const width = Math.max((span.durationMs / traceDuration) * 100, 1.2);
+              const selected = selectedSpanId === span.id;
+              const isCritical = criticalPath.has(span.id);
+              const spanEvents = story.logs.filter((log) => log.spanId === span.id);
+
+              return (
+                <button
+                  key={span.id}
+                  type="button"
+                  role="treeitem"
+                  aria-selected={selected}
+                  onClick={() => onSelectSpan(span.id)}
+                  className={cn(
+                    "grid w-full grid-cols-[220px_1fr_68px] items-center gap-3 rounded-lg px-2 py-2 text-left outline-none transition-colors duration-150 hover:bg-foreground/[0.04] hover:transition-none focus-visible:ring-2 focus-visible:ring-ring",
+                    selected && "bg-foreground/[0.06] ring-1 ring-foreground/[0.1]",
+                  )}
+                >
+                  <span className="flex min-w-0 items-center gap-2" style={{ paddingLeft: `${Math.min(index, 3) * 8}px` }}>
+                    <span className={cn(
+                      "h-1.5 w-1.5 shrink-0 rounded-full",
+                      span.status === "error" ? "bg-red-500" : "bg-emerald-500",
+                    )} />
+                    <span className="min-w-0">
+                      <span className="block truncate text-xs font-medium text-foreground">{span.operation}</span>
+                      <span className="block truncate font-mono text-[10px] text-muted-foreground">{span.service}</span>
+                    </span>
+                  </span>
+                  <span className="relative h-7 overflow-hidden rounded-md bg-foreground/[0.035]">
+                    <motion.span
+                      initial={shouldReduceMotion ? false : { scaleX: 0 }}
+                      animate={{ scaleX: 1 }}
+                      transition={{ duration: shouldReduceMotion ? 0 : 0.28, delay: shouldReduceMotion ? 0 : index * 0.035 }}
+                      className={cn(
+                        "absolute top-1 h-5 origin-left rounded",
+                        span.status === "error"
+                          ? "bg-red-500/75"
+                          : isCritical
+                            ? "bg-amber-500/75"
+                            : "bg-cyan-500/65",
+                      )}
+                      style={{ left: `${left}%`, width: `${width}%` }}
+                    />
+                    {spanEvents.map((event) => {
+                      const markerLeft = ((event.offsetMs - traceStart) / traceDuration) * 100;
+                      return (
+                        <span
+                          key={event.id}
+                          className="absolute top-0 h-7 w-px bg-foreground/80"
+                          style={{ left: `${Math.max(0, Math.min(markerLeft, 100))}%` }}
+                          title={`${event.level}: ${event.message}`}
+                          aria-label={`Event: ${event.message}`}
+                        >
+                          <span className="absolute -left-0.5 top-0 h-1.5 w-1.5 rotate-45 bg-foreground" />
+                        </span>
+                      );
+                    })}
+                  </span>
+                  <span className="text-right font-mono text-[10px] tabular-nums text-muted-foreground">
+                    {formatDuration(span.durationMs)}
+                  </span>
+                </button>
+              );
+            })}
+          </div>
+          <div className="mt-3 flex flex-wrap items-center gap-3 border-t border-foreground/[0.05] pt-3 text-[10px] text-muted-foreground">
+            <span className="flex items-center gap-1.5"><span className="h-2 w-3 rounded-sm bg-amber-500/75" />Critical path</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-3 rounded-sm bg-cyan-500/65" />Healthy span</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-3 rounded-sm bg-red-500/75" />Failed span</span>
+            <span className="flex items-center gap-1.5"><span className="h-2 w-px bg-foreground" />Structured event</span>
+          </div>
+        </div>
+      </div>
+    </DesignAnalyticsCard>
+  );
+}
+
+function StructuredLogs({
+  logs,
+  selectedSpanId,
+  onSelectSpan,
+}: {
+  logs: StructuredLog[],
+  selectedSpanId: string | null,
+  onSelectSpan: (spanId: string) => void,
+}) {
+  return (
+    <DesignAnalyticsCard gradient="slate" chart={{ type: "none" }}>
+      <DesignAnalyticsCardHeader
+        label="Stage-aligned logs"
+        right={<DesignBadge label={`${logs.length} events`} color="blue" size="sm" />}
+      />
+      {logs.length === 0 ? (
+        <div className="p-4">
+          <DesignAlert
+            variant="info"
+            title="No logs in this stage"
+            description="Advance playback to inspect stage-specific telemetry."
+          />
+        </div>
+      ) : (
+        <div className="max-h-80 overflow-y-auto" role="log" aria-label="Structured logs for the active incident stage">
+          {logs.map((log) => (
+            <button
+              key={log.id}
+              type="button"
+              onClick={() => onSelectSpan(log.spanId)}
+              className={cn(
+                "grid w-full grid-cols-[76px_64px_minmax(0,1fr)] gap-2 border-b border-foreground/[0.05] px-4 py-3 text-left outline-none transition-colors duration-150 last:border-b-0 hover:bg-foreground/[0.035] hover:transition-none focus-visible:ring-2 focus-visible:ring-inset focus-visible:ring-ring",
+                selectedSpanId === log.spanId && "bg-foreground/[0.05]",
+              )}
+            >
+              <span className="font-mono text-[10px] tabular-nums text-muted-foreground">{formatOffset(log.offsetMs)}</span>
+              <DesignBadge label={log.level} color={badgeColorForLog(log.level)} size="sm" />
+              <span className="min-w-0">
+                <span className="flex min-w-0 items-center gap-2">
+                  <span className="truncate text-xs font-medium text-foreground">{log.message}</span>
+                  <span className="shrink-0 font-mono text-[10px] text-muted-foreground">{log.service}</span>
+                </span>
+                <span className="mt-1 block truncate font-mono text-[10px] text-muted-foreground">
+                  trace={log.traceId} · span={log.spanId}
+                </span>
+                <span className="mt-1 flex flex-wrap gap-x-3 gap-y-1 font-mono text-[10px] text-muted-foreground">
+                  {log.attributes.map((attribute) => (
+                    <span key={attribute.key}>{attribute.key}={String(attribute.value)}</span>
+                  ))}
+                </span>
+              </span>
+            </button>
+          ))}
+        </div>
+      )}
+    </DesignAnalyticsCard>
+  );
+}
+
+function ErrorIssue({
+  error,
+  activeStageKind,
+}: {
+  error: IncidentError | undefined,
+  activeStageKind: IncidentStory["stages"][number]["kind"],
+}) {
+  const regressionLabel = activeStageKind === "recovery"
+    ? "Resolved"
+    : activeStageKind === "mitigation"
+      ? "Recovering"
+      : "Regressed";
+  const regressionColor: BadgeColor = activeStageKind === "recovery"
+    ? "green"
+    : activeStageKind === "mitigation"
+      ? "orange"
+      : "red";
+
+  return (
+    <DesignAnalyticsCard gradient="orange" chart={{ type: "none" }}>
+      <DesignAnalyticsCardHeader
+        label="Grouped error issue"
+        right={<DesignBadge label={regressionLabel} color={regressionColor} size="sm" />}
+      />
+      {error == null ? (
+        <div className="p-4">
+          <DesignAlert variant="success" title="No grouped issue" description="No error fingerprint is associated with this incident." />
+        </div>
+      ) : (
+        <div className="p-4">
+          <div className="flex flex-col gap-3 border-b border-foreground/[0.06] pb-4 sm:flex-row sm:items-start sm:justify-between">
+            <div className="min-w-0">
+              <div className="flex items-center gap-2">
+                <BugIcon className="h-4 w-4 shrink-0 text-red-600 dark:text-red-400" weight="fill" />
+                <h3 className="truncate text-sm font-semibold text-foreground">{error.title}</h3>
+              </div>
+              <p className="mt-1 text-xs leading-relaxed text-muted-foreground">{error.message}</p>
+              <p className="mt-2 truncate font-mono text-[10px] text-muted-foreground">fingerprint={error.fingerprint}</p>
+            </div>
+            <div className="grid shrink-0 grid-cols-2 gap-4 text-right">
+              <div>
+                <div className="font-mono text-base font-semibold tabular-nums text-foreground">{error.count.toLocaleString()}</div>
+                <div className="text-[10px] uppercase tracking-wider text-muted-foreground">events</div>
+              </div>
+              <div>
+                <div className="font-mono text-base font-semibold tabular-nums text-foreground">{error.affectedUsers.toLocaleString()}</div>
+                <div className="text-[10px] uppercase tracking-wider text-muted-foreground">users</div>
+              </div>
+            </div>
+          </div>
+
+          <div className="grid gap-4 pt-4 lg:grid-cols-2">
+            <section aria-labelledby="stack-frames-heading">
+              <h4 id="stack-frames-heading" className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <StackIcon className="h-3.5 w-3.5" />
+                Stack frames
+              </h4>
+              <div className="space-y-1">
+                {error.stackFrames.map((frame) => (
+                  <div
+                    key={`${frame.file}:${frame.line}:${frame.column}`}
+                    className={cn(
+                      "rounded-lg px-3 py-2 font-mono text-[10px]",
+                      frame.inApplication ? "bg-red-500/[0.07]" : "bg-foreground/[0.035]",
+                    )}
+                  >
+                    <div className="truncate font-semibold text-foreground">{frame.functionName}()</div>
+                    <div className="truncate text-muted-foreground">{frame.file}:{frame.line}:{frame.column}</div>
+                  </div>
+                ))}
+              </div>
+            </section>
+            <section aria-labelledby="breadcrumbs-heading">
+              <h4 id="breadcrumbs-heading" className="mb-2 flex items-center gap-1.5 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                <TerminalWindowIcon className="h-3.5 w-3.5" />
+                Breadcrumbs
+              </h4>
+              <div className="space-y-1">
+                {error.breadcrumbs.map((breadcrumb) => (
+                  <div key={`${breadcrumb.offsetMs}-${breadcrumb.message}`} className="grid grid-cols-[64px_1fr] gap-2 rounded-lg bg-foreground/[0.035] px-3 py-2">
+                    <span className="font-mono text-[10px] tabular-nums text-muted-foreground">{formatOffset(breadcrumb.offsetMs)}</span>
+                    <span className="min-w-0">
+                      <span className="block truncate text-[10px] font-medium text-foreground">{breadcrumb.message}</span>
+                      <span className="font-mono text-[9px] uppercase tracking-wider text-muted-foreground">{breadcrumb.category} · {breadcrumb.level}</span>
+                    </span>
+                  </div>
+                ))}
+              </div>
+            </section>
+          </div>
+        </div>
+      )}
+    </DesignAnalyticsCard>
+  );
+}
+
+function nodePosition(index: number, nodeCount: number): { x: number, y: number } {
+  const columns = Math.min(topologyColumns, Math.max(nodeCount, 1));
+  const rows = Math.ceil(nodeCount / columns);
+  const column = index % columns;
+  const row = Math.floor(index / columns);
+  return {
+    x: columns === 1 ? 300 : 80 + (column * 440) / (columns - 1),
+    y: rows === 1 ? 100 : 45 + (row * 110) / (rows - 1),
+  };
+}
+
+function findNodePosition(nodes: TopologyNode[], nodeId: string): { x: number, y: number } | undefined {
+  const index = nodes.findIndex((node) => node.id === nodeId);
+  return index === -1 ? undefined : nodePosition(index, nodes.length);
+}
+
+function TopologyConnection({ edge, nodes }: { edge: TopologyEdge, nodes: TopologyNode[] }) {
+  const source = findNodePosition(nodes, edge.source);
+  const target = findNodePosition(nodes, edge.target);
+  if (source == null || target == null) return null;
+
+  return (
+    <g className={topologyStateClass(edge.health)}>
+      <line
+        x1={source.x}
+        y1={source.y}
+        x2={target.x}
+        y2={target.y}
+        stroke="currentColor"
+        strokeWidth={edge.health === "healthy" ? 1.5 : 2.5}
+        strokeDasharray={edge.health === "healthy" ? undefined : "5 4"}
+        opacity={0.65}
+      />
+      <text
+        x={(source.x + target.x) / 2}
+        y={(source.y + target.y) / 2 - 5}
+        fill="currentColor"
+        textAnchor="middle"
+        className="text-[8px] font-medium"
+      >
+        {edge.protocol} · {edge.requestsPerMinute.toLocaleString()} rpm
+      </text>
+    </g>
+  );
+}
+
+function ServiceTopologyView({ story }: { story: IncidentStory }) {
+  const nodes = story.topology.nodes;
+  return (
+    <DesignAnalyticsCard gradient="purple" chart={{ type: "none" }}>
+      <DesignAnalyticsCardHeader
+        label="Service topology"
+        right={(
+          <div className="flex items-center gap-1.5">
+            <DesignBadge
+              label={`${nodes.filter((node) => node.health === "healthy").length} healthy`}
+              color="green"
+              size="sm"
+            />
+            <DesignBadge
+              label={`${nodes.filter((node) => node.health !== "healthy").length} impaired`}
+              color="orange"
+              size="sm"
+            />
+          </div>
+        )}
+      />
+      <div className="p-4">
+        <svg
+          viewBox="0 0 600 200"
+          className="h-auto min-h-52 w-full"
+          role="img"
+          aria-labelledby={`topology-title-${story.id} topology-description-${story.id}`}
+        >
+          <title id={`topology-title-${story.id}`}>Service topology for {story.shortTitle}</title>
+          <desc id={`topology-description-${story.id}`}>Connections and health states for {nodes.length} services involved in the incident.</desc>
+          {story.topology.edges.map((edge) => (
+            <TopologyConnection key={edge.id} edge={edge} nodes={nodes} />
+          ))}
+          {nodes.map((node, index) => {
+            const position = nodePosition(index, nodes.length);
+            return (
+              <g key={node.id} className={topologyStateClass(node.health)}>
+                <circle cx={position.x} cy={position.y} r="28" fill="currentColor" opacity="0.1" />
+                <circle cx={position.x} cy={position.y} r="22" fill="var(--background)" stroke="currentColor" strokeWidth="2" />
+                <circle cx={position.x} cy={position.y - 7} r="4" fill="currentColor" />
+                <text x={position.x} y={position.y + 5} textAnchor="middle" fill="currentColor" className="text-[8px] font-semibold">
+                  {node.kind}
+                </text>
+                <text x={position.x} y={position.y + 42} textAnchor="middle" className="fill-foreground text-[10px] font-semibold">
+                  {node.label}
+                </text>
+                <text x={position.x} y={position.y + 54} textAnchor="middle" className="fill-muted-foreground text-[8px]">
+                  {node.errorRatePercent}% err · {node.latencyP95Ms}ms p95
+                </text>
+              </g>
+            );
+          })}
+        </svg>
+        <div className="mt-2 flex flex-wrap gap-2" aria-label="Service health summary">
+          {nodes.map((node) => (
+            <DesignBadge
+              key={node.id}
+              label={`${node.label}: ${node.health}`}
+              color={badgeColorForHealth(node.health)}
+              size="sm"
+            />
+          ))}
+        </div>
+      </div>
+    </DesignAnalyticsCard>
+  );
+}
+
+function SloBurn({ story }: { story: IncidentStory }) {
+  const { slo } = story;
+  const budgetConsumed = Math.max(0, slo.budgetRemainingBeforePercent - slo.budgetRemainingCurrentPercent);
+  const budgetRemainingWidth = Math.max(0, Math.min(slo.budgetRemainingCurrentPercent, 100));
+
+  return (
+    <DesignAnalyticsCard gradient="orange" chart={{ type: "none" }}>
+      <DesignAnalyticsCardHeader
+        label="SLO & error budget"
+        right={(
+          <DesignBadge
+            label={`${slo.burnRate.toLocaleString(undefined, { maximumFractionDigits: 1 })}× burn`}
+            color={slo.burnRate > 2 ? "red" : slo.burnRate > 1 ? "orange" : "green"}
+            icon={PulseIcon}
+            size="sm"
+          />
+        )}
+      />
+      <div className="p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div>
+            <div className="text-xs font-semibold text-foreground">{slo.objective}</div>
+            <div className="mt-1 text-[10px] text-muted-foreground">{slo.targetPercent}% target · {slo.windowDays}-day window</div>
+          </div>
+          <div className="text-right">
+            <div className={cn(
+              "font-mono text-xl font-semibold tabular-nums",
+              slo.observedPercent >= slo.targetPercent ? "text-emerald-600 dark:text-emerald-400" : "text-red-600 dark:text-red-400",
+            )}>
+              {slo.observedPercent}%
+            </div>
+            <div className="text-[10px] uppercase tracking-wider text-muted-foreground">observed</div>
+          </div>
+        </div>
+        <div className="mt-4">
+          <div className="mb-1.5 flex items-center justify-between text-[10px] text-muted-foreground">
+            <span>Error budget remaining</span>
+            <span className="font-mono tabular-nums">{slo.budgetRemainingCurrentPercent}%</span>
+          </div>
+          <div className="h-2 overflow-hidden rounded-full bg-foreground/[0.07]">
+            <div
+              className={cn(
+                "h-full rounded-full",
+                budgetRemainingWidth < 25 ? "bg-red-500" : budgetRemainingWidth < 50 ? "bg-amber-500" : "bg-emerald-500",
+              )}
+              style={{ width: `${budgetRemainingWidth}%` }}
+            />
+          </div>
+        </div>
+        <div className="mt-4 grid grid-cols-3 divide-x divide-foreground/[0.06] rounded-xl bg-foreground/[0.035] py-3 text-center">
+          <div>
+            <div className="font-mono text-sm font-semibold tabular-nums text-foreground">{budgetConsumed.toFixed(1)}%</div>
+            <div className="mt-1 text-[9px] uppercase tracking-wider text-muted-foreground">consumed</div>
+          </div>
+          <div>
+            <div className="font-mono text-sm font-semibold tabular-nums text-foreground">{slo.projectedMinutesToExhaustion}m</div>
+            <div className="mt-1 text-[9px] uppercase tracking-wider text-muted-foreground">to exhaust</div>
+          </div>
+          <div>
+            <div className="font-mono text-sm font-semibold tabular-nums text-foreground">{slo.budgetRemainingBeforePercent}%</div>
+            <div className="mt-1 text-[9px] uppercase tracking-wider text-muted-foreground">before</div>
+          </div>
+        </div>
+      </div>
+    </DesignAnalyticsCard>
+  );
+}
+
+export function TelemetryInvestigation({
+  story,
+  activeStageIndex,
+  selectedSpanId,
+  onSelectSpan,
+}: TelemetryInvestigationProps) {
+  const activeStage = story.stages.at(activeStageIndex) ?? story.stages.at(0);
+  if (activeStage == null) {
+    return (
+      <DesignAlert
+        variant="error"
+        title="Telemetry unavailable"
+        description="This incident story has no investigation stages."
+      />
+    );
+  }
+
+  const stageLogs = story.logs.filter((log) => log.stageId === activeStage.id);
+  const stageError = story.errors.find((error) => error.stageId === activeStage.id)
+    ?? story.errors.find((error) => error.spanId === selectedSpanId)
+    ?? story.errors[0];
+
+  return (
+    <section aria-labelledby={`telemetry-investigation-${story.id}`} className="space-y-4">
+      <div className="flex flex-col gap-2 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <div className="flex items-center gap-2">
+            <TreeStructureIcon className="h-4 w-4 text-cyan-600 dark:text-cyan-400" />
+            <h2 id={`telemetry-investigation-${story.id}`} className="text-xs font-semibold uppercase tracking-wider text-foreground">
+              Telemetry investigation
+            </h2>
+          </div>
+          <p className="mt-1 text-xs text-muted-foreground">
+            Stage {activeStageIndex + 1} · {activeStage.title}
+          </p>
+        </div>
+        <div className="flex flex-wrap gap-2">
+          <DesignBadge label={`${story.waterfallSpans.length} spans`} color="cyan" icon={StackIcon} size="sm" />
+          <DesignBadge label={`${stageLogs.length} stage logs`} color="blue" icon={TerminalWindowIcon} size="sm" />
+          <DesignBadge label={`${story.affectedUsers.toLocaleString()} affected`} color="red" icon={UsersIcon} size="sm" />
+        </div>
+      </div>
+
+      <div className="grid overflow-hidden rounded-2xl bg-background ring-1 ring-foreground/[0.06] sm:grid-cols-2 lg:grid-cols-3">
+        {story.metrics.map((metric) => <MetricSummary key={metric.id} metric={metric} />)}
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.45fr)_minmax(360px,0.75fr)]">
+        <TraceWaterfall story={story} selectedSpanId={selectedSpanId} onSelectSpan={onSelectSpan} />
+        <StructuredLogs logs={stageLogs} selectedSpanId={selectedSpanId} onSelectSpan={onSelectSpan} />
+      </div>
+
+      <div className="grid gap-4 xl:grid-cols-[minmax(0,1.15fr)_minmax(360px,0.85fr)]">
+        <ErrorIssue error={stageError} activeStageKind={activeStage.kind} />
+        <SloBurn story={story} />
+      </div>
+
+      <ServiceTopologyView story={story} />
+
+      {story.topology.nodes.some((node) => node.health !== "healthy") && (
+        <DesignAlert
+          variant="warning"
+          title="Degraded dependency path detected"
+          description={`${story.topology.nodes.filter((node) => node.health !== "healthy").map((node) => node.label).join(", ")} show elevated errors or latency for this incident.`}
+        />
+      )}
+    </section>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/blast-radius-panel.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/blast-radius-panel.tsx
@@ -1,0 +1,38 @@
+"use client";
+
+import { CheckCircleIcon } from "@phosphor-icons/react";
+import { MIGRATIONS } from "../fixtures/databases";
+import { CxChip, CxPanel, cx } from "./ui-kit";
+
+export function BlastRadiusPanel() {
+  const blastRadius = MIGRATIONS[0].blastRadius;
+
+  return (
+    <CxPanel
+      title="Who could this affect?"
+      meta={<CxChip tone="warn">{blastRadius.orgsAffected} orgs</CxChip>}
+      bodyClassName="space-y-3 p-3"
+    >
+      <p className="text-sm leading-6">{blastRadius.plainSummary}</p>
+      <div className="flex flex-wrap gap-1.5 tabular-nums">
+        <CxChip tone="warn">{blastRadius.orgsAffected} orgs</CxChip>
+        <CxChip tone="bad">{blastRadius.enterpriseOrgs} enterprise</CxChip>
+        <CxChip tone="warn">${blastRadius.arrUsd.toLocaleString()} ARR</CxChip>
+      </div>
+      <div className="rounded-md border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2.5 text-xs leading-5 text-amber-950 dark:text-amber-100">
+        {blastRadius.predictedOutcome}
+      </div>
+      <div>
+        <p className={cx.label}>Recommended sequence</p>
+        <ol className="mt-2 space-y-1.5">
+          {blastRadius.recommendedSequence.map((step, index) => (
+            <li key={step} className={`flex items-start gap-2 ${cx.panelInset} px-3 py-2 text-xs`}>
+              <CheckCircleIcon className="mt-0.5 size-3.5 shrink-0 text-emerald-600" />
+              <span><span className={`mr-1 ${cx.mono} text-muted-foreground`}>{index + 1}.</span>{step}</span>
+            </li>
+          ))}
+        </ol>
+      </div>
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/branch-tree.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/branch-tree.tsx
@@ -1,0 +1,76 @@
+"use client";
+
+import { DatabaseIcon, GitBranchIcon, LinkIcon } from "@phosphor-icons/react";
+import { DB_BRANCHES } from "../fixtures/databases";
+import type { DbBranch } from "../fixtures/types";
+import { CxChip } from "./ui-kit";
+
+const KIND_TONES = {
+  production: "ok",
+  preview: "accent",
+  dev: "neutral",
+  forensic: "warn",
+  clone: "neutral",
+} as const;
+
+function sizeLabel(sizeGb: number) {
+  return sizeGb >= 1_024 ? `${sizeGb / 1_024} TB` : `${sizeGb} GB`;
+}
+
+function BranchRow(props: {
+  branch: DbBranch,
+  depth: number,
+  selected: boolean,
+  onSelect: (id: string) => void,
+}) {
+  return (
+    <button
+      type="button"
+      onClick={() => props.onSelect(props.branch.id)}
+      className={`w-full rounded-xl px-3 py-2.5 text-left transition-colors duration-150 hover:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+        props.selected ? "bg-primary/[0.08] ring-1 ring-primary/20" : "hover:bg-foreground/[0.04]"
+      }`}
+      style={{ paddingLeft: `${12 + props.depth * 18}px` }}
+    >
+      <div className="flex min-w-0 items-center gap-2">
+        {props.depth === 0 ? <DatabaseIcon className="h-4 w-4 shrink-0" /> : <GitBranchIcon className="h-4 w-4 shrink-0 text-muted-foreground" />}
+        <span className="min-w-0 flex-1 truncate text-sm font-medium">{props.branch.name}</span>
+        <CxChip tone={KIND_TONES[props.branch.kind]}>{props.branch.kind}</CxChip>
+      </div>
+      <div className="mt-1.5 flex items-center gap-2 pl-6 text-[11px] text-muted-foreground tabular-nums">
+        <span>{sizeLabel(props.branch.sizeGb)}</span>
+        {props.branch.releaseVersion != null && <span>· {props.branch.releaseVersion}</span>}
+      </div>
+      {props.branch.previewUrl != null && (
+        <div className="mt-1 flex min-w-0 items-center gap-1 pl-6 text-[11px] text-primary">
+          <LinkIcon className="h-3 w-3 shrink-0" />
+          <span className="truncate">{props.branch.previewUrl}</span>
+        </div>
+      )}
+    </button>
+  );
+}
+
+export function BranchTree(props: { selectedId: string, onSelect: (id: string) => void }) {
+  const roots = DB_BRANCHES.filter((branch) => branch.parentId == null);
+  const childrenFor = (id: string) => DB_BRANCHES.filter((branch) => branch.parentId === id);
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col">
+      <div className="border-b border-border/60 px-4 py-4">
+        <p className="text-xs font-semibold uppercase tracking-wider">Database branches</p>
+        <p className="mt-1 text-xs text-muted-foreground">Production, previews, and safe copies.</p>
+      </div>
+      <div className="min-h-0 flex-1 space-y-1 overflow-y-auto p-2">
+        {roots.map((root) => (
+          <div key={root.id}>
+            <BranchRow branch={root} depth={0} selected={props.selectedId === root.id} onSelect={props.onSelect} />
+            {childrenFor(root.id).map((child) => (
+              <BranchRow key={child.id} branch={child} depth={1} selected={props.selectedId === child.id} onSelect={props.onSelect} />
+            ))}
+          </div>
+        ))}
+      </div>
+    </aside>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/build-log-viewer.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/build-log-viewer.tsx
@@ -1,0 +1,102 @@
+"use client";
+
+import { useEffect, useMemo, useRef } from "react";
+import type { BuildLogLine } from "../fixtures/types";
+import { useDemoScript, type ScriptStep } from "../use-demo-scripts";
+import { CxChip, CxPanel, StatusDot, cx } from "./ui-kit";
+
+export type BuildLogViewerProps = {
+  buildLog: BuildLogLine[],
+  running: boolean,
+};
+
+export function BuildLogViewer({ buildLog, running }: BuildLogViewerProps) {
+  const viewportRef = useRef<HTMLDivElement>(null);
+  const { steps, lineSteps } = useMemo(() => {
+    const nextSteps: ScriptStep[] = [];
+    const nextLineSteps = new Map<string, BuildLogLine["step"]>();
+
+    for (const line of buildLog) {
+      nextSteps.push({ kind: "wait", ms: line.delayMs });
+      const scriptIndex = nextSteps.length;
+      nextSteps.push({ kind: "line", text: line.text, level: line.level });
+      nextLineSteps.set(`line-${scriptIndex}`, line.step);
+    }
+
+    return { steps: nextSteps, lineSteps: nextLineSteps };
+  }, [buildLog]);
+  const { state } = useDemoScript(steps, running);
+  const visibleLines = running
+    ? state.lines.map((line) => {
+      const step = lineSteps.get(line.id);
+      if (step == null) {
+        throw new Error(`Build log line "${line.id}" has no matching step.`);
+      }
+      return { ...line, step };
+    })
+    : buildLog.map((line) => ({
+      id: line.id,
+      text: line.text,
+      level: line.level ?? "info",
+      step: line.step,
+    }));
+
+  useEffect(() => {
+    const viewport = viewportRef.current;
+    if (viewport != null) {
+      viewport.scrollTop = viewport.scrollHeight;
+    }
+  }, [visibleLines.length]);
+
+  return (
+    <CxPanel
+      title="Build"
+      meta={
+        <div className="flex items-center gap-2">
+          <StatusDot status={running && !state.finished ? "warn" : "ok"} />
+          <span className={cx.mono}>{running && !state.finished ? "running" : "ready"}</span>
+        </div>
+      }
+      bodyClassName="p-0"
+    >
+      <div
+        ref={viewportRef}
+        className="max-h-72 min-h-44 overflow-y-auto bg-[#0b0b0f] px-4 py-3 font-mono text-[11px] leading-5 text-[#c8c7d1]"
+        aria-live="polite"
+      >
+        {visibleLines.length === 0 ? (
+          <div className="flex min-h-36 items-center justify-center text-[#6b7280]">
+            No build output for this release.
+          </div>
+        ) : (
+          <div className="space-y-1.5">
+            {visibleLines.map((line) => (
+              <div key={line.id} className="flex items-start gap-3">
+                <span className="w-14 shrink-0 text-[#6b7280]">{line.step}</span>
+                <span
+                  className={
+                    line.level === "success"
+                      ? "text-[#7dcea8]"
+                      : line.level === "warn"
+                        ? "text-amber-300"
+                        : "text-[#c8c7d1]"
+                  }
+                >
+                  {line.text}
+                </span>
+              </div>
+            ))}
+            {running && !state.finished && (
+              <span className="inline-block h-3.5 w-1.5 animate-pulse bg-[#7c6cff] motion-reduce:animate-none" />
+            )}
+          </div>
+        )}
+      </div>
+      {!running && (
+        <div className="border-t border-black/[0.06] px-4 py-2 dark:border-white/[0.06]">
+          <CxChip tone="ok">All checks passed</CxChip>
+        </div>
+      )}
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/clone-wizard.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/clone-wizard.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { DesignButton, DesignPillToggle } from "@/components/design-components";
+import { CheckCircleIcon, CopyIcon, DatabaseIcon, ShieldCheckIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { CLONE_PRESETS, SCHEMA_TABLES } from "../fixtures/databases";
+import { useDemoScript, type ScriptStep } from "../use-demo-scripts";
+import { SensitiveKindChip } from "./schema-browser";
+import { CxChip, CxPanel, cx } from "./ui-kit";
+
+const CLONE_STEPS: ScriptStep[] = [
+  { kind: "progress", id: "snapshot", label: "Snapshot", status: "running" },
+  { kind: "wait", ms: 450 },
+  { kind: "progress", id: "snapshot", label: "Snapshot", status: "done" },
+  { kind: "progress", id: "sample", label: "Sample", status: "running" },
+  { kind: "wait", ms: 550 },
+  { kind: "progress", id: "sample", label: "Sample", status: "done" },
+  { kind: "progress", id: "anonymize", label: "Anonymize", status: "running" },
+  { kind: "wait", ms: 650 },
+  { kind: "progress", id: "anonymize", label: "Anonymize", status: "done" },
+  { kind: "progress", id: "verify", label: "Verify", status: "running" },
+  { kind: "wait", ms: 500 },
+  { kind: "progress", id: "verify", label: "Verify", status: "done" },
+  { kind: "progress", id: "ready", label: "Ready", status: "done" },
+];
+
+const STEP_IDS = ["snapshot", "sample", "anonymize", "verify", "ready"] as const;
+
+export function CloneWizard() {
+  const [presetId, setPresetId] = useState(CLONE_PRESETS[1].id);
+  const [started, setStarted] = useState(false);
+  const [attachment, setAttachment] = useState<"pr" | "dev" | null>(null);
+  const demo = useDemoScript(CLONE_STEPS);
+  const preset = CLONE_PRESETS.find((item) => item.id === presetId) ?? CLONE_PRESETS[1];
+  const sensitiveColumns = SCHEMA_TABLES.flatMap((table) =>
+    table.columns
+      .filter((column) => column.sensitive != null)
+      .map((column) => ({ table: table.name, column })),
+  );
+
+  const start = () => {
+    setStarted(true);
+    setAttachment(null);
+    demo.start();
+  };
+
+  return (
+    <CxPanel
+      title="Make a safe copy"
+      meta={<CxChip>anonymized</CxChip>}
+      bodyClassName="space-y-4 p-3"
+    >
+      <p className={cx.muted}>A safe copy of your real data — emails and names replaced with fakes.</p>
+      <div>
+        <p className={cx.label}>Copy size</p>
+        <div className="mt-2">
+          <DesignPillToggle
+            options={CLONE_PRESETS.map((item) => ({ id: item.id, label: item.targetSizeLabel === "Full (2 TB)" ? "Full" : item.targetSizeLabel }))}
+            selected={presetId}
+            onSelect={setPresetId}
+            size="sm"
+          />
+        </div>
+        <p className="mt-2 text-sm font-medium tabular-nums">
+          {preset.targetSizeLabel} — {preset.orgsPreserved.toLocaleString()} orgs including {preset.enterpriseOrgs} enterprise, with whole organizations kept together.
+        </p>
+        <div className="mt-2 flex flex-wrap gap-1.5">
+          {preset.coverageNotes.map((note) => <CxChip key={note}>{note}</CxChip>)}
+        </div>
+      </div>
+
+      <div className="grid gap-3 lg:grid-cols-2">
+        <div className={`${cx.panelInset} p-3`}>
+          <p className={cx.label}>Schema preview</p>
+          <div className="mt-2 space-y-1.5">
+            {sensitiveColumns.slice(0, 6).map(({ table, column }) => (
+              <div key={`${table}.${column.name}`} className="flex items-center gap-2 rounded-md bg-amber-500/[0.06] px-2.5 py-1.5 text-xs">
+                <span className={`min-w-0 flex-1 truncate ${cx.mono}`}>{table}.{column.name}</span>
+                {column.sensitive != null && <SensitiveKindChip kind={column.sensitive.kind} />}
+              </div>
+            ))}
+          </div>
+        </div>
+        <div className={`${cx.panelInset} p-3`}>
+          <p className={cx.label}>Redaction report</p>
+          <div className="mt-2 space-y-2">
+            {preset.redactionReport.map((entry) => (
+              <div key={entry.field} className="text-xs">
+                <div className="flex items-center gap-2">
+                  <ShieldCheckIcon className="size-3.5 text-emerald-600" />
+                  <span className={cx.mono}>{entry.field}</span>
+                </div>
+                <p className={`ml-5 mt-0.5 truncate ${cx.mono} text-muted-foreground`}>example: {entry.example}</p>
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      {started && (
+        <div className={`${cx.panelInset} p-3`}>
+          <div className="grid grid-cols-5 gap-2">
+            {STEP_IDS.map((id) => {
+              const progress = demo.state.progress.get(id);
+              return (
+                <div key={id} className="text-center">
+                  <div className={`mx-auto flex size-7 items-center justify-center rounded-full text-xs font-semibold ${
+                    progress?.status === "done"
+                      ? "bg-emerald-500/15 text-emerald-700 dark:text-emerald-300"
+                      : progress?.status === "running"
+                        ? "bg-[#7c6cff]/15 text-[#5b4fd6] dark:text-[#b4acff]"
+                        : "bg-foreground/[0.05] text-muted-foreground"
+                  }`}>
+                    {progress?.status === "done" ? <CheckCircleIcon className="size-4" /> : STEP_IDS.indexOf(id) + 1}
+                  </div>
+                  <p className="mt-1 text-[10px] capitalize text-muted-foreground">{id}</p>
+                </div>
+              );
+            })}
+          </div>
+        </div>
+      )}
+
+      {demo.state.finished ? (
+        <div className="space-y-3">
+          <div className="rounded-md border border-emerald-500/25 bg-emerald-500/[0.07] px-3 py-2.5 text-xs leading-5 text-emerald-950 dark:text-emerald-100">
+            Safe copy ready — sensitive values were replaced and the sample passed verification.
+          </div>
+          <div className={`${cx.panelInset} p-3`}>
+            <p className={cx.label}>Connection string</p>
+            <code className={`mt-1 block overflow-x-auto ${cx.mono}`}>postgres://safe_copy:••••@clone-5gb.db.hexclave.dev/acme</code>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            <DesignButton size="sm" onClick={() => setAttachment("pr")}><CopyIcon className="mr-1.5 size-4" />Attach to PR</DesignButton>
+            <DesignButton size="sm" variant="secondary" onClick={() => setAttachment("dev")}><DatabaseIcon className="mr-1.5 size-4" />Attach to dev environment</DesignButton>
+          </div>
+          {attachment != null && <p className="text-xs text-emerald-700 dark:text-emerald-300">Attached to {attachment === "pr" ? "pricing PR #184" : "Maya’s development environment"} ✓</p>}
+        </div>
+      ) : (
+        <DesignButton onClick={start} loading={started && demo.state.progress.size > 0} loadingStyle="disabled">
+          <ShieldCheckIcon className="mr-2 size-4" />
+          Make Me a Safe Copy
+        </DesignButton>
+      )}
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/closing-briefing.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/closing-briefing.tsx
@@ -1,0 +1,52 @@
+import { DesignBadge, DesignCard } from "@/components/design-components";
+import { CheckCircleIcon, NewspaperClippingIcon, ShieldCheckIcon, TimerIcon } from "@phosphor-icons/react";
+import type { ContinuumIncidentStory } from "../fixtures/types";
+
+export function ClosingBriefing({ closingCard }: { closingCard: ContinuumIncidentStory["closingCard"] }) {
+  return (
+    <DesignCard
+      title="Daily Briefing"
+      subtitle={closingCard.title}
+      icon={NewspaperClippingIcon}
+      gradient="green"
+      actions={<DesignBadge label="Incident closed" color="green" icon={CheckCircleIcon} size="sm" />}
+    >
+      <div className="grid gap-3 md:grid-cols-[minmax(0,1fr)_minmax(14rem,0.45fr)_minmax(14rem,0.45fr)]">
+        <ul className="space-y-2 rounded-xl bg-foreground/[0.035] p-4">
+          {closingCard.bullets.map((bullet) => (
+            <li key={bullet} className="flex items-start gap-2 text-sm text-foreground">
+              <CheckCircleIcon className="mt-0.5 h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" weight="fill" />
+              <span>{bullet}</span>
+            </li>
+          ))}
+        </ul>
+        <div className="flex flex-col justify-between rounded-xl bg-cyan-500/[0.07] p-4 ring-1 ring-cyan-500/15">
+          <TimerIcon className="h-5 w-5 text-cyan-600 dark:text-cyan-400" />
+          <div className="mt-5">
+            <div className="font-mono text-3xl font-semibold tabular-nums text-foreground">
+              {closingCard.avoidedDowntimeMinutes}
+            </div>
+            <div className="mt-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              minutes of downtime avoided
+            </div>
+          </div>
+        </div>
+        <div className="flex flex-col justify-between rounded-xl bg-emerald-500/[0.07] p-4 ring-1 ring-emerald-500/15">
+          <ShieldCheckIcon className="h-5 w-5 text-emerald-600 dark:text-emerald-400" />
+          <div className="mt-5">
+            <div className="font-mono text-3xl font-semibold tabular-nums text-foreground">
+              {closingCard.protectedArrUsd.toLocaleString(undefined, {
+                style: "currency",
+                currency: "USD",
+                maximumFractionDigits: 0,
+              })}
+            </div>
+            <div className="mt-1 text-xs font-semibold uppercase tracking-wider text-muted-foreground">
+              annual revenue protected
+            </div>
+          </div>
+        </div>
+      </div>
+    </DesignCard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/compat-matrix.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/compat-matrix.tsx
@@ -1,0 +1,82 @@
+"use client";
+
+import { COMPAT_MATRIX, DEFERRED_CLEANUP_CAPTION } from "../fixtures/databases";
+import type { CompatVerdict } from "../fixtures/types";
+import { CxChip, CxPanel, StatusDot, cx } from "./ui-kit";
+
+const verdictTone = new Map<CompatVerdict, { label: string, className: string }>([
+  ["green", { label: "ok", className: "bg-[#42946e]/15 text-[#2f6b4f] dark:text-[#7dcea8]" }],
+  ["amber", { label: "careful", className: "bg-amber-500/15 text-amber-800 dark:text-amber-200" }],
+  ["red", { label: "no", className: "bg-red-500/15 text-red-700 dark:text-red-300" }],
+]);
+
+function getCell(rowIndex: number, columnIndex: number): CompatVerdict {
+  return COMPAT_MATRIX.cells[rowIndex][columnIndex];
+}
+
+export function CompatMatrix() {
+  const activeVersions = new Set([
+    COMPAT_MATRIX.activeWindow.from,
+    COMPAT_MATRIX.activeWindow.to,
+  ]);
+
+  return (
+    <CxPanel
+      title="Compatibility"
+      meta={<CxChip tone="ok">Safe to undo</CxChip>}
+      bodyClassName="space-y-4 p-4"
+    >
+      <p className="text-sm leading-6 text-muted-foreground">{COMPAT_MATRIX.headline}</p>
+
+      <div className="overflow-x-auto">
+        <div
+          className="grid min-w-[32rem] gap-1.5"
+          style={{
+            gridTemplateColumns: `7.5rem repeat(${COMPAT_MATRIX.schemaStates.length}, minmax(6.5rem, 1fr))`,
+          }}
+        >
+          <div />
+          {COMPAT_MATRIX.schemaStates.map((schemaState) => (
+            <div key={schemaState} className="px-2 pb-1 text-center text-[11px] text-muted-foreground">
+              {schemaState}
+            </div>
+          ))}
+
+          {COMPAT_MATRIX.versions.map((version, rowIndex) => {
+            const isActive = activeVersions.has(version);
+            return (
+              <div key={version} className="contents">
+                <div className="flex items-center gap-2 px-2 py-1.5">
+                  <span className={cx.mono}>{version}</span>
+                  {isActive && <StatusDot status="info" />}
+                </div>
+                {COMPAT_MATRIX.schemaStates.map((schemaState, columnIndex) => {
+                  const verdict = getCell(rowIndex, columnIndex);
+                  const tone = verdictTone.get(verdict);
+                  if (tone == null) throw new Error(`Unknown verdict "${verdict}"`);
+                  return (
+                    <div
+                      key={`${version}-${schemaState}`}
+                      className={[
+                        "flex min-h-9 items-center justify-center rounded-md text-[11px] font-medium",
+                        tone.className,
+                        isActive ? "ring-1 ring-[#7c6cff]/40" : "",
+                      ].join(" ")}
+                    >
+                      {tone.label}
+                    </div>
+                  );
+                })}
+              </div>
+            );
+          })}
+        </div>
+      </div>
+
+      <p className={cx.muted}>Green means these versions can share your database.</p>
+      <div className="rounded-md border border-amber-500/20 bg-amber-500/[0.06] px-3 py-2.5 text-xs leading-5 text-amber-950 dark:text-amber-100">
+        {DEFERRED_CLEANUP_CAPTION}
+      </div>
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/continuum-map.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/continuum-map.tsx
@@ -1,0 +1,357 @@
+"use client";
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger,
+} from "@/components/ui/dropdown-menu";
+import {
+  CaretDownIcon,
+  CloudIcon,
+  DatabaseIcon,
+  HardDrivesIcon,
+  RocketLaunchIcon,
+  UsersIcon,
+} from "@phosphor-icons/react";
+import { useEffect, useMemo, useRef, useState } from "react";
+import {
+  CANVAS_BRANCHES,
+  MAP_EDGES,
+  MAP_NODES,
+  NODE_SIZE,
+  VIEWBOX,
+} from "../fixtures/topology";
+import type { ContinuumMapNode } from "../fixtures/types";
+import { StatusDot, cellStateToCxStatus, type CxStatus } from "./ui-kit";
+
+type ContinuumMapProps = {
+  nodeHealthOverrides?: Map<string, string>,
+  edgeHealthOverrides?: Map<string, string>,
+  selectedNodeId?: string | null,
+  onSelectNode?: (nodeId: string) => void,
+  branchId?: string,
+  onBranchChange?: (branchId: string) => void,
+};
+
+const nodeById = new Map(MAP_NODES.map((node) => [node.id, node]));
+
+function healthToStatus(health: string): CxStatus {
+  switch (health) {
+    case "critical": {
+      return "bad";
+    }
+    case "degraded": {
+      return "warn";
+    }
+    case "protected": {
+      return "info";
+    }
+    case "pinned": {
+      return "pinned";
+    }
+    case "healthy": {
+      return "ok";
+    }
+    default: {
+      return cellStateToCxStatus(health);
+    }
+  }
+}
+
+function edgeStroke(health: string): string {
+  switch (health) {
+    case "critical": {
+      return "#ef4444";
+    }
+    case "degraded": {
+      return "#f59e0b";
+    }
+    case "active": {
+      return "#a78bfa";
+    }
+    default: {
+      return "rgba(255,255,255,0.18)";
+    }
+  }
+}
+
+function kindIcon(kind: ContinuumMapNode["kind"]) {
+  switch (kind) {
+    case "customer": {
+      return UsersIcon;
+    }
+    case "cell": {
+      return HardDrivesIcon;
+    }
+    case "release": {
+      return RocketLaunchIcon;
+    }
+    case "database": {
+      return DatabaseIcon;
+    }
+    case "provider":
+    case "region": {
+      return CloudIcon;
+    }
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
+  }
+}
+
+function kindAccent(kind: ContinuumMapNode["kind"]): string {
+  switch (kind) {
+    case "customer": {
+      return "border-l-[#38bdf8]";
+    }
+    case "cell": {
+      return "border-l-[#34d399]";
+    }
+    case "release": {
+      return "border-l-[#a78bfa]";
+    }
+    case "database": {
+      return "border-l-[#fbbf24]";
+    }
+    case "provider":
+    case "region": {
+      return "border-l-[#94a3b8]";
+    }
+    default: {
+      const exhaustive: never = kind;
+      return exhaustive;
+    }
+  }
+}
+
+function usePrefersReducedMotion(): boolean {
+  const [reduced, setReduced] = useState(false);
+  useEffect(() => {
+    const mq = window.matchMedia("(prefers-reduced-motion: reduce)");
+    const update = () => setReduced(mq.matches);
+    update();
+    mq.addEventListener("change", update);
+    return () => mq.removeEventListener("change", update);
+  }, []);
+  return reduced;
+}
+
+/** Orthogonal-ish bezier between block centers (Railway/n8n feel). */
+function edgePath(sx: number, sy: number, tx: number, ty: number): string {
+  const dy = Math.abs(ty - sy);
+  const midY = (sy + ty) / 2;
+  if (dy < 40) {
+    const midX = (sx + tx) / 2;
+    return `M ${sx} ${sy} C ${midX} ${sy}, ${midX} ${ty}, ${tx} ${ty}`;
+  }
+  return `M ${sx} ${sy} C ${sx} ${midY}, ${tx} ${midY}, ${tx} ${ty}`;
+}
+
+export function ContinuumMap({
+  nodeHealthOverrides,
+  edgeHealthOverrides,
+  selectedNodeId,
+  onSelectNode,
+  branchId: branchIdProp,
+  onBranchChange,
+}: ContinuumMapProps) {
+  const reducedMotion = usePrefersReducedMotion();
+  const scrollerRef = useRef<HTMLDivElement>(null);
+  const [internalBranchId, setInternalBranchId] = useState<string>(CANVAS_BRANCHES[0].id);
+  const branchId = branchIdProp ?? internalBranchId;
+  const resolveBranchChange = onBranchChange ?? setInternalBranchId;
+  const branch = CANVAS_BRANCHES.find((b) => b.id === branchId) ?? CANVAS_BRANCHES[0];
+
+  const selectedNode = useMemo(
+    () => MAP_NODES.find((n) => n.id === selectedNodeId) ?? null,
+    [selectedNodeId],
+  );
+
+  return (
+    <div className="relative flex min-h-[70vh] flex-1 flex-col overflow-hidden rounded-lg border border-black/[0.08] bg-[#0b0b0f] dark:border-white/[0.08]">
+      {/* Canvas chrome: breadcrumb + branch switcher */}
+      <div className="z-20 flex items-center justify-between gap-3 border-b border-white/[0.06] bg-[#0f0e14]/95 px-3 py-2 backdrop-blur-md">
+        <nav className="flex min-w-0 items-center gap-1.5 text-[12px]" aria-label="Canvas breadcrumb">
+          <span className="text-[#6b7280]">Continuum</span>
+          <span className="text-[#3f3f46]">/</span>
+          <span className="text-[#a1a0ab]">Canvas</span>
+          <span className="text-[#3f3f46]">/</span>
+          <DropdownMenu>
+            <DropdownMenuTrigger asChild>
+              <button
+                type="button"
+                className="inline-flex items-center gap-1 rounded px-1.5 py-0.5 font-mono text-[12px] text-[#f7f7f8] transition-colors duration-150 hover:bg-white/[0.06] hover:transition-none"
+              >
+                {branch.label}
+                <CaretDownIcon className="size-3 text-[#6b7280]" />
+              </button>
+            </DropdownMenuTrigger>
+            <DropdownMenuContent align="start" className="min-w-[12rem]">
+              {CANVAS_BRANCHES.map((option) => (
+                <DropdownMenuItem
+                  key={option.id}
+                  onClick={() => resolveBranchChange(option.id)}
+                  className="font-mono text-xs"
+                >
+                  {option.label}
+                  {option.id === branchId ? " ·" : ""}
+                </DropdownMenuItem>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          {selectedNode != null && (
+            <>
+              <span className="text-[#3f3f46]">/</span>
+              <span className="truncate text-[#f7f7f8]">{selectedNode.label}</span>
+            </>
+          )}
+        </nav>
+        <span className="shrink-0 font-mono text-[10px] tabular-nums text-[#6b7280]">
+          {MAP_NODES.length} services · {MAP_EDGES.length} links
+        </span>
+      </div>
+
+      <div ref={scrollerRef} className="relative min-h-0 flex-1 overflow-auto">
+        <div
+          className="relative"
+          style={{ width: VIEWBOX.width, height: VIEWBOX.height, minWidth: "100%" }}
+        >
+          {/* Dot grid */}
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            style={{
+              backgroundImage: "radial-gradient(rgba(255,255,255,0.07) 1px, transparent 1px)",
+              backgroundSize: "20px 20px",
+            }}
+          />
+          <div
+            aria-hidden
+            className="pointer-events-none absolute inset-0"
+            style={{
+              background:
+                "radial-gradient(ellipse 55% 40% at 50% 35%, rgba(85,63,131,0.22), transparent 70%)",
+            }}
+          />
+
+          {/* Edges */}
+          <svg
+            className="pointer-events-none absolute inset-0"
+            width={VIEWBOX.width}
+            height={VIEWBOX.height}
+            viewBox={`0 0 ${VIEWBOX.width} ${VIEWBOX.height}`}
+          >
+            {MAP_EDGES.map((edge, index) => {
+              const source = nodeById.get(edge.source);
+              const target = nodeById.get(edge.target);
+              if (source == null || target == null) {
+                throw new Error(`Edge "${edge.id}" references unknown node.`);
+              }
+              const health = edgeHealthOverrides?.get(edge.id) ?? edge.health;
+              const active = health === "active" || health === "critical" || health === "degraded";
+              // Connect bottom of source to top of target
+              const sx = source.x;
+              const sy = source.y + NODE_SIZE.height / 2 - 4;
+              const tx = target.x;
+              const ty = target.y - NODE_SIZE.height / 2 + 4;
+              const d = edgePath(sx, sy, tx, ty);
+              return (
+                <g key={edge.id}>
+                  <path
+                    d={d}
+                    fill="none"
+                    stroke={edgeStroke(health)}
+                    strokeWidth={active ? 2 : 1.25}
+                    strokeLinecap="round"
+                    style={
+                      reducedMotion || edge.kind === "traffic"
+                        ? undefined
+                        : { animation: `cx-flow 1.4s linear ${index * -0.1}s infinite`, strokeDasharray: "5 7" }
+                    }
+                    strokeDasharray={edge.kind === "failover" ? "4 6" : undefined}
+                  />
+                  {/* Port dots */}
+                  <circle cx={sx} cy={sy} r="3" fill="#1c1a28" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+                  <circle cx={tx} cy={ty} r="3" fill="#1c1a28" stroke="rgba(255,255,255,0.25)" strokeWidth="1" />
+                  {edge.label != null && (
+                    <text
+                      x={(sx + tx) / 2}
+                      y={(sy + ty) / 2 - 6}
+                      textAnchor="middle"
+                      fill="#6b7280"
+                      fontSize="9"
+                      fontFamily="ui-monospace, monospace"
+                    >
+                      {edge.label}
+                    </text>
+                  )}
+                </g>
+              );
+            })}
+          </svg>
+
+          {/* HTML service blocks */}
+          {MAP_NODES.map((node) => {
+            const health = nodeHealthOverrides?.get(node.id) ?? node.health;
+            const status = healthToStatus(health);
+            const selected = selectedNodeId === node.id;
+            const Icon = kindIcon(node.kind);
+            const left = node.x - NODE_SIZE.width / 2;
+            const top = node.y - NODE_SIZE.height / 2;
+
+            return (
+              <button
+                key={node.id}
+                type="button"
+                onClick={() => onSelectNode?.(node.id)}
+                aria-pressed={selected}
+                className={[
+                  "absolute flex flex-col justify-between rounded-lg border border-l-[3px] px-3 py-2.5 text-left shadow-[0_12px_40px_rgba(0,0,0,0.45)] outline-none transition-[border-color,box-shadow,transform] duration-150 hover:transition-none",
+                  kindAccent(node.kind),
+                  selected
+                    ? "z-10 border-white/25 bg-[#252233] ring-2 ring-[#7c6cff]/50"
+                    : "border-white/[0.08] bg-[#1c1a28] hover:border-white/20 hover:bg-[#221f30]",
+                  "focus-visible:ring-2 focus-visible:ring-[#7c6cff]/60",
+                ].join(" ")}
+                style={{
+                  left,
+                  top,
+                  width: NODE_SIZE.width,
+                  height: NODE_SIZE.height,
+                }}
+              >
+                <div className="flex items-center gap-2">
+                  <span className="flex size-6 shrink-0 items-center justify-center rounded-md bg-white/[0.04] text-[#a1a0ab]">
+                    <Icon className="size-3.5" weight="duotone" />
+                  </span>
+                  <span className="min-w-0 flex-1 truncate text-[12px] font-medium tracking-tight text-[#f7f7f8]">
+                    {node.label}
+                  </span>
+                  <StatusDot status={status} />
+                </div>
+                <div className="flex items-center justify-between gap-2 pl-8">
+                  <span className="text-[9px] uppercase tracking-[0.14em] text-[#6b7280]">
+                    {node.kind === "provider" ? "cloud" : node.kind}
+                  </span>
+                  {node.subtitle != null && (
+                    <span className="truncate font-mono text-[10px] tabular-nums text-[#a1a0ab]">
+                      {node.subtitle}
+                    </span>
+                  )}
+                </div>
+              </button>
+            );
+          })}
+        </div>
+      </div>
+
+      <style>{`
+        @keyframes cx-flow {
+          to { stroke-dashoffset: -24; }
+        }
+      `}</style>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/copilot-rail.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/copilot-rail.tsx
@@ -1,0 +1,54 @@
+"use client";
+
+import { DesignBadge } from "@/components/design-components";
+import { RobotIcon, SparkleIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import { DATABASES_COPILOT_HINTS } from "../fixtures/copilot-script";
+
+const RESPONSES = [
+  "I’ll use the 5 GB sample, keep whole organizations together, and replace sensitive values with realistic fakes.",
+  "The cleanup only removes legacy_role after every active version has moved forward. It is waiting safely right now.",
+  "The current write path would affect 37 organizations. I recommend a compatibility release and backfill first.",
+] as const;
+
+export function CopilotRail() {
+  const [selectedHint, setSelectedHint] = useState(0);
+
+  return (
+    <aside className="flex h-full min-h-0 flex-col">
+      <div className="border-b border-border/60 px-4 py-4">
+        <div className="flex items-center gap-2">
+          <RobotIcon className="h-4 w-4" />
+          <p className="text-xs font-semibold uppercase tracking-wider">Database copilot</p>
+          <DesignBadge label="Ready" color="green" size="sm" />
+        </div>
+        <p className="mt-1 text-xs text-muted-foreground">Understands branches, data shape, and release safety.</p>
+      </div>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto p-4">
+        <div className="rounded-xl bg-primary/[0.06] p-3 text-xs leading-5 ring-1 ring-primary/10">
+          <div className="mb-1 flex items-center gap-1.5 font-medium"><SparkleIcon className="h-3.5 w-3.5" />Copilot</div>
+          {RESPONSES[selectedHint]}
+        </div>
+        <div>
+          <p className="mb-2 text-[11px] font-semibold uppercase tracking-wider text-muted-foreground">Try asking</p>
+          <div className="space-y-2">
+            {DATABASES_COPILOT_HINTS.map((hint, index) => (
+              <button
+                key={hint}
+                type="button"
+                onClick={() => setSelectedHint(index)}
+                className={`w-full rounded-xl px-3 py-2.5 text-left text-xs leading-5 ring-1 transition-colors duration-150 hover:transition-none focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40 ${
+                  selectedHint === index
+                    ? "bg-primary/[0.07] ring-primary/20"
+                    : "bg-foreground/[0.02] ring-border/60 hover:bg-foreground/[0.05]"
+                }`}
+              >
+                {hint}
+              </button>
+            ))}
+          </div>
+        </div>
+      </div>
+    </aside>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/database-workspace.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/database-workspace.tsx
@@ -1,0 +1,244 @@
+"use client";
+
+import { DesignButton } from "@/components/design-components";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
+import { ArrowsClockwiseIcon, DatabaseIcon } from "@phosphor-icons/react";
+import { useState } from "react";
+import {
+  DB_PITR,
+  DB_REPLICAS,
+  DEFERRED_CLEANUP_CAPTION,
+  MIGRATIONS,
+} from "../fixtures/databases";
+import type { DbReplica, DbReplicaRole } from "../fixtures/types";
+import { BlastRadiusPanel } from "./blast-radius-panel";
+import { BranchTree } from "./branch-tree";
+import { CloneWizard } from "./clone-wizard";
+import { CompatMatrix } from "./compat-matrix";
+import { CopilotRail } from "./copilot-rail";
+import { QueryInsights } from "./query-insights";
+import { SchemaBrowser } from "./schema-browser";
+import { CxChip, CxPanel, StatusDot, cx } from "./ui-kit";
+
+const ROLE_LABELS: Record<DbReplicaRole, string> = {
+  "primary": "Primary",
+  "sync-replica": "Sync replica",
+  "async-replica": "Async replica",
+  "standby": "Cross-cloud standby",
+};
+
+type DatabaseWorkspaceProps = {
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+};
+
+export function DatabaseWorkspace({ open, onOpenChange }: DatabaseWorkspaceProps) {
+  const [selectedBranchId, setSelectedBranchId] = useState("db-prod");
+  // Mock-only: "promoting" briefly animates the standby taking over, then settles back.
+  const [promotedReplicaId, setPromotedReplicaId] = useState<string | null>(null);
+
+  return (
+    <Sheet open={open} onOpenChange={onOpenChange}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-3xl" hasCloseButton>
+        <SheetHeader className={`space-y-1 border-b px-5 py-4 text-left ${cx.hairline}`}>
+          <div className="flex items-center gap-2">
+            <DatabaseIcon className="size-4" />
+            <SheetTitle className="text-base">Production DB</SheetTitle>
+            <CxChip tone="ok">both versions ok</CxChip>
+            <CxChip>2 TB</CxChip>
+          </div>
+          <SheetDescription className="text-xs">
+            Replication, branches, safe copies, and change safety — everything for this database.
+          </SheetDescription>
+        </SheetHeader>
+
+        <Tabs defaultValue="replication" className="flex min-h-0 flex-1 flex-col">
+          <div className={`shrink-0 border-b px-4 py-2 ${cx.hairline}`}>
+            <TabsList className="h-8 flex-wrap">
+              <TabsTrigger value="replication" className="text-xs">Replication</TabsTrigger>
+              <TabsTrigger value="branches" className="text-xs">Branches</TabsTrigger>
+              <TabsTrigger value="compat" className="text-xs">Compatibility</TabsTrigger>
+              <TabsTrigger value="copies" className="text-xs">Safe copies</TabsTrigger>
+              <TabsTrigger value="schema" className="text-xs">Schema</TabsTrigger>
+              <TabsTrigger value="queries" className="text-xs">Queries</TabsTrigger>
+              <TabsTrigger value="copilot" className="text-xs">Copilot</TabsTrigger>
+            </TabsList>
+          </div>
+
+          <div className="min-h-0 flex-1 overflow-y-auto p-4">
+            <TabsContent value="replication" className="mt-0 space-y-3">
+              <ReplicationPanel
+                promotedReplicaId={promotedReplicaId}
+                onPromote={async (replicaId) => {
+                  setPromotedReplicaId(replicaId);
+                  await new Promise((resolve) => setTimeout(resolve, 900));
+                  setPromotedReplicaId(null);
+                }}
+              />
+              <PitrPanel />
+            </TabsContent>
+
+            <TabsContent value="branches" className="mt-0">
+              <CxPanel title="Database branches" bodyClassName="min-h-0">
+                <BranchTree selectedId={selectedBranchId} onSelect={setSelectedBranchId} />
+              </CxPanel>
+            </TabsContent>
+
+            <TabsContent value="compat" className="mt-0 space-y-3">
+              <CompatMatrix />
+              <MigrationSplitPanel />
+              <BlastRadiusPanel />
+            </TabsContent>
+
+            <TabsContent value="copies" className="mt-0">
+              <CloneWizard />
+            </TabsContent>
+
+            <TabsContent value="schema" className="mt-0">
+              <SchemaBrowser />
+            </TabsContent>
+
+            <TabsContent value="queries" className="mt-0">
+              <QueryInsights />
+            </TabsContent>
+
+            <TabsContent value="copilot" className="mt-0">
+              <CxPanel title="Database copilot" bodyClassName="min-h-[24rem]">
+                <CopilotRail />
+              </CxPanel>
+            </TabsContent>
+          </div>
+        </Tabs>
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function ReplicationPanel({
+  promotedReplicaId,
+  onPromote,
+}: {
+  promotedReplicaId: string | null,
+  onPromote: (replicaId: string) => Promise<void>,
+}) {
+  return (
+    <CxPanel
+      title="Replication"
+      meta={<CxChip tone="ok">{DB_REPLICAS.length - 1} replicas live</CxChip>}
+      bodyClassName="divide-y divide-black/[0.05] dark:divide-white/[0.05]"
+    >
+      {DB_REPLICAS.map((replica) => (
+        <ReplicaRow
+          key={replica.id}
+          replica={replica}
+          promoting={promotedReplicaId === replica.id}
+          onPromote={() => onPromote(replica.id)}
+        />
+      ))}
+    </CxPanel>
+  );
+}
+
+function ReplicaRow({
+  replica,
+  promoting,
+  onPromote,
+}: {
+  replica: DbReplica,
+  promoting: boolean,
+  onPromote: () => Promise<void>,
+}) {
+  return (
+    <div className="flex items-center gap-3 px-4 py-3">
+      <StatusDot status={replica.state === "live" ? "ok" : replica.state === "catching-up" ? "warn" : "idle"} />
+      <div className="min-w-0 flex-1">
+        <div className="flex items-center gap-2">
+          <p className="text-[13px] font-medium">{ROLE_LABELS[replica.role]}</p>
+          <CxChip>{replica.provider} {replica.region}</CxChip>
+        </div>
+        <p className={`mt-0.5 ${cx.mono} text-muted-foreground`}>
+          {replica.role === "primary" ? "accepting writes" : `lag ${replica.lagMs}ms · ${replica.state}`}
+        </p>
+      </div>
+      {replica.promotable && (
+        <DesignButton size="sm" variant="outline" loading={promoting} loadingStyle="disabled" onClick={onPromote}>
+          <ArrowsClockwiseIcon className="mr-1.5 size-3.5" />
+          Promote
+        </DesignButton>
+      )}
+    </div>
+  );
+}
+
+function PitrPanel() {
+  const oldestRestore = new Date(DB_PITR.oldestRestorePoint);
+  const lastSnapshot = new Date(DB_PITR.lastSnapshotAt);
+
+  return (
+    <CxPanel
+      title="Point-in-time recovery"
+      meta={<CxChip tone="ok">{DB_PITR.retentionDays}-day window</CxChip>}
+      bodyClassName="space-y-2 p-4"
+    >
+      <PitrRow label="Oldest restore point" value={oldestRestore.toLocaleString()} />
+      <PitrRow label="Last snapshot" value={lastSnapshot.toLocaleString()} />
+      <PitrRow label="WAL archive lag" value={`${DB_PITR.walArchiveLagSeconds}s`} />
+      <p className={cx.muted}>
+        Restore any second in the last {DB_PITR.retentionDays} days to a new branch — production stays untouched.
+      </p>
+    </CxPanel>
+  );
+}
+
+function PitrRow({ label, value }: { label: string, value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-black/[0.05] pb-2 last:border-0 dark:border-white/[0.05]">
+      <span className="text-[12px] text-muted-foreground">{label}</span>
+      <span className={`${cx.mono} text-foreground`}>{value}</span>
+    </div>
+  );
+}
+
+function MigrationSplitPanel() {
+  const migration = MIGRATIONS[0];
+
+  return (
+    <CxPanel title="How this change was split" bodyClassName="space-y-3 p-4">
+      <p className="text-sm leading-6 text-muted-foreground">{DEFERRED_CLEANUP_CAPTION}</p>
+      <div className="grid gap-2 md:grid-cols-2">
+        <div className="space-y-2 rounded-md border border-[#42946e]/25 bg-[#42946e]/[0.06] p-3">
+          <div className="flex items-center gap-2">
+            <StatusDot status="ok" />
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em]">Applied now</p>
+          </div>
+          {migration.steps.filter((step) => step.kind === "expand").map((step) => (
+            <div key={step.id} className="rounded-md bg-background/70 px-3 py-2">
+              <p className="text-xs font-medium">{step.plainLabel}</p>
+              <pre className="mt-1 overflow-x-auto font-mono text-[10px] text-muted-foreground">{step.sql}</pre>
+            </div>
+          ))}
+        </div>
+        <div className="space-y-2 rounded-md border border-amber-500/25 bg-amber-500/[0.06] p-3">
+          <div className="flex items-center gap-2">
+            <StatusDot status="warn" />
+            <p className="text-[11px] font-medium uppercase tracking-[0.12em]">Waiting safely</p>
+          </div>
+          {migration.steps.filter((step) => step.kind === "contract").map((step) => (
+            <div key={step.id} className="rounded-md bg-background/70 px-3 py-2">
+              <p className="text-xs font-medium">{step.plainLabel}</p>
+              <p className="mt-1 text-[11px] text-muted-foreground">{step.heldBy}</p>
+              <pre className="mt-1 overflow-x-auto font-mono text-[10px] text-muted-foreground">{step.sql}</pre>
+            </div>
+          ))}
+        </div>
+      </div>
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/forensic-clone-lab.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/forensic-clone-lab.tsx
@@ -1,0 +1,217 @@
+"use client";
+
+import {
+  DesignAlert,
+  DesignBadge,
+  DesignButton,
+  DesignCard,
+  DesignDialog,
+  DesignDialogClose,
+} from "@/components/design-components";
+import {
+  CheckCircleIcon,
+  ClockCountdownIcon,
+  DatabaseIcon,
+  FlaskIcon,
+  LinkIcon,
+  LockKeyIcon,
+  RobotIcon,
+} from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect } from "react";
+import { CLONE_PRESETS } from "../fixtures/databases";
+import { FORENSIC_COPILOT_SCRIPT } from "../fixtures/copilot-script";
+import { useDemoScript, type ScriptStep } from "../use-demo-scripts";
+
+const constructionScript: ScriptStep[] = [
+  { kind: "progress", id: "snapshot", label: "Snapshot production branch", status: "running" },
+  { kind: "wait", ms: 220 },
+  { kind: "progress", id: "snapshot", label: "Snapshot production branch", status: "done" },
+  { kind: "progress", id: "sample", label: "Keep representative tenant data", status: "running" },
+  { kind: "wait", ms: 220 },
+  { kind: "progress", id: "sample", label: "Keep representative tenant data", status: "done" },
+  { kind: "progress", id: "redact", label: "Replace sensitive values", status: "running" },
+  { kind: "wait", ms: 260 },
+  { kind: "progress", id: "redact", label: "Replace sensitive values", status: "done" },
+  { kind: "progress", id: "verify", label: "Verify links between records", status: "running" },
+  { kind: "wait", ms: 220 },
+  { kind: "progress", id: "verify", label: "Verify links between records", status: "done" },
+  { kind: "line", text: "Forensic clone ready", level: "success" },
+];
+
+const constructionStepIds = ["snapshot", "sample", "redact", "verify"] as const;
+
+function getForensicPreset() {
+  const preset = CLONE_PRESETS.find((candidate) => candidate.id === "clone-5gb");
+  if (preset == null) throw new Error("The 5 GB forensic clone preset is required for Incident Command.");
+  return preset;
+}
+
+function getApprovalRequest() {
+  const turn = FORENSIC_COPILOT_SCRIPT.find((candidate) => candidate.approval != null);
+  if (turn?.approval == null) throw new Error("The forensic copilot script must include an approval request.");
+  return { turn, approval: turn.approval };
+}
+
+const forensicPreset = getForensicPreset();
+const approvalRequest = getApprovalRequest();
+
+export function ForensicCloneLab({
+  open,
+  onOpenChange,
+  cloneReady,
+  waitingOnApproval,
+  approved,
+  onApprove,
+}: {
+  open: boolean,
+  onOpenChange: (open: boolean) => void,
+  cloneReady: boolean,
+  waitingOnApproval: boolean,
+  approved: boolean,
+  onApprove: () => void,
+}) {
+  const shouldReduceMotion = useReducedMotion();
+  const { state, reset } = useDemoScript(constructionScript, cloneReady);
+
+  useEffect(() => {
+    if (!cloneReady) reset();
+  }, [cloneReady, reset]);
+
+  const visibleTurns = approved
+    ? FORENSIC_COPILOT_SCRIPT
+    : FORENSIC_COPILOT_SCRIPT.slice(0, FORENSIC_COPILOT_SCRIPT.indexOf(approvalRequest.turn) + 1);
+
+  return (
+    <DesignDialog
+      open={open}
+      onOpenChange={onOpenChange}
+      size="4xl"
+      icon={FlaskIcon}
+      title="Forensic Clone Lab"
+      description="A sanitized copy for reproducing the customer issue without touching production."
+      footer={(
+        <DesignDialogClose asChild>
+          <DesignButton variant="secondary">Close lab</DesignButton>
+        </DesignDialogClose>
+      )}
+    >
+      <div className="grid gap-4 lg:grid-cols-[minmax(0,0.9fr)_minmax(0,1.1fr)]">
+        <div className="space-y-4">
+          <DesignCard
+            title="Construction timeline"
+            icon={DatabaseIcon}
+            gradient="cyan"
+            actions={<DesignBadge label={state.finished ? "Ready" : "Building"} color={state.finished ? "green" : "cyan"} size="sm" />}
+          >
+            <div className="space-y-2">
+              {constructionStepIds.map((stepId) => {
+                const progress = state.progress.get(stepId);
+                const done = progress?.status === "done";
+                return (
+                  <div key={stepId} className="flex items-center gap-2 rounded-xl bg-foreground/[0.035] px-3 py-2">
+                    <CheckCircleIcon
+                      className={done ? "h-4 w-4 text-emerald-600 dark:text-emerald-400" : "h-4 w-4 text-muted-foreground"}
+                      weight={done ? "fill" : "regular"}
+                    />
+                    <span className="text-xs text-foreground">{progress?.label ?? "Waiting…"}</span>
+                  </div>
+                );
+              })}
+            </div>
+          </DesignCard>
+
+          <motion.div
+            initial={false}
+            animate={{
+              opacity: state.progress.get("redact")?.status === "done" ? 1 : 0.45,
+              scale: state.progress.get("redact")?.status === "done" && !shouldReduceMotion ? [0.99, 1.01, 1] : 1,
+            }}
+          >
+            <DesignCard
+              title="Redaction report"
+              subtitle={`${forensicPreset.redactionReport.length} sensitive fields transformed · record links preserved`}
+              icon={LockKeyIcon}
+              gradient="purple"
+            >
+              <div className="flex flex-wrap gap-2">
+                {forensicPreset.redactionReport.map((item) => (
+                  <DesignBadge key={item.field} label={`${item.field} · ${item.kind}`} color="purple" size="sm" />
+                ))}
+              </div>
+            </DesignCard>
+          </motion.div>
+
+          <DesignAlert
+            variant="info"
+            title="Temporary clone URL"
+            description={(
+              <span className="flex flex-wrap items-center gap-2">
+                <LinkIcon className="h-3.5 w-3.5" />
+                <span className="font-mono">atlas-forensics-147.hexclave.app</span>
+                <span className="flex items-center gap-1"><ClockCountdownIcon className="h-3.5 w-3.5" />Expires in 30 minutes</span>
+              </span>
+            )}
+          />
+        </div>
+
+        <DesignCard
+          title="Agent investigation"
+          subtitle="The agent can inspect only this sanitized clone."
+          icon={RobotIcon}
+          gradient={approved ? "green" : "orange"}
+          actions={<DesignBadge label={approved ? "Access approved" : "Approval required"} color={approved ? "green" : "orange"} size="sm" />}
+        >
+          <div className="space-y-2">
+            {visibleTurns.map((turn) => (
+              <div key={turn.id} className="rounded-xl bg-foreground/[0.035] px-3 py-2 ring-1 ring-foreground/[0.05]">
+                <div className="mb-1 text-[10px] font-semibold uppercase tracking-wider text-muted-foreground">
+                  {turn.role === "agent" ? "Devin" : "System"}
+                </div>
+                <p className="text-xs leading-relaxed text-foreground">{turn.text}</p>
+              </div>
+            ))}
+
+            {!approved && (
+              <div className={waitingOnApproval ? "rounded-xl bg-amber-500/[0.08] p-3 ring-2 ring-amber-500/25" : "rounded-xl bg-foreground/[0.035] p-3"}>
+                <div className="flex items-start justify-between gap-3">
+                  <div>
+                    <div className="text-sm font-semibold text-foreground">{approvalRequest.approval.title}</div>
+                    <p className="mt-1 text-xs text-muted-foreground">{approvalRequest.approval.detail}</p>
+                  </div>
+                  <DesignBadge label={`${approvalRequest.approval.expiresInMinutes} min`} color="orange" size="sm" />
+                </div>
+                <DesignButton className="mt-3 w-full" onClick={onApprove} disabled={!waitingOnApproval}>
+                  Approve Agent Access
+                </DesignButton>
+              </div>
+            )}
+
+            <div className="grid grid-cols-3 gap-2 pt-2">
+              <div className="rounded-xl bg-foreground/[0.035] p-3 text-center">
+                <div className="text-[10px] uppercase tracking-wider text-muted-foreground">Repro</div>
+                <div className={approved ? "mt-1 text-xs font-semibold text-emerald-600 dark:text-emerald-400" : "mt-1 text-xs font-semibold text-red-600 dark:text-red-400"}>
+                  {approved ? "Failed → Passed" : "Failed"}
+                </div>
+              </div>
+              <div className="flex items-center justify-center rounded-xl bg-emerald-500/[0.07] p-3">
+                <DesignBadge label="Compat green" color="green" size="sm" />
+              </div>
+              <div className="flex items-center justify-center rounded-xl bg-emerald-500/[0.07] p-3">
+                <DesignBadge label="Regression green" color="green" size="sm" />
+              </div>
+            </div>
+
+            {approved && (
+              <DesignAlert
+                variant="success"
+                title="Fix verified"
+                description="The issue now passes in the clone. Compatibility and regression checks are green."
+              />
+            )}
+          </div>
+        </DesignCard>
+      </div>
+    </DesignDialog>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/incident-scrubber.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/incident-scrubber.tsx
@@ -1,0 +1,103 @@
+"use client";
+
+import { ArrowCounterClockwiseIcon, PauseIcon, PlayIcon } from "@phosphor-icons/react";
+import type { ContinuumIncidentStory } from "../fixtures/types";
+
+/**
+ * Minimal transport bar. Stage markers are unlabeled ticks on the track itself
+ * (labels overlapped badly since acts cluster near the start); the active act
+ * is announced once, next to the time.
+ */
+export function IncidentScrubber({
+  story,
+  elapsedMs,
+  isPlaying,
+  waitingOnGate,
+  activeStageId,
+  formatTime,
+  onElapsedChange,
+  onPlayingChange,
+  onRestart,
+}: {
+  story: ContinuumIncidentStory,
+  elapsedMs: number,
+  isPlaying: boolean,
+  waitingOnGate: boolean,
+  activeStageId: string,
+  formatTime: (elapsedMs: number) => string,
+  onElapsedChange: (elapsedMs: number) => void,
+  onPlayingChange: (isPlaying: boolean) => void,
+  onRestart: () => void,
+}) {
+  const activeStage = story.stages.find((stage) => stage.id === activeStageId);
+  const progressPercent = (elapsedMs / story.durationMs) * 100;
+
+  return (
+    <div className="rounded-lg border border-black/[0.08] px-3 py-2.5 dark:border-white/[0.08]">
+      <div className="flex items-center gap-2.5">
+        <button
+          type="button"
+          aria-label={isPlaying ? "Pause" : "Play"}
+          disabled={waitingOnGate || elapsedMs >= story.durationMs}
+          onClick={() => onPlayingChange(!isPlaying)}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md border border-black/[0.08] text-foreground transition-colors duration-150 hover:bg-black/[0.04] hover:transition-none disabled:opacity-40 dark:border-white/[0.08] dark:hover:bg-white/[0.06]"
+        >
+          {isPlaying ? <PauseIcon className="size-3.5" weight="fill" /> : <PlayIcon className="size-3.5" weight="fill" />}
+        </button>
+        <button
+          type="button"
+          aria-label="Restart"
+          onClick={onRestart}
+          className="flex size-7 shrink-0 items-center justify-center rounded-md text-muted-foreground transition-colors duration-150 hover:bg-black/[0.04] hover:text-foreground hover:transition-none dark:hover:bg-white/[0.06]"
+        >
+          <ArrowCounterClockwiseIcon className="size-3.5" />
+        </button>
+
+        {/* Track with stage ticks baked in */}
+        <div className="relative min-w-0 flex-1">
+          <div className="pointer-events-none absolute inset-y-0 left-0 right-0 flex items-center">
+            <div className="relative h-1 w-full rounded-full bg-black/[0.08] dark:bg-white/[0.1]">
+              <div
+                className={`absolute inset-y-0 left-0 rounded-full ${waitingOnGate ? "bg-amber-500" : "bg-[#7c6cff]"}`}
+                style={{ width: `${progressPercent}%` }}
+              />
+              {story.stages.map((stage) => (
+                <span
+                  key={stage.id}
+                  className={[
+                    "absolute top-1/2 size-[5px] -translate-x-1/2 -translate-y-1/2 rounded-full",
+                    stage.gate != null
+                      ? elapsedMs >= stage.offsetMs ? "bg-amber-500" : "bg-amber-500/50"
+                      : elapsedMs >= stage.offsetMs ? "bg-[#7c6cff]" : "bg-black/20 dark:bg-white/25",
+                  ].join(" ")}
+                  style={{ left: `${(stage.offsetMs / story.durationMs) * 100}%` }}
+                />
+              ))}
+            </div>
+          </div>
+          <input
+            type="range"
+            min={0}
+            max={story.durationMs}
+            step={250}
+            value={elapsedMs}
+            aria-label="Playback position"
+            onChange={(event) => onElapsedChange(event.currentTarget.valueAsNumber)}
+            className="relative z-10 h-7 w-full cursor-pointer appearance-none bg-transparent [&::-webkit-slider-thumb]:size-3 [&::-webkit-slider-thumb]:appearance-none [&::-webkit-slider-thumb]:rounded-full [&::-webkit-slider-thumb]:bg-foreground"
+          />
+        </div>
+
+        <span className="shrink-0 font-mono text-[11px] tabular-nums text-muted-foreground">
+          {formatTime(elapsedMs)} / {formatTime(story.durationMs)}
+        </span>
+      </div>
+
+      {activeStage != null && (
+        <p className="mt-1.5 truncate pl-[4.75rem] text-[11px] text-muted-foreground">
+          Act {activeStage.act} · {activeStage.title}
+          {waitingOnGate ? " — waiting on your decision" : ""}
+        </p>
+      )}
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/node-inspector.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/node-inspector.tsx
@@ -1,0 +1,302 @@
+"use client";
+
+import { DesignButton } from "@/components/design-components";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import {
+  ArrowsClockwiseIcon,
+  CloudIcon,
+  CopyIcon,
+  DatabaseIcon,
+  HardDrivesIcon,
+  PushPinIcon,
+  RocketLaunchIcon,
+  UsersIcon,
+} from "@phosphor-icons/react";
+import { setCellState } from "../continuum-store";
+import { DB_BRANCHES, DB_REPLICAS } from "../fixtures/databases";
+import { RELEASES } from "../fixtures/releases";
+import { cellById, tenantById } from "../fixtures/tenants";
+import type { ContinuumMapNode } from "../fixtures/types";
+import { BuildLogViewer } from "./build-log-viewer";
+import { CxChip, StatusDot, cellStateToCxStatus, cx } from "./ui-kit";
+
+type NodeInspectorProps = {
+  node: ContinuumMapNode | null,
+  onClose: () => void,
+  cellStateOverrides?: Map<string, string>,
+};
+
+function cellIdFromNode(nodeId: string): string | null {
+  if (!nodeId.startsWith("n-cell-")) return null;
+  return nodeId.replace(/^n-/, "");
+}
+
+function customerIdFromNode(nodeId: string): string | null {
+  const map = new Map([
+    ["n-atlas", "t-atlas"],
+    ["n-northstar", "t-northstar"],
+    ["n-lumen", "t-lumen"],
+  ]);
+  return map.get(nodeId) ?? null;
+}
+
+export function NodeInspector({ node, onClose, cellStateOverrides }: NodeInspectorProps) {
+  const open = node != null;
+
+  return (
+    <Sheet open={open} onOpenChange={(next) => { if (!next) onClose(); }}>
+      <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-md" hasCloseButton>
+        {node != null && (
+          <InspectorBody node={node} cellStateOverrides={cellStateOverrides} />
+        )}
+      </SheetContent>
+    </Sheet>
+  );
+}
+
+function InspectorBody({
+  node,
+  cellStateOverrides,
+}: {
+  node: ContinuumMapNode,
+  cellStateOverrides?: Map<string, string>,
+}) {
+  switch (node.kind) {
+    case "customer": {
+      return <CustomerBody node={node} />;
+    }
+    case "cell": {
+      return <CellBody node={node} cellStateOverrides={cellStateOverrides} />;
+    }
+    case "release": {
+      return <ReleaseBody node={node} />;
+    }
+    case "database": {
+      return <DatabaseBody node={node} />;
+    }
+    case "provider": {
+      return <ProviderBody node={node} />;
+    }
+    case "region": {
+      return <ProviderBody node={node} />;
+    }
+    default: {
+      const exhaustive: never = node.kind;
+      throw new Error(`Unhandled node kind: ${exhaustive}`);
+    }
+  }
+}
+
+function InspectorChrome({
+  icon: Icon,
+  title,
+  subtitle,
+  status,
+  children,
+}: {
+  icon: React.ElementType,
+  title: string,
+  subtitle: string,
+  status: "ok" | "warn" | "bad" | "info" | "idle" | "pinned",
+  children: React.ReactNode,
+}) {
+  return (
+    <>
+      <SheetHeader className="space-y-3 border-b border-black/[0.08] px-5 py-4 text-left dark:border-white/[0.08]">
+        <div className="flex items-start gap-3">
+          <div className="flex size-9 items-center justify-center rounded-md border border-black/[0.08] bg-black/[0.03] dark:border-white/[0.08] dark:bg-white/[0.04]">
+            <Icon className="size-4" />
+          </div>
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <StatusDot status={status} />
+              <SheetTitle className="truncate text-base font-semibold tracking-tight">{title}</SheetTitle>
+            </div>
+            <SheetDescription className="mt-1 text-xs text-muted-foreground">{subtitle}</SheetDescription>
+          </div>
+        </div>
+      </SheetHeader>
+      <div className="min-h-0 flex-1 space-y-4 overflow-y-auto px-5 py-4">{children}</div>
+    </>
+  );
+}
+
+function CustomerBody({ node }: { node: ContinuumMapNode }) {
+  const tenantId = customerIdFromNode(node.id);
+  if (tenantId == null) throw new Error(`No tenant mapped for node ${node.id}`);
+  const tenant = tenantById(tenantId);
+
+  return (
+    <InspectorChrome
+      icon={UsersIcon}
+      title={tenant.name}
+      subtitle={`${tenant.plan} · ${tenant.userCount.toLocaleString()} users · ${tenant.residency}`}
+      status="ok"
+    >
+      <Row label="ARR" value={`$${(tenant.arrUsd / 1000).toFixed(0)}k`} />
+      <Row label="Users" value={tenant.userCount.toLocaleString()} />
+      <Row label="Residency" value={tenant.residency} />
+      <Section title="Recent sessions">
+        {["Invite admin · 4m ago", "SSO sign-in · 18m ago", "Billing settings · 41m ago"].map((line) => (
+          <p key={line} className="font-mono text-[11px] text-muted-foreground">{line}</p>
+        ))}
+      </Section>
+    </InspectorChrome>
+  );
+}
+
+function CellBody({
+  node,
+  cellStateOverrides,
+}: {
+  node: ContinuumMapNode,
+  cellStateOverrides?: Map<string, string>,
+}) {
+  const cellId = cellIdFromNode(node.id);
+  if (cellId == null) throw new Error(`No cell mapped for node ${node.id}`);
+  const cell = cellById(cellId);
+  const tenant = tenantById(cell.tenantId);
+  const state = cellStateOverrides?.get(cellId) ?? cell.state;
+
+  return (
+    <InspectorChrome
+      icon={HardDrivesIcon}
+      title={tenant.name}
+      subtitle={`Cell · ${cell.provider} ${cell.regionId}`}
+      status={cellStateToCxStatus(state)}
+    >
+      <Row label="Release" value={cell.releaseVersion} />
+      <Row label="State" value={state.replace("_", " ")} />
+      <Row label="Replication lag" value={`${cell.replicationLagMs}ms`} />
+      <Row label="Recovery" value={`${cell.recovery.mode} → ${cell.recovery.standbyProvider}`} />
+
+      <Section title="Actions">
+        <div className="flex flex-wrap gap-2">
+          <DesignButton size="sm" variant="outline" onClick={() => setCellState(cellId, "pinned")}>
+            <PushPinIcon className="mr-1.5 size-3.5" />
+            Pin
+          </DesignButton>
+          <DesignButton size="sm" variant="outline" onClick={() => setCellState(cellId, "protected")}>
+            Isolate
+          </DesignButton>
+          <DesignButton
+            size="sm"
+            variant="outline"
+            onClick={async () => {
+              setCellState(cellId, "failing_over");
+              await new Promise((r) => setTimeout(r, 700));
+              setCellState(cellId, "healthy");
+            }}
+          >
+            <ArrowsClockwiseIcon className="mr-1.5 size-3.5" />
+            Fail over
+          </DesignButton>
+          <DesignButton size="sm" variant="outline">
+            <CopyIcon className="mr-1.5 size-3.5" />
+            Clone
+          </DesignButton>
+        </div>
+        <p className="mt-2 text-[11px] text-muted-foreground">Sessions lost on failover: 0</p>
+      </Section>
+    </InspectorChrome>
+  );
+}
+
+function ReleaseBody({ node }: { node: ContinuumMapNode }) {
+  const release = RELEASES[0];
+  return (
+    <InspectorChrome
+      icon={RocketLaunchIcon}
+      title={node.label}
+      subtitle={release.title}
+      status="ok"
+    >
+      <div className="flex flex-wrap gap-1.5">
+        <CxChip tone="accent">{release.status.replace("_", " ")}</CxChip>
+        <CxChip>{release.framework}</CxChip>
+        <CxChip>{release.connectedRepo}</CxChip>
+      </div>
+      <Row label="Commits" value={String(release.commits.length)} />
+      <Row label="Blast radius" value={`${release.blastRadiusUsers.toLocaleString()} users`} />
+      <Section title="Build logs">
+        <div className="-mx-1">
+          <BuildLogViewer buildLog={release.buildLog} running={false} />
+        </div>
+      </Section>
+    </InspectorChrome>
+  );
+}
+
+function DatabaseBody({ node }: { node: ContinuumMapNode }) {
+  return (
+    <InspectorChrome
+      icon={DatabaseIcon}
+      title={node.label}
+      subtitle="Shared across active versions"
+      status="ok"
+    >
+      <Row label="Size" value="2 TB" />
+      <Row label="Compat" value="Both versions ok" />
+      <Section title="Replication">
+        <div className="space-y-2 rounded-md border border-black/[0.06] p-3 dark:border-white/[0.06]">
+          {DB_REPLICAS.map((replica) => (
+            <div key={replica.id} className="flex items-center justify-between text-[12px]">
+              <span>{replica.role} → {replica.provider} {replica.region}</span>
+              {replica.role === "primary"
+                ? <CxChip tone="ok">live</CxChip>
+                : <span className={cx.mono}>lag {replica.lagMs}ms</span>}
+            </div>
+          ))}
+        </div>
+      </Section>
+      <Section title="Branches">
+        {DB_BRANCHES.map((branch) => (
+          <p key={branch.id} className="font-mono text-[11px] text-muted-foreground">{branch.name}</p>
+        ))}
+      </Section>
+    </InspectorChrome>
+  );
+}
+
+function ProviderBody({ node }: { node: ContinuumMapNode }) {
+  return (
+    <InspectorChrome
+      icon={CloudIcon}
+      title={node.label}
+      subtitle={node.subtitle ?? "Cloud provider"}
+      status="ok"
+    >
+      <Row label="Role" value={node.label === "AWS" ? "Primary" : "Standby"} />
+      <Row label="Region" value={node.subtitle ?? "—"} />
+      <Section title="Traffic">
+        <p className="text-[12px] text-muted-foreground">
+          Cells and databases can fail over here without forcing customers to sign in again.
+        </p>
+      </Section>
+    </InspectorChrome>
+  );
+}
+
+function Section({ title, children }: { title: string, children: React.ReactNode }) {
+  return (
+    <div>
+      <p className={cx.label}>{title}</p>
+      <div className="mt-2 space-y-1.5">{children}</div>
+    </div>
+  );
+}
+
+function Row({ label, value }: { label: string, value: string }) {
+  return (
+    <div className="flex items-center justify-between gap-3 border-b border-black/[0.05] py-2 last:border-0 dark:border-white/[0.05]">
+      <span className="text-[12px] text-muted-foreground">{label}</span>
+      <span className="font-mono text-[12px] tabular-nums text-foreground">{value}</span>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/protect-checklist.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/protect-checklist.tsx
@@ -1,0 +1,83 @@
+"use client";
+
+import { DesignBadge, DesignCard } from "@/components/design-components";
+import { CheckCircleIcon, ShieldCheckIcon } from "@phosphor-icons/react";
+import { motion, useReducedMotion } from "motion/react";
+import { useEffect, useState } from "react";
+
+const protectionSteps = [
+  "Rollout paused",
+  "Tenant isolated",
+  "Pinned to v1.0.46 — safe, because cleanup is still deferred",
+  "Database restored",
+  "Traffic switched",
+  "Customer restored",
+] as const;
+
+export function ProtectChecklist({ active }: { active: boolean }) {
+  const shouldReduceMotion = useReducedMotion();
+  const [visibleCount, setVisibleCount] = useState(0);
+
+  useEffect(() => {
+    if (!active) {
+      setVisibleCount(0);
+      return;
+    }
+
+    if (shouldReduceMotion) {
+      setVisibleCount(protectionSteps.length);
+      return;
+    }
+
+    const timers = protectionSteps.map((_, index) => window.setTimeout(
+      () => setVisibleCount(index + 1),
+      140 * (index + 1),
+    ));
+    return () => {
+      for (const timer of timers) window.clearTimeout(timer);
+    };
+  }, [active, shouldReduceMotion]);
+
+  if (!active) return null;
+
+  return (
+    <DesignCard
+      title="Customer protection"
+      subtitle="Only the affected customers moved back. Healthy customers stayed on the new version."
+      icon={ShieldCheckIcon}
+      gradient="green"
+      actions={<DesignBadge label={`${visibleCount} of ${protectionSteps.length} complete`} color="green" size="sm" />}
+    >
+      <div className="grid gap-2 sm:grid-cols-2 xl:grid-cols-3">
+        {protectionSteps.map((step, index) => {
+          const visible = index < visibleCount;
+          return (
+            <motion.div
+              key={step}
+              initial={false}
+              animate={{ opacity: visible ? 1 : 0.35, y: visible ? 0 : 3 }}
+              transition={{ duration: shouldReduceMotion ? 0 : 0.18 }}
+              className="flex min-h-12 items-center gap-2 rounded-xl bg-foreground/[0.035] px-3 py-2 ring-1 ring-foreground/[0.05]"
+            >
+              <CheckCircleIcon
+                className={visible ? "h-4 w-4 shrink-0 text-emerald-600 dark:text-emerald-400" : "h-4 w-4 shrink-0 text-muted-foreground"}
+                weight={visible ? "fill" : "regular"}
+              />
+              <span className="text-xs font-medium text-foreground">{step}</span>
+            </motion.div>
+          );
+        })}
+      </div>
+      <motion.div
+        initial={false}
+        animate={{ opacity: visibleCount === protectionSteps.length ? 1 : 0 }}
+        className="mt-3 flex flex-wrap items-center justify-between gap-2 rounded-xl bg-emerald-500/[0.07] px-3 py-2 ring-1 ring-emerald-500/15"
+      >
+        <span className="text-xs font-semibold text-emerald-700 dark:text-emerald-300">Customer service restored</span>
+        <span className="font-mono text-xs tabular-nums text-emerald-700 dark:text-emerald-300">
+          Sessions lost: 0 · Re-auths forced: 0
+        </span>
+      </motion.div>
+    </DesignCard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/query-insights.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/query-insights.tsx
@@ -1,0 +1,26 @@
+"use client";
+
+import { SLOW_QUERIES } from "../fixtures/databases";
+import { CxChip, CxPanel, cx } from "./ui-kit";
+
+export function QueryInsights() {
+  return (
+    <CxPanel
+      title="Query insights"
+      meta={<CxChip tone="warn">{SLOW_QUERIES.length} slow paths</CxChip>}
+      bodyClassName="space-y-3 p-3"
+    >
+      {SLOW_QUERIES.map((query) => (
+        <div key={query.id} className={`${cx.panelInset} p-3`}>
+          <div className="flex flex-wrap items-center gap-2 tabular-nums">
+            <CxChip tone="warn">p95 {query.p95Ms} ms</CxChip>
+            <span className="text-[11px] text-muted-foreground">{query.callsPerMin.toLocaleString()} calls/min</span>
+          </div>
+          <pre className={`mt-2 overflow-x-auto rounded-md bg-black/[0.04] p-2.5 ${cx.mono} text-muted-foreground dark:bg-white/[0.04]`}>{query.sql}</pre>
+          <p className="mt-2 text-xs leading-5">{query.plainHint}</p>
+          <pre className={`mt-2 overflow-x-auto rounded-md bg-black/[0.04] p-2.5 ${cx.mono} text-muted-foreground dark:bg-white/[0.04]`}>{query.suggestedIndex}</pre>
+        </div>
+      ))}
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/release-cockpit.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/release-cockpit.tsx
@@ -1,0 +1,193 @@
+"use client";
+
+import { DesignButton } from "@/components/design-components";
+import { useSyncExternalStore } from "react";
+import {
+  getContinuumState,
+  patchContinuumState,
+  subscribeContinuum,
+} from "../continuum-store";
+import { MIGRATIONS } from "../fixtures/databases";
+import type { Release } from "../fixtures/types";
+import { BuildLogViewer } from "./build-log-viewer";
+import { CompatMatrix } from "./compat-matrix";
+import { RolloutStages } from "./rollout-stages";
+import { CxChip, CxPanel, StatusDot, cx } from "./ui-kit";
+
+const affectedTenants = [
+  { id: "tenant-atlas", name: "Atlas Health" },
+  { id: "tenant-northstar", name: "Northstar Legal" },
+  { id: "tenant-lumen", name: "Lumen Finance" },
+] as const;
+
+export type ReleaseCockpitProps = {
+  release: Release,
+  paused: boolean,
+};
+
+function formatUsd(value: number): string {
+  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}k`;
+  return `$${value}`;
+}
+
+function stepKindLabel(kind: "expand" | "contract"): string {
+  return kind === "expand" ? "safe now" : "cleanup later";
+}
+
+export function ReleaseCockpit({ release, paused }: ReleaseCockpitProps) {
+  const continuumState = useSyncExternalStore(
+    subscribeContinuum,
+    getContinuumState,
+    getContinuumState,
+  );
+  const migration = MIGRATIONS.find((candidate) => candidate.releaseVersion === release.version);
+
+  const startRollout = () => {
+    patchContinuumState((previous) => {
+      const stageStatuses = new Map(previous.stageStatuses);
+      stageStatuses.set("stage-1", "complete");
+      stageStatuses.set("stage-2", "healthy");
+      return {
+        ...previous,
+        releaseStatus: "rolling_out",
+        stageStatuses,
+      };
+    });
+  };
+
+  const resumeRollout = () => {
+    patchContinuumState({ releaseStatus: "rolling_out" });
+  };
+
+  const pinTenant = (tenantId: string) => {
+    patchContinuumState((previous) => {
+      const pinnedVersions = new Map(previous.pinnedVersions);
+      pinnedVersions.set(tenantId, release.versionWindow.from);
+      return { ...previous, pinnedVersions };
+    });
+  };
+
+  const protectAffectedTenants = () => {
+    patchContinuumState((previous) => {
+      const pinnedVersions = new Map(previous.pinnedVersions);
+      for (const tenant of affectedTenants) {
+        pinnedVersions.set(tenant.id, release.versionWindow.from);
+      }
+      return { ...previous, pinnedVersions };
+    });
+  };
+
+  return (
+    <div className="min-w-0 space-y-3">
+      <CxPanel
+        title={release.title}
+        meta={<span className={cx.mono}>{release.version}</span>}
+        bodyClassName="space-y-4 p-4"
+      >
+        <div className="flex flex-col gap-4 lg:flex-row lg:items-start lg:justify-between">
+          <div className="min-w-0 space-y-2">
+            <div className="flex flex-wrap items-center gap-2">
+              <CxChip tone="accent">{release.status.replace("_", " ")}</CxChip>
+              <CxChip>{release.framework}</CxChip>
+              <span className={cx.mono}>{release.connectedRepo}</span>
+            </div>
+            <p className="text-sm leading-6 text-muted-foreground">
+              Move customers forward in stages. Undo one tenant without changing everyone else.
+            </p>
+          </div>
+          <div className="flex flex-wrap gap-2">
+            {paused ? (
+              <>
+                <DesignButton variant="outline" size="sm" onClick={protectAffectedTenants}>
+                  Protect affected
+                </DesignButton>
+                <DesignButton size="sm" onClick={resumeRollout}>
+                  Resume
+                </DesignButton>
+              </>
+            ) : release.status === "draft" ? (
+              <DesignButton size="sm" onClick={startRollout}>
+                Start rollout
+              </DesignButton>
+            ) : null}
+          </div>
+        </div>
+
+        <div className="grid grid-cols-2 gap-2 sm:grid-cols-5">
+          {[
+            { label: "Commits", value: String(release.commits.length) },
+            { label: "Migrations", value: String(release.migrationCount) },
+            { label: "Flags", value: String(release.featureFlags.length) },
+            { label: "Users", value: release.blastRadiusUsers.toLocaleString() },
+            { label: "ARR", value: formatUsd(release.blastRadiusArrUsd) },
+          ].map((stat) => (
+            <div key={stat.label} className="rounded-md border border-black/[0.06] px-3 py-2.5 dark:border-white/[0.06]">
+              <p className={cx.label}>{stat.label}</p>
+              <p className="mt-1 text-lg font-semibold tabular-nums tracking-tight">{stat.value}</p>
+            </div>
+          ))}
+        </div>
+      </CxPanel>
+
+      {migration != null && (
+        <CxPanel title="Migration" meta={<span className="text-[11px] text-muted-foreground">{migration.orm}</span>} bodyClassName="space-y-2 p-4">
+          <p className="text-sm text-muted-foreground">{migration.title}</p>
+          {migration.steps.map((step) => (
+            <div key={step.id} className="rounded-md border border-black/[0.06] px-3 py-2.5 dark:border-white/[0.06]">
+              <div className="flex flex-wrap items-center justify-between gap-2">
+                <div className="flex items-center gap-2">
+                  <StatusDot status={step.kind === "expand" ? "ok" : "warn"} />
+                  <span className="text-[13px] font-medium">{step.plainLabel}</span>
+                </div>
+                <div className="flex items-center gap-1.5">
+                  <CxChip tone={step.kind === "expand" ? "ok" : "warn"}>{stepKindLabel(step.kind)}</CxChip>
+                  <CxChip>{step.status}</CxChip>
+                </div>
+              </div>
+              <pre className="mt-2 overflow-x-auto font-mono text-[10px] text-muted-foreground">{step.sql}</pre>
+              {step.heldBy != null && (
+                <p className="mt-2 text-[11px] text-amber-800 dark:text-amber-200">{step.heldBy}</p>
+              )}
+            </div>
+          ))}
+        </CxPanel>
+      )}
+
+      <CompatMatrix />
+      <RolloutStages stages={release.stages} stageStatuses={continuumState.stageStatuses} />
+      <BuildLogViewer
+        buildLog={release.buildLog}
+        running={release.status === "rolling_out"}
+      />
+
+      <CxPanel
+        title="Pin a customer back"
+        meta={<span className="text-[11px] text-muted-foreground">Everyone else stays</span>}
+        bodyClassName="divide-y divide-black/[0.06] dark:divide-white/[0.06]"
+      >
+        {affectedTenants.map((tenant) => {
+          const pinnedVersion = continuumState.pinnedVersions.get(tenant.id);
+          return (
+            <div key={tenant.id} className="flex items-center justify-between gap-3 px-4 py-3">
+              <div>
+                <p className="text-[13px] font-medium">{tenant.name}</p>
+                <p className="mt-0.5 text-[11px] text-muted-foreground">
+                  {pinnedVersion == null ? `On ${release.version}` : `Pinned to ${pinnedVersion}`}
+                </p>
+              </div>
+              <DesignButton
+                variant="outline"
+                size="sm"
+                disabled={pinnedVersion != null}
+                onClick={() => pinTenant(tenant.id)}
+              >
+                {pinnedVersion == null ? `Pin to ${release.versionWindow.from}` : "Pinned"}
+              </DesignButton>
+            </div>
+          );
+        })}
+      </CxPanel>
+    </div>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/rollout-stages.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/rollout-stages.tsx
@@ -1,0 +1,108 @@
+"use client";
+
+import type { RolloutStage, RolloutStageStatus } from "../fixtures/types";
+import { CxChip, CxPanel, StatusDot, cellStateToCxStatus, cx, type CxStatus } from "./ui-kit";
+
+export type RolloutStagesProps = {
+  stages: RolloutStage[],
+  stageStatuses?: ReadonlyMap<string, RolloutStageStatus>,
+};
+
+function statusToCx(status: RolloutStageStatus): CxStatus {
+  switch (status) {
+    case "complete":
+    case "healthy": {
+      return "ok";
+    }
+    case "running": {
+      return "info";
+    }
+    case "paused": {
+      return "warn";
+    }
+    case "skipped":
+    case "pending": {
+      return "idle";
+    }
+    default: {
+      const exhaustive: never = status;
+      return cellStateToCxStatus(exhaustive);
+    }
+  }
+}
+
+function formatArr(arrUsd: number): string {
+  if (arrUsd === 0) return "$0";
+  if (arrUsd >= 1_000_000) return `$${(arrUsd / 1_000_000).toFixed(1)}M`;
+  if (arrUsd >= 1_000) return `$${Math.round(arrUsd / 1_000)}k`;
+  return `$${arrUsd}`;
+}
+
+export function RolloutStages({ stages, stageStatuses = new Map() }: RolloutStagesProps) {
+  const resolvedStages = stages.map((stage) => {
+    const status = stageStatuses.get(stage.id) ?? stage.status;
+    const healthGate = status === "complete" || status === "healthy"
+      ? "passing"
+      : stage.healthGate;
+    return { ...stage, status, healthGate };
+  });
+  const currentStageIndex = resolvedStages.findIndex((stage) => (
+    stage.status === "running"
+    || stage.status === "paused"
+    || stage.status === "pending"
+  ));
+
+  return (
+    <CxPanel
+      title="Rollout"
+      meta={<span className="text-[11px] text-muted-foreground">Smallest customers first</span>}
+      bodyClassName="p-0"
+    >
+      <ol className="divide-y divide-black/[0.06] dark:divide-white/[0.06]">
+        {resolvedStages.map((stage, index) => {
+          const isCurrent = index === currentStageIndex;
+          return (
+            <li
+              key={stage.id}
+              className={[
+                "flex items-start gap-3 px-4 py-3",
+                isCurrent ? "bg-[#7c6cff]/[0.06]" : "",
+              ].join(" ")}
+            >
+              <div className="mt-1.5 flex flex-col items-center gap-1">
+                <StatusDot status={statusToCx(stage.status)} />
+                {index < resolvedStages.length - 1 && (
+                  <span className="h-8 w-px bg-black/[0.08] dark:bg-white/[0.08]" aria-hidden />
+                )}
+              </div>
+              <div className="min-w-0 flex-1">
+                <div className="flex flex-wrap items-center justify-between gap-2">
+                  <div>
+                    <p className="text-[13px] font-medium tracking-tight">
+                      {index + 1}. {stage.label}
+                      {isCurrent && <span className="ml-2 text-[10px] font-medium text-[#7c6cff]">current</span>}
+                    </p>
+                    <p className="mt-0.5 text-[11px] text-muted-foreground">{stage.segment}</p>
+                  </div>
+                  <div className="flex items-center gap-1.5">
+                    <CxChip>{stage.status.replace("_", " ")}</CxChip>
+                    <CxChip tone={stage.healthGate === "passing" ? "ok" : stage.healthGate === "failing" ? "bad" : "neutral"}>
+                      {stage.healthGate}
+                    </CxChip>
+                  </div>
+                </div>
+                <p className={cnMono(stage)}>
+                  {stage.users.toLocaleString()} users · {stage.orgs.toLocaleString()} orgs · {formatArr(stage.arrUsd)} ARR
+                </p>
+              </div>
+            </li>
+          );
+        })}
+      </ol>
+    </CxPanel>
+  );
+}
+
+function cnMono(_stage: RolloutStage): string {
+  return `mt-2 ${cx.mono} text-muted-foreground`;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/schema-browser.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/schema-browser.tsx
@@ -1,0 +1,56 @@
+"use client";
+
+import { TableIcon } from "@phosphor-icons/react";
+import { SCHEMA_TABLES } from "../fixtures/databases";
+import type { SensitiveKind } from "../fixtures/types";
+import { CxChip, CxPanel, cx } from "./ui-kit";
+
+const SENSITIVE_TONES: Record<SensitiveKind, "warn" | "bad"> = {
+  email: "warn",
+  name: "warn",
+  phone: "bad",
+  freetext: "bad",
+  ssn: "bad",
+  address: "warn",
+};
+
+export function SensitiveKindChip(props: { kind: SensitiveKind }) {
+  return <CxChip tone={SENSITIVE_TONES[props.kind]}>{props.kind}</CxChip>;
+}
+
+export function SchemaBrowser() {
+  return (
+    <CxPanel
+      title="Schema"
+      meta={<CxChip>{SCHEMA_TABLES.length} tables</CxChip>}
+      bodyClassName="space-y-3 p-3"
+    >
+      <p className={cx.muted}>
+        Sensitive fields are marked in your schema — anonymization uses them automatically.
+      </p>
+      {SCHEMA_TABLES.map((table) => (
+        <div key={table.name} className={cx.panelInset}>
+          <div className={`flex items-center gap-2 border-b px-3 py-2 ${cx.hairline}`}>
+            <TableIcon className="size-3.5 text-muted-foreground" />
+            <span className={`${cx.mono} font-semibold`}>{table.name}</span>
+            <span className="ml-auto text-[11px] text-muted-foreground tabular-nums">{table.columns.length} columns</span>
+          </div>
+          <div>
+            {table.columns.map((column) => (
+              <div
+                key={column.name}
+                className={`flex items-center gap-2 border-b border-black/[0.04] px-3 py-1.5 text-xs last:border-0 dark:border-white/[0.04] ${
+                  column.sensitive == null ? "" : "bg-amber-500/[0.05]"
+                }`}
+              >
+                <span className={`min-w-0 flex-1 truncate ${cx.mono}`}>{column.name}</span>
+                <span className={`${cx.mono} text-muted-foreground`}>{column.type}{column.nullable ? "?" : ""}</span>
+                {column.sensitive != null && <SensitiveKindChip kind={column.sensitive.kind} />}
+              </div>
+            ))}
+          </div>
+        </div>
+      ))}
+    </CxPanel>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/ui-kit.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/components/ui-kit.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import { cn } from "@/components/ui";
+import type { ReactNode } from "react";
+
+/** Continuum-local Railway-inspired surfaces. Scoped so we don't fight the rest of the dashboard. */
+export const cx = {
+  canvas:
+    "relative overflow-hidden rounded-lg border border-black/[0.08] bg-[#0f0e14] text-[#f7f7f8] shadow-[inset_0_1px_0_rgba(255,255,255,0.04)] dark:border-white/[0.08]",
+  panel:
+    "rounded-lg border border-black/[0.08] bg-white/90 dark:border-white/[0.08] dark:bg-[#16141f]/90",
+  panelInset:
+    "rounded-md border border-black/[0.06] bg-black/[0.02] dark:border-white/[0.06] dark:bg-white/[0.03]",
+  hairline: "border-black/[0.08] dark:border-white/[0.08]",
+  mono: "font-mono text-[11px] tabular-nums tracking-tight",
+  label: "text-[10px] font-medium uppercase tracking-[0.14em] text-muted-foreground",
+  title: "text-sm font-medium tracking-tight text-foreground",
+  muted: "text-xs text-muted-foreground",
+} as const;
+
+export type CxStatus = "ok" | "warn" | "bad" | "info" | "idle" | "pinned";
+
+const statusDotClass = new Map<CxStatus, string>([
+  ["ok", "bg-[#42946e] shadow-[0_0_0_3px_rgba(66,148,110,0.18)]"],
+  ["warn", "bg-amber-400 shadow-[0_0_0_3px_rgba(251,191,36,0.18)]"],
+  ["bad", "bg-red-500 shadow-[0_0_0_3px_rgba(239,68,68,0.2)]"],
+  ["info", "bg-[#7c6cff] shadow-[0_0_0_3px_rgba(124,108,255,0.18)]"],
+  ["idle", "bg-zinc-400 shadow-[0_0_0_3px_rgba(161,161,170,0.15)]"],
+  ["pinned", "bg-violet-400 shadow-[0_0_0_3px_rgba(167,139,250,0.2)]"],
+]);
+
+export function StatusDot({ status, className }: { status: CxStatus, className?: string }) {
+  const color = statusDotClass.get(status);
+  if (color == null) throw new Error(`Unknown Continuum status: ${status}`);
+  return <span className={cn("inline-block size-1.5 shrink-0 rounded-full", color, className)} aria-hidden />;
+}
+
+export function CxShell({ children, className }: { children: ReactNode, className?: string }) {
+  return (
+    <div className={cn("flex min-h-0 flex-1 flex-col gap-3", className)}>
+      {children}
+    </div>
+  );
+}
+
+export function CxHeader({
+  title,
+  description,
+  actions,
+}: {
+  title: string,
+  description?: string,
+  actions?: ReactNode,
+}) {
+  return (
+    <div className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+      <div className="min-w-0 space-y-1">
+        <h1 className="text-xl font-semibold tracking-tight text-foreground sm:text-2xl">{title}</h1>
+        {description != null && (
+          <p className="max-w-2xl text-sm leading-6 text-muted-foreground">{description}</p>
+        )}
+      </div>
+      {actions != null && <div className="flex shrink-0 items-center gap-2">{actions}</div>}
+    </div>
+  );
+}
+
+export function CxMetricStrip({
+  items,
+}: {
+  items: { label: string, value: string, hint?: string }[],
+}) {
+  return (
+    <div className={cn(cx.panel, "grid grid-cols-1 divide-y sm:grid-cols-3 sm:divide-x sm:divide-y-0", cx.hairline)}>
+      {items.map((item) => (
+        <div key={item.label} className="px-4 py-3">
+          <p className={cx.label}>{item.label}</p>
+          <p className="mt-1.5 text-2xl font-semibold tracking-tight tabular-nums text-foreground">{item.value}</p>
+          {item.hint != null && <p className="mt-1 text-[11px] leading-4 text-muted-foreground">{item.hint}</p>}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+export function CxPanel({
+  title,
+  meta,
+  children,
+  className,
+  bodyClassName,
+}: {
+  title: string,
+  meta?: ReactNode,
+  children: ReactNode,
+  className?: string,
+  bodyClassName?: string,
+}) {
+  return (
+    <section className={cn(cx.panel, "flex min-h-0 flex-col overflow-hidden", className)}>
+      <div className={cn("flex items-center justify-between gap-3 border-b px-4 py-2.5", cx.hairline)}>
+        <h2 className={cx.title}>{title}</h2>
+        {meta != null && <div className="shrink-0">{meta}</div>}
+      </div>
+      <div className={cn("min-h-0 flex-1", bodyClassName)}>{children}</div>
+    </section>
+  );
+}
+
+export function CxChip({ children, tone = "neutral" }: { children: ReactNode, tone?: "neutral" | "ok" | "warn" | "bad" | "accent" }) {
+  const toneClass = {
+    neutral: "border-black/[0.08] bg-black/[0.03] text-muted-foreground dark:border-white/[0.08] dark:bg-white/[0.04]",
+    ok: "border-[#42946e]/30 bg-[#42946e]/10 text-[#2f6b4f] dark:text-[#7dcea8]",
+    warn: "border-amber-500/30 bg-amber-500/10 text-amber-800 dark:text-amber-200",
+    bad: "border-red-500/30 bg-red-500/10 text-red-700 dark:text-red-300",
+    accent: "border-[#7c6cff]/30 bg-[#7c6cff]/10 text-[#5b4fd6] dark:text-[#b4acff]",
+  }[tone];
+  return (
+    <span className={cn("inline-flex items-center gap-1.5 rounded px-1.5 py-0.5 text-[10px] font-medium", toneClass)}>
+      {children}
+    </span>
+  );
+}
+
+export function cellStateToCxStatus(state: string): CxStatus {
+  switch (state) {
+    case "healthy":
+    case "deploying": {
+      return "ok";
+    }
+    case "degraded":
+    case "isolating":
+    case "recovering": {
+      return "warn";
+    }
+    case "failing_over":
+    case "protected": {
+      return "info";
+    }
+    case "pinned": {
+      return "pinned";
+    }
+    default: {
+      return "idle";
+    }
+  }
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/continuum-store.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/continuum-store.ts
@@ -1,0 +1,74 @@
+import type { CellState, RolloutStageStatus } from "./fixtures/types";
+
+export type ContinuumDemoState = {
+  cellStates: Map<string, CellState>,
+  releaseStatus: "draft" | "rolling_out" | "paused" | "complete",
+  stageStatuses: Map<string, RolloutStageStatus>,
+  pinnedVersions: Map<string, string>,
+  incidentBanner: string | null,
+  deferredReleased: boolean,
+  forensicCloneReady: boolean,
+};
+
+type Listener = () => void;
+
+const listeners = new Set<Listener>();
+
+function createInitialState(): ContinuumDemoState {
+  return {
+    cellStates: new Map(),
+    releaseStatus: "draft",
+    stageStatuses: new Map([
+      ["stage-1", "pending"],
+      ["stage-2", "pending"],
+      ["stage-3", "pending"],
+      ["stage-4", "pending"],
+      ["stage-5", "pending"],
+    ]),
+    pinnedVersions: new Map(),
+    incidentBanner: null,
+    deferredReleased: false,
+    forensicCloneReady: false,
+  };
+}
+
+let state: ContinuumDemoState = createInitialState();
+
+export function getContinuumState(): ContinuumDemoState {
+  return state;
+}
+
+export function subscribeContinuum(listener: Listener): () => void {
+  listeners.add(listener);
+  return () => {
+    listeners.delete(listener);
+  };
+}
+
+function emit() {
+  for (const listener of listeners) {
+    listener();
+  }
+}
+
+export function patchContinuumState(patch: Partial<ContinuumDemoState> | ((prev: ContinuumDemoState) => ContinuumDemoState)) {
+  state = typeof patch === "function" ? patch(state) : { ...state, ...patch };
+  emit();
+}
+
+export function resetContinuumState() {
+  state = createInitialState();
+  emit();
+}
+
+export function setCellState(cellId: string, cellState: CellState) {
+  patchContinuumState((prev) => {
+    const cellStates = new Map(prev.cellStates);
+    cellStates.set(cellId, cellState);
+    return { ...prev, cellStates };
+  });
+}
+
+export function setIncidentBanner(message: string | null) {
+  patchContinuumState({ incidentBanner: message });
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/databases/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/databases/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function Page(props: { params: Promise<{ projectId: string }> }) {
+  const params = await props.params;
+  redirect(`/projects/${encodeURIComponent(params.projectId)}/continuum`);
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/copilot-script.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/copilot-script.ts
@@ -1,0 +1,58 @@
+import type { CopilotTurn } from "./types";
+
+export const FORENSIC_COPILOT_SCRIPT: CopilotTurn[] = [
+  {
+    id: "c1",
+    role: "system",
+    text: "Forensic clone attached. Logs, 8 session replays, and Atlas tenant config are in scope.",
+    delayMs: 400,
+  },
+  {
+    id: "c2",
+    role: "agent",
+    text: "Reproducing the invitations failure against the sanitized clone…",
+    delayMs: 800,
+  },
+  {
+    id: "c3",
+    role: "agent",
+    text: "Root cause: custom role lookup assumes role_id is always set for enterprise orgs with >5,000 members. Legacy path still null during SSO invite.",
+    delayMs: 1_200,
+  },
+  {
+    id: "c4",
+    role: "agent",
+    text: "Devin wants temporary read access to organization_roles in the sanitized clone — expires in 30 minutes.",
+    delayMs: 600,
+    approval: {
+      id: "approve-org-roles-read",
+      title: "Temporary read access",
+      detail: "organization_roles in the sanitized forensic clone · expires in 30 minutes",
+      expiresInMinutes: 30,
+    },
+  },
+  {
+    id: "c5",
+    role: "agent",
+    text: "Access granted. Applying null-safe role resolution + dual-read fallback…",
+    delayMs: 1_000,
+  },
+  {
+    id: "c6",
+    role: "agent",
+    text: "Repro: Failed → Passed. Compat check green. Regression suite green.",
+    delayMs: 900,
+  },
+  {
+    id: "c7",
+    role: "system",
+    text: "Fix packaged for affected tenants first, then global resume.",
+    delayMs: 500,
+  },
+];
+
+export const DATABASES_COPILOT_HINTS = [
+  "Want me to make a safe 5 GB copy for the pricing PR?",
+  "I can explain what the waiting cleanup step will do once Atlas moves forward.",
+  "Before you apply that NOT NULL, I can show who it would break.",
+] as const;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/databases.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/databases.ts
@@ -1,0 +1,241 @@
+import type {
+  ClonePreset,
+  CompatMatrix,
+  DbBranch,
+  DbPointInTimeRecovery,
+  DbReplica,
+  Migration,
+  SchemaTable,
+  SlowQuery,
+} from "./types";
+
+export const DB_BRANCHES: DbBranch[] = [
+  { id: "db-prod", name: "production", parentId: null, kind: "production", releaseVersion: "v1.0.46–47", sizeGb: 2_048, createdAt: "2024-01-12T00:00:00.000Z" },
+  { id: "db-prod-eu", name: "production-eu", parentId: null, kind: "production", releaseVersion: "v1.0.46–47", sizeGb: 410, createdAt: "2024-03-01T00:00:00.000Z" },
+  { id: "db-preview-pricing", name: "feat-pricing", parentId: "db-prod", kind: "preview", releaseVersion: "preview", previewUrl: "feat-pricing--acme.hexclave.app", sizeGb: 12, createdAt: "2026-07-08T14:00:00.000Z" },
+  { id: "db-dev-maya", name: "dev/maya", parentId: "db-prod", kind: "dev", sizeGb: 5, createdAt: "2026-07-09T09:00:00.000Z" },
+  { id: "db-clone-5gb", name: "clone/5gb-sample", parentId: "db-prod", kind: "clone", sizeGb: 5, createdAt: "2026-07-10T11:00:00.000Z" },
+];
+
+export const DB_REPLICAS: DbReplica[] = [
+  { id: "rep-primary", role: "primary", provider: "AWS", region: "us-east-1", lagMs: 0, state: "live", promotable: false },
+  { id: "rep-sync", role: "sync-replica", provider: "AWS", region: "us-east-2", lagMs: 3, state: "live", promotable: true },
+  { id: "rep-async-eu", role: "async-replica", provider: "AWS", region: "eu-west-1", lagMs: 96, state: "live", promotable: true },
+  { id: "rep-standby-gcp", role: "standby", provider: "GCP", region: "us-central1", lagMs: 42, state: "live", promotable: true },
+];
+
+export const DB_PITR: DbPointInTimeRecovery = {
+  retentionDays: 14,
+  oldestRestorePoint: "2026-06-26T11:00:00.000Z",
+  lastSnapshotAt: "2026-07-10T18:30:00.000Z",
+  walArchiveLagSeconds: 4,
+};
+
+export const SCHEMA_TABLES: SchemaTable[] = [
+  {
+    name: "users",
+    columns: [
+      { name: "id", type: "uuid", nullable: false },
+      { name: "email", type: "text", nullable: true, sensitive: { kind: "email" } },
+      { name: "full_name", type: "text", nullable: true, sensitive: { kind: "name" } },
+      { name: "phone", type: "text", nullable: true, sensitive: { kind: "phone" } },
+      { name: "notes", type: "text", nullable: true, sensitive: { kind: "freetext" } },
+      { name: "organization_id", type: "uuid", nullable: false },
+      { name: "legacy_role", type: "text", nullable: true },
+      { name: "role_id", type: "uuid", nullable: true },
+      { name: "created_at", type: "timestamptz", nullable: false },
+    ],
+  },
+  {
+    name: "organizations",
+    columns: [
+      { name: "id", type: "uuid", nullable: false },
+      { name: "name", type: "text", nullable: false, sensitive: { kind: "name" } },
+      { name: "plan", type: "text", nullable: false },
+      { name: "billing_email", type: "text", nullable: true, sensitive: { kind: "email" } },
+    ],
+  },
+  {
+    name: "organization_roles",
+    columns: [
+      { name: "id", type: "uuid", nullable: false },
+      { name: "organization_id", type: "uuid", nullable: false },
+      { name: "name", type: "text", nullable: false },
+      { name: "permissions", type: "jsonb", nullable: false },
+    ],
+  },
+  {
+    name: "invitations",
+    columns: [
+      { name: "id", type: "uuid", nullable: false },
+      { name: "email", type: "text", nullable: false, sensitive: { kind: "email" } },
+      { name: "organization_id", type: "uuid", nullable: false },
+      { name: "role_id", type: "uuid", nullable: true },
+      { name: "status", type: "text", nullable: false },
+    ],
+  },
+];
+
+export const MIGRATIONS: Migration[] = [
+  {
+    id: "mig-roles-147",
+    releaseVersion: "v1.0.47",
+    orm: "prisma",
+    title: "organization_roles + invitations.role_id",
+    steps: [
+      {
+        id: "step-expand-table",
+        kind: "expand",
+        sql: "CREATE TABLE organization_roles (...);",
+        plainLabel: "Add a new roles table (safe for old and new versions)",
+        status: "applied",
+      },
+      {
+        id: "step-expand-col",
+        kind: "expand",
+        sql: "ALTER TABLE users ADD COLUMN role_id uuid NULL;",
+        plainLabel: "Add role_id column (nullable — old version ignores it)",
+        status: "applied",
+      },
+      {
+        id: "step-contract-drop",
+        kind: "contract",
+        sql: "ALTER TABLE users DROP COLUMN legacy_role;",
+        plainLabel: "Remove the old role column",
+        heldBy: "Atlas Health is still on the previous version",
+        status: "deferred",
+      },
+    ],
+    beforeDiff: `- model User {
+-   legacy_role String?
+- }`,
+    afterDiff: `+ model OrganizationRole {
++   id             String
++   organizationId String
++   name           String
++   permissions    Json
++ }
++ model User {
++   roleId String?
++ }`,
+    blastRadius: {
+      nullRows: 1_842,
+      orgsAffected: 37,
+      enterpriseOrgs: 4,
+      arrUsd: 92_400,
+      plainSummary: "1,842 users have a null email, spread across 37 orgs (4 enterprise, $92,400 ARR).",
+      predictedOutcome: "The previous app version still writes nulls during SSO provisioning. Predicted outcome: SSO sign-in failures for 12% of enterprise users.",
+      recommendedSequence: [
+        "Deploy a compat release that stops writing nulls",
+        "Backfill missing emails",
+        "Validate zero nulls remain",
+        "Apply the NOT NULL constraint",
+      ],
+    },
+    lockWarning: "DROP COLUMN waits for open transactions — held until the version window closes.",
+  },
+];
+
+export const COMPAT_MATRIX: CompatMatrix = {
+  versions: ["v1.0.45", "v1.0.46", "v1.0.47"],
+  // Column headers for the compat grid — plain labels for the three database shapes
+  // a release moves through: before the safe additions, while both app versions share
+  // the database, and after old columns are cleaned up.
+  schemaStates: ["Before update", "Both versions", "After cleanup"],
+  cells: [
+    ["green", "green", "red"],
+    ["amber", "green", "red"],
+    ["red", "green", "green"],
+  ],
+  activeWindow: { from: "v1.0.46", to: "v1.0.47" },
+  headline: "Your database works with both the current and previous version — safe to undo anytime ✓",
+};
+
+export const CLONE_PRESETS: ClonePreset[] = [
+  {
+    id: "clone-1gb",
+    targetSizeLabel: "1 GB",
+    targetSizeGb: 1,
+    orgsPreserved: 84,
+    enterpriseOrgs: 1,
+    coverageNotes: ["All schema shapes covered", "Rare enum values included"],
+    redactionReport: [
+      { field: "users.email", kind: "email", example: "alex.rivera@example.com" },
+      { field: "users.full_name", kind: "name", example: "Alex Rivera" },
+      { field: "users.notes", kind: "freetext", example: "[scrubbed]" },
+    ],
+  },
+  {
+    id: "clone-5gb",
+    targetSizeLabel: "5 GB",
+    targetSizeGb: 5,
+    orgsPreserved: 412,
+    enterpriseOrgs: 6,
+    coverageNotes: ["All schema shapes covered", "Rare enum values included", "Invite + role edge cases preserved"],
+    redactionReport: [
+      { field: "users.email", kind: "email", example: "sam.chen@example.com" },
+      { field: "users.full_name", kind: "name", example: "Sam Chen" },
+      { field: "users.phone", kind: "phone", example: "+1-555-0142" },
+      { field: "users.notes", kind: "freetext", example: "[scrubbed]" },
+      { field: "organizations.billing_email", kind: "email", example: "billing@example.org" },
+    ],
+  },
+  {
+    id: "clone-50gb",
+    targetSizeLabel: "50 GB",
+    targetSizeGb: 50,
+    orgsPreserved: 3_840,
+    enterpriseOrgs: 28,
+    coverageNotes: ["Statistically representative", "Whole tenants kept together"],
+    redactionReport: [
+      { field: "users.email", kind: "email", example: "jordan.lee@example.com" },
+      { field: "users.full_name", kind: "name", example: "Jordan Lee" },
+      { field: "users.notes", kind: "freetext", example: "[scrubbed]" },
+    ],
+  },
+  {
+    id: "clone-full",
+    targetSizeLabel: "Full (2 TB)",
+    targetSizeGb: 2_048,
+    orgsPreserved: 12_400,
+    enterpriseOrgs: 86,
+    coverageNotes: ["Complete production copy", "Anonymized end-to-end"],
+    redactionReport: [
+      { field: "users.email", kind: "email", example: "taylor.ng@example.com" },
+      { field: "users.full_name", kind: "name", example: "Taylor Ng" },
+      { field: "users.notes", kind: "freetext", example: "[scrubbed]" },
+    ],
+  },
+];
+
+export const SLOW_QUERIES: SlowQuery[] = [
+  {
+    id: "sq-1",
+    sql: "SELECT * FROM invitations WHERE organization_id = $1 AND status = 'pending'",
+    p95Ms: 840,
+    callsPerMin: 1_240,
+    suggestedIndex: "CREATE INDEX invitations_org_status_idx ON invitations (organization_id, status);",
+    plainHint: "Invites for large orgs are scanning the whole table. An index on org + status would fix it.",
+  },
+  {
+    id: "sq-2",
+    sql: "SELECT u.* FROM users u JOIN organization_roles r ON u.role_id = r.id WHERE r.name = $1",
+    p95Ms: 420,
+    callsPerMin: 380,
+    suggestedIndex: "CREATE INDEX users_role_id_idx ON users (role_id);",
+    plainHint: "Looking up users by role is slower than it should be after the new roles table landed.",
+  },
+];
+
+export const AUTOSCALING_SAMPLES = [
+  { t: 0, cpu: 22, connections: 180 },
+  { t: 1, cpu: 28, connections: 210 },
+  { t: 2, cpu: 41, connections: 290 },
+  { t: 3, cpu: 55, connections: 360 },
+  { t: 4, cpu: 48, connections: 340 },
+  { t: 5, cpu: 36, connections: 260 },
+  { t: 6, cpu: 30, connections: 220 },
+] as const;
+
+export const DEFERRED_CLEANUP_CAPTION =
+  "One cleanup step is waiting until everyone's on the new version (Atlas Health is still on the old one).";

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/incident.test.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/incident.test.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from "vitest";
+import { formatIncidentTime, getIncidentStage, getStageIndex, INCIDENT_STORY } from "./incident";
+
+describe("continuum incident fixtures", () => {
+  it("returns the first stage at t=0", () => {
+    const stage = getIncidentStage(INCIDENT_STORY, 0);
+    expect(stage.id).toMatchInlineSnapshot(`"act1-ready"`);
+    expect(stage.gate?.actionLabel).toMatchInlineSnapshot(`"Start Rollout"`);
+  });
+
+  it("advances through acts by offset", () => {
+    expect(getIncidentStage(INCIDENT_STORY, 22_000).act).toBe(2);
+    expect(getIncidentStage(INCIDENT_STORY, 40_000).act).toBe(3);
+    expect(getIncidentStage(INCIDENT_STORY, 95_000).act).toBe(4);
+    expect(getIncidentStage(INCIDENT_STORY, 130_000).act).toBe(5);
+  });
+
+  it("formats playback time", () => {
+    expect(formatIncidentTime(0)).toMatchInlineSnapshot(`"0:00"`);
+    expect(formatIncidentTime(65_000)).toMatchInlineSnapshot(`"1:05"`);
+  });
+
+  it("resolves stage index for scrubber", () => {
+    expect(getStageIndex(INCIDENT_STORY, 0)).toBe(0);
+    expect(getStageIndex(INCIDENT_STORY, 40_000)).toBe(3);
+  });
+
+  it("closing card protects the demo ARR number", () => {
+    expect(INCIDENT_STORY.closingCard.protectedArrUsd).toMatchInlineSnapshot(`184000`);
+    expect(INCIDENT_STORY.closingCard.avoidedDowntimeMinutes).toMatchInlineSnapshot(`47`);
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/incident.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/incident.ts
@@ -1,0 +1,224 @@
+import type { ContinuumIncidentStory } from "./types";
+
+export const INCIDENT_STORY: ContinuumIncidentStory = {
+  id: "enterprise-roles-rollout",
+  title: "v1.0.47 — Enterprise Roles Update",
+  durationMs: 180_000,
+  stages: [
+    {
+      id: "act1-ready",
+      act: 1,
+      offsetMs: 0,
+      title: "Ready to ship",
+      summary: "v1.0.47 is built. Compat is green for both versions. Two expand steps already applied; one cleanup step is waiting.",
+      overrides: {
+        metrics: [
+          { id: "error-rate", value: 0.4 },
+          { id: "arr-at-risk", value: 0 },
+          { id: "cells-healthy", value: 10 },
+        ],
+        logLines: [
+          "Build ready · Next.js 15.2",
+          "Compat matrix: v1.0.46 + v1.0.47 all green",
+          "Deferred: DROP COLUMN legacy_role (held until window closes)",
+        ],
+      },
+      gate: {
+        actionLabel: "Start Rollout",
+        preview: "Ship to internal orgs first, then 20% of free orgs. Everyone else stays on the previous version until each stage looks healthy.",
+      },
+    },
+    {
+      id: "act1-stages-green",
+      act: 1,
+      offsetMs: 8_000,
+      title: "Stages 1 and 2 look good",
+      summary: "This update is going out to your smallest customers first. So far, all good.",
+      overrides: {
+        cellStates: {
+          "cell-internal": "healthy",
+          "cell-free-1": "healthy",
+          "cell-free-2": "healthy",
+        },
+        metrics: [
+          { id: "error-rate", value: 0.5 },
+          { id: "arr-at-risk", value: 0 },
+          { id: "cells-healthy", value: 10 },
+        ],
+        logLines: [
+          "Stage 1 Internal orgs — healthy",
+          "Stage 2 20% free orgs — healthy",
+        ],
+      },
+    },
+    {
+      id: "act2-break",
+      act: 2,
+      offsetMs: 22_000,
+      title: "Something broke — only for big customers",
+      summary: "3 of your biggest customers hit an error when inviting admins — $184k of revenue is on those accounts. Free and small tenants are fine.",
+      overrides: {
+        cellStates: {
+          "cell-atlas": "degraded",
+          "cell-northstar": "degraded",
+          "cell-lumen": "degraded",
+        },
+        edgeHealth: {
+          "e-atlas-cell": "critical",
+          "e-ns-cell": "degraded",
+          "e-lumen-cell": "degraded",
+        },
+        metrics: [
+          { id: "error-rate", value: 8.7 },
+          { id: "arr-at-risk", value: 184_000 },
+          { id: "cells-healthy", value: 7 },
+        ],
+        logLines: [
+          "Auto-paused rollout at stage 4",
+          "Errors isolated to invitations endpoint · large orgs only",
+          "8 session replays available · Atlas, Northstar, Lumen",
+        ],
+      },
+      gate: {
+        actionLabel: "Protect Affected Tenants",
+        preview: "Pause the rollout, pin Atlas / Northstar / Lumen back to the previous version (schema still supports both), restore their databases, and keep everyone else on the new version.",
+      },
+    },
+    {
+      id: "act3-protect",
+      act: 3,
+      offsetMs: 40_000,
+      title: "Those customers are protected",
+      summary: "Atlas Health is back on the previous version. The cleanup step is still waiting — so undo stayed safe. Sessions lost: 0. Re-auths forced: 0.",
+      overrides: {
+        cellStates: {
+          "cell-atlas": "pinned",
+          "cell-northstar": "protected",
+          "cell-lumen": "protected",
+        },
+        edgeHealth: {
+          "e-atlas-cell": "healthy",
+          "e-ns-cell": "healthy",
+          "e-lumen-cell": "healthy",
+          "e-failover": "active",
+        },
+        metrics: [
+          { id: "error-rate", value: 0.6 },
+          { id: "arr-at-risk", value: 0 },
+          { id: "cells-healthy", value: 10 },
+          { id: "sessions-lost", value: 0 },
+          { id: "reauths-forced", value: 0 },
+        ],
+        logLines: [
+          "Rollout paused ✓",
+          "Tenants isolated ✓",
+          "Pinned to v1.0.46 — safe, contract step still deferred ✓",
+          "Database restored to safe checkpoint ✓",
+          "Traffic switched ✓",
+          "Atlas warm-standby failover on GCP · lag → 0ms",
+          "Sessions lost: 0 · Re-auths forced: 0",
+        ],
+      },
+      gate: {
+        actionLabel: "Create Forensic Clone",
+        preview: "Make a safe copy of Atlas production data — emails and names replaced with fakes — then attach logs, replays, and tenant config for the agent.",
+      },
+    },
+    {
+      id: "act4-clone",
+      act: 4,
+      offsetMs: 70_000,
+      title: "Forensic clone ready",
+      summary: "A safe copy is ready with a temporary URL (expires in 30 minutes). The agent can reproduce the bug without touching real customer data.",
+      overrides: {
+        logLines: [
+          "Snapshot → sample → anonymize → verify → ready",
+          "Redaction report: 5 fields transformed, referential integrity kept",
+          "Temporary URL issued · 30 min expiry",
+        ],
+      },
+      gate: {
+        actionLabel: "Approve Agent Access",
+        preview: "Devin wants temporary read access to organization_roles in the sanitized clone — expires in 30 minutes.",
+      },
+    },
+    {
+      id: "act4-fix",
+      act: 4,
+      offsetMs: 95_000,
+      title: "Fix verified in the clone",
+      summary: "The agent reproduced the bug, shipped a fix, and flipped the repro from Failed to Passed. Compat and regression checks are green.",
+      overrides: {
+        logLines: [
+          "Repro: Failed → Passed",
+          "Compat check: green",
+          "Regression suite: green",
+        ],
+      },
+      gate: {
+        actionLabel: "Resume Global Rollout",
+        preview: "Ship the fix to the affected tenants first, hold healthy, then continue the global rollout. When the last tenant leaves the old version, the deferred cleanup releases on its own.",
+      },
+    },
+    {
+      id: "act5-recover",
+      act: 5,
+      offsetMs: 130_000,
+      title: "Recovered — cleanup finished itself",
+      summary: "Affected tenants isolated and recovered without rolling back healthy customers. The schema cleanup you'd normally forget just happened, safely, by itself.",
+      overrides: {
+        cellStates: {
+          "cell-atlas": "healthy",
+          "cell-northstar": "healthy",
+          "cell-lumen": "healthy",
+        },
+        edgeHealth: {
+          "e-failover": "healthy",
+        },
+        metrics: [
+          { id: "error-rate", value: 0.4 },
+          { id: "arr-at-risk", value: 0 },
+          { id: "cells-healthy", value: 10 },
+        ],
+        logLines: [
+          "Last tenant reached v1.0.47 · version window closed",
+          "Deferred DROP COLUMN legacy_role released automatically",
+          "Global rollout complete",
+        ],
+      },
+    },
+  ],
+  closingCard: {
+    title: "Incident closed",
+    bullets: [
+      "Affected tenants isolated and recovered without rolling back healthy customers",
+      "Avoided downtime: 47 minutes",
+      "Protected revenue: $184,000 ARR",
+      "Sessions lost: 0 · Re-auths forced: 0",
+    ],
+    avoidedDowntimeMinutes: 47,
+    protectedArrUsd: 184_000,
+  },
+};
+
+export function getIncidentStage(story: ContinuumIncidentStory, elapsedMs: number) {
+  let selected = story.stages[0];
+  for (const stage of story.stages) {
+    if (stage.offsetMs > elapsedMs) break;
+    selected = stage;
+  }
+  return selected;
+}
+
+export function formatIncidentTime(elapsedMs: number): string {
+  const clampedMs = Number.isFinite(elapsedMs) ? Math.max(0, elapsedMs) : 0;
+  const totalSeconds = Math.floor(clampedMs / 1000);
+  const minutes = Math.floor(totalSeconds / 60);
+  const seconds = totalSeconds % 60;
+  return `${minutes}:${seconds.toString().padStart(2, "0")}`;
+}
+
+export function getStageIndex(story: ContinuumIncidentStory, elapsedMs: number): number {
+  const stage = getIncidentStage(story, elapsedMs);
+  return story.stages.findIndex((s) => s.id === stage.id);
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/platform.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/platform.ts
@@ -1,0 +1,98 @@
+import type {
+  PlatformAnalytics,
+  PlatformCron,
+  PlatformDomain,
+  PlatformEnvVar,
+  PlatformFirewallEvent,
+  PlatformFunction,
+  PlatformRuntimeLog,
+  PlatformSpeedInsight,
+  PlatformUsage,
+} from "./types";
+
+export const RUNTIME_LOGS: PlatformRuntimeLog[] = [
+  { id: "rl-1", level: "info", route: "/api/invitations", deployment: "v1.0.47", message: "POST 201 · 42ms", at: "17:41:02" },
+  { id: "rl-2", level: "error", route: "/api/invitations", deployment: "v1.0.47", message: "TypeError: Cannot read properties of null (role_id)", at: "17:41:08" },
+  { id: "rl-3", level: "warn", route: "/api/invitations", deployment: "v1.0.47", message: "Retrying role lookup for org_atlas", at: "17:41:08" },
+  { id: "rl-4", level: "info", route: "/api/auth/session", deployment: "v1.0.46", message: "GET 200 · session resumed after failover", at: "17:42:11" },
+  { id: "rl-5", level: "info", route: "/api/teams", deployment: "v1.0.47", message: "GET 200 · 18ms", at: "17:42:14" },
+];
+
+export const FUNCTIONS: PlatformFunction[] = [
+  { id: "fn-1", name: "api/invitations", kind: "serverless", invocations: 42_800, errors: 612, p99Ms: 1_240, coldStarts: 18 },
+  { id: "fn-2", name: "api/auth/session", kind: "edge", invocations: 210_000, errors: 2, p99Ms: 48, coldStarts: 0 },
+  { id: "fn-3", name: "middleware", kind: "middleware", invocations: 890_000, errors: 0, p99Ms: 12, coldStarts: 0 },
+  { id: "fn-4", name: "api/webhooks/stripe", kind: "serverless", invocations: 8_400, errors: 0, p99Ms: 320, coldStarts: 4 },
+];
+
+export const CRON_JOBS: PlatformCron[] = [
+  { id: "cron-1", name: "purge-expired-invites", schedule: "0 */6 * * *", lastStatus: "ok", lastRunAt: "2026-07-10T12:00:00.000Z" },
+  { id: "cron-2", name: "compat-window-sweeper", schedule: "*/5 * * * *", lastStatus: "ok", lastRunAt: "2026-07-10T17:40:00.000Z" },
+  { id: "cron-3", name: "usage-rollup", schedule: "0 0 * * *", lastStatus: "ok", lastRunAt: "2026-07-10T00:00:00.000Z" },
+];
+
+export const DOMAINS: PlatformDomain[] = [
+  {
+    id: "dom-1",
+    hostname: "app.acme.com",
+    ssl: "active",
+    dns: [
+      { type: "CNAME", name: "app", value: "cname.hexclave.app" },
+      { type: "TXT", name: "_hexclave", value: "hc-verify=…" },
+    ],
+  },
+  {
+    id: "dom-2",
+    hostname: "feat-pricing--acme.hexclave.app",
+    ssl: "active",
+    dns: [{ type: "CNAME", name: "feat-pricing--acme", value: "preview.hexclave.app" }],
+  },
+];
+
+export const ENV_VARS: PlatformEnvVar[] = [
+  { id: "ev-1", key: "DATABASE_URL", environments: ["dev", "preview", "prod"], encrypted: true },
+  { id: "ev-2", key: "HEXCLAVE_SECRET_SERVER_KEY", environments: ["dev", "preview", "prod"], encrypted: true },
+  { id: "ev-3", key: "FEATURE_CUSTOM_ROLES", environments: ["preview", "prod"], encrypted: false, branchOverride: "feat-pricing" },
+  { id: "ev-4", key: "STRIPE_WEBHOOK_SECRET", environments: ["prod"], encrypted: true },
+];
+
+export const FIREWALL_EVENTS: PlatformFirewallEvent[] = [
+  { id: "fw-1", kind: "challenge", count: 1_240, country: "US" },
+  { id: "fw-2", kind: "bot", count: 8_420, country: "CN" },
+  { id: "fw-3", kind: "blocked", count: 312, country: "RU" },
+];
+
+export const WEB_ANALYTICS: PlatformAnalytics = {
+  visitors: 48_200,
+  pageViews: 182_400,
+  topReferrers: [
+    { source: "Direct", views: 62_000 },
+    { source: "docs.acme.com", views: 28_400 },
+    { source: "google", views: 21_200 },
+  ],
+  topCountries: [
+    { country: "United States", views: 98_000 },
+    { country: "Germany", views: 18_400 },
+    { country: "United Kingdom", views: 14_200 },
+  ],
+};
+
+export const SPEED_INSIGHTS: PlatformSpeedInsight[] = [
+  { route: "/", lcp: 1.2, cls: 0.02, inp: 48, score: "good" },
+  { route: "/settings/roles", lcp: 2.8, cls: 0.08, inp: 160, score: "needs-improvement" },
+  { route: "/invitations", lcp: 3.4, cls: 0.12, inp: 280, score: "poor" },
+];
+
+export const USAGE_SPEND: PlatformUsage = {
+  bandwidthGb: 1_840,
+  functionInvocations: 12_400_000,
+  buildMinutes: 420,
+  projectedBillUsd: 1_280,
+  spendCapUsd: 2_500,
+};
+
+export const STORAGE_CARDS = [
+  { id: "kv", title: "KV", subtitle: "Edge key-value · 12 namespaces", metric: "4.2M reads/day" },
+  { id: "blob", title: "Blob", subtitle: "Object storage · 840 GB", metric: "1.1M requests/day" },
+  { id: "edge-config", title: "Edge Config", subtitle: "Feature flags + config", metric: "Tied to rollout stages" },
+] as const;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/releases.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/releases.ts
@@ -1,0 +1,84 @@
+import type { Release } from "./types";
+
+export const RELEASES: Release[] = [
+  {
+    id: "rel-147",
+    version: "v1.0.47",
+    title: "Enterprise Roles Update",
+    status: "draft",
+    commits: [
+      { sha: "a1b2c3d", message: "Add organization_roles table", author: "maya" },
+      { sha: "e4f5g6h", message: "Wire invitations to custom roles", author: "jordan" },
+      { sha: "i7j8k9l", message: "Backfill default admin role", author: "maya" },
+      { sha: "m0n1o2p", message: "Gate custom roles behind flag", author: "sam" },
+      { sha: "q3r4s5t", message: "Fix SSO provisioning null email path", author: "jordan" },
+      { sha: "u6v7w8x", message: "Update invite email copy", author: "priya" },
+      { sha: "y9z0a1b", message: "Add role audit events", author: "maya" },
+      { sha: "c2d3e4f", message: "Compat expand: add role_id nullable", author: "sam" },
+      { sha: "g5h6i7j", message: "Compat expand: dual-write roles", author: "sam" },
+      { sha: "k8l9m0n", message: "Defer drop of legacy_role", author: "sam" },
+      { sha: "o1p2q3r", message: "Dashboard: roles settings page", author: "priya" },
+      { sha: "s4t5u6v", message: "E2E: invite with custom role", author: "jordan" },
+    ],
+    migrationCount: 1,
+    featureFlags: [
+      { id: "ff-custom-roles", name: "custom_roles", description: "Enable custom organization roles" },
+      { id: "ff-role-audit", name: "role_audit_events", description: "Emit audit events for role changes" },
+    ],
+    blastRadiusUsers: 84_000,
+    blastRadiusArrUsd: 1_400_000,
+    versionWindow: { from: "v1.0.46", to: "v1.0.47" },
+    stages: [
+      { id: "stage-1", label: "Internal orgs", segment: "Hexclave Internal", users: 86, orgs: 1, arrUsd: 0, status: "pending", healthGate: "waiting" },
+      { id: "stage-2", label: "20% of free orgs", segment: "Free plan sample", users: 420, orgs: 48, arrUsd: 0, status: "pending", healthGate: "waiting" },
+      { id: "stage-3", label: "Small paid orgs", segment: "Starter + Growth", users: 6_950, orgs: 312, arrUsd: 38_000, status: "pending", healthGate: "waiting" },
+      { id: "stage-4", label: "Enterprise without custom roles", segment: "Enterprise (default roles)", users: 18_200, orgs: 14, arrUsd: 420_000, status: "pending", healthGate: "waiting" },
+      { id: "stage-5", label: "Everyone", segment: "All remaining tenants", users: 58_344, orgs: 1_840, arrUsd: 942_000, status: "pending", healthGate: "waiting" },
+    ],
+    buildLog: [
+      { id: "bl-1", step: "install", text: "Detected Next.js 15.2 · using cached node_modules", delayMs: 200, level: "info" },
+      { id: "bl-2", step: "install", text: "pnpm install — 0 added, cache hit", delayMs: 400, level: "success" },
+      { id: "bl-3", step: "check", text: "Running lint + typecheck gates…", delayMs: 300, level: "info" },
+      { id: "bl-4", step: "check", text: "Checks passed (12s)", delayMs: 500, level: "success" },
+      { id: "bl-5", step: "build", text: "Compiling application…", delayMs: 400, level: "info" },
+      { id: "bl-6", step: "build", text: "Collecting page data · 48 routes", delayMs: 600, level: "info" },
+      { id: "bl-7", step: "build", text: "Build complete · 41.2 MB output", delayMs: 500, level: "success" },
+      { id: "bl-8", step: "deploy", text: "Uploading build artifacts…", delayMs: 400, level: "info" },
+      { id: "bl-9", step: "deploy", text: "Skew protection enabled for v1.0.46 ↔ v1.0.47", delayMs: 300, level: "info" },
+      { id: "bl-10", step: "deploy", text: "Ready — awaiting rollout start", delayMs: 200, level: "success" },
+    ],
+    framework: "Next.js",
+    connectedRepo: "acme/app · main",
+  },
+  {
+    id: "rel-146",
+    version: "v1.0.46",
+    title: "Invite reliability",
+    status: "complete",
+    commits: [
+      { sha: "prev001", message: "Retry invite email delivery", author: "priya" },
+      { sha: "prev002", message: "Harden SSO null-email path", author: "jordan" },
+    ],
+    migrationCount: 0,
+    featureFlags: [],
+    blastRadiusUsers: 84_000,
+    blastRadiusArrUsd: 1_400_000,
+    versionWindow: { from: "v1.0.46", to: "v1.0.46" },
+    stages: [
+      { id: "s146-1", label: "Everyone", segment: "All tenants", users: 84_000, orgs: 2_215, arrUsd: 1_400_000, status: "complete", healthGate: "passing" },
+    ],
+    buildLog: [],
+    framework: "Next.js",
+    connectedRepo: "acme/app · main",
+  },
+];
+
+export function releaseById(id: string): Release {
+  const release = RELEASES.find((r) => r.id === id);
+  if (release == null) {
+    throw new Error(`Unknown release id: ${id}`);
+  }
+  return release;
+}
+
+export const ACTIVE_RELEASE_ID = "rel-147";

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/tenants.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/tenants.ts
@@ -1,0 +1,165 @@
+import type { Tenant, TenantCell } from "./types";
+
+export const TENANTS: Tenant[] = [
+  { id: "t-atlas", name: "Atlas Health", plan: "enterprise", arrUsd: 84_000, userCount: 12_400, residency: "US" },
+  { id: "t-northstar", name: "Northstar Legal", plan: "enterprise", arrUsd: 62_000, userCount: 8_200, residency: "US" },
+  { id: "t-lumen", name: "Lumen Finance", plan: "enterprise", arrUsd: 38_000, userCount: 5_100, residency: "EU" },
+  { id: "t-bright", name: "Brightpath Schools", plan: "growth", arrUsd: 18_400, userCount: 3_200, residency: "US" },
+  { id: "t-orbit", name: "Orbit Retail", plan: "growth", arrUsd: 12_200, userCount: 2_800, residency: "US" },
+  { id: "t-cascade", name: "Cascade Labs", plan: "starter", arrUsd: 4_800, userCount: 640, residency: "US" },
+  { id: "t-pine", name: "Pine & Co", plan: "starter", arrUsd: 2_400, userCount: 310, residency: "CA" },
+  { id: "t-free-1", name: "Hobby Desk", plan: "free", arrUsd: 0, userCount: 12, residency: "US" },
+  { id: "t-free-2", name: "Weekend Builders", plan: "free", arrUsd: 0, userCount: 8, residency: "EU" },
+  { id: "t-internal", name: "Hexclave Internal", plan: "enterprise", arrUsd: 0, userCount: 86, residency: "US" },
+];
+
+export const CELLS: TenantCell[] = [
+  {
+    id: "cell-atlas",
+    tenantId: "t-atlas",
+    state: "healthy",
+    releaseVersion: "v1.0.46",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "warm-standby", standbyProvider: "GCP", standbyRegion: "us-central", rpoSeconds: 5, rtoSeconds: 30 },
+    replicationLagMs: 42,
+    lastHealthyAt: "2026-07-10T17:40:00.000Z",
+  },
+  {
+    id: "cell-northstar",
+    tenantId: "t-northstar",
+    state: "healthy",
+    releaseVersion: "v1.0.46",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "warm-standby", standbyProvider: "Azure", standbyRegion: "eastus", rpoSeconds: 5, rtoSeconds: 45 },
+    replicationLagMs: 38,
+    lastHealthyAt: "2026-07-10T17:40:00.000Z",
+  },
+  {
+    id: "cell-lumen",
+    tenantId: "t-lumen",
+    state: "healthy",
+    releaseVersion: "v1.0.46",
+    dbBranchId: "db-prod-eu",
+    regionId: "eu-west",
+    provider: "AWS",
+    recovery: { mode: "warm-standby", standbyProvider: "GCP", standbyRegion: "europe-west", rpoSeconds: 8, rtoSeconds: 40 },
+    replicationLagMs: 55,
+    lastHealthyAt: "2026-07-10T17:39:00.000Z",
+  },
+  {
+    id: "cell-bright",
+    tenantId: "t-bright",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "us-west",
+    provider: "GCP",
+    recovery: { mode: "cold", standbyProvider: "AWS", standbyRegion: "us-west", rpoSeconds: 300, rtoSeconds: 900 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:41:00.000Z",
+  },
+  {
+    id: "cell-orbit",
+    tenantId: "t-orbit",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "cold", standbyProvider: "AWS", standbyRegion: "us-west", rpoSeconds: 300, rtoSeconds: 900 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:41:00.000Z",
+  },
+  {
+    id: "cell-cascade",
+    tenantId: "t-cascade",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "cold", standbyProvider: "AWS", standbyRegion: "us-east", rpoSeconds: 600, rtoSeconds: 1_800 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:41:00.000Z",
+  },
+  {
+    id: "cell-pine",
+    tenantId: "t-pine",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "ca-central",
+    provider: "Azure",
+    recovery: { mode: "cold", standbyProvider: "Azure", standbyRegion: "canadaeast", rpoSeconds: 600, rtoSeconds: 1_800 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:40:00.000Z",
+  },
+  {
+    id: "cell-free-1",
+    tenantId: "t-free-1",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "cold", standbyProvider: "AWS", standbyRegion: "us-east", rpoSeconds: 3_600, rtoSeconds: 7_200 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:41:00.000Z",
+  },
+  {
+    id: "cell-free-2",
+    tenantId: "t-free-2",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod-eu",
+    regionId: "eu-west",
+    provider: "AWS",
+    recovery: { mode: "cold", standbyProvider: "AWS", standbyRegion: "eu-west", rpoSeconds: 3_600, rtoSeconds: 7_200 },
+    replicationLagMs: 0,
+    lastHealthyAt: "2026-07-10T17:41:00.000Z",
+  },
+  {
+    id: "cell-internal",
+    tenantId: "t-internal",
+    state: "healthy",
+    releaseVersion: "v1.0.47",
+    dbBranchId: "db-prod",
+    regionId: "us-east",
+    provider: "AWS",
+    recovery: { mode: "active-active", standbyProvider: "GCP", standbyRegion: "us-central", rpoSeconds: 0, rtoSeconds: 0 },
+    replicationLagMs: 12,
+    lastHealthyAt: "2026-07-10T17:42:00.000Z",
+  },
+];
+
+export function tenantById(id: string): Tenant {
+  const tenant = TENANTS.find((t) => t.id === id);
+  if (tenant == null) {
+    throw new Error(`Unknown tenant id: ${id}`);
+  }
+  return tenant;
+}
+
+export function cellById(id: string): TenantCell {
+  const cell = CELLS.find((c) => c.id === id);
+  if (cell == null) {
+    throw new Error(`Unknown cell id: ${id}`);
+  }
+  return cell;
+}
+
+export function cellsWithTenants() {
+  return CELLS.map((cell) => ({ cell, tenant: tenantById(cell.tenantId) }));
+}
+
+export const OVERVIEW_METRICS = {
+  revenueExposedUsd: 184_000,
+  cellsHealthy: 10,
+  cellsTotal: 10,
+  recoveryFreshnessSeconds: 42,
+  activeVersionWindow: { from: "v1.0.46", to: "v1.0.47" },
+} as const;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/topology.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/topology.ts
@@ -1,0 +1,53 @@
+import type { ContinuumMapEdge, ContinuumMapNode, ContinuumRegion } from "./types";
+
+export const REGIONS: ContinuumRegion[] = [
+  { id: "us-east", label: "US East", provider: "AWS", x: 210, y: 150 },
+  { id: "us-west", label: "US West", provider: "GCP", x: 140, y: 160 },
+  { id: "us-central", label: "US Central", provider: "GCP", x: 175, y: 155 },
+  { id: "eu-west", label: "EU West", provider: "AWS", x: 400, y: 125 },
+  { id: "ca-central", label: "Canada", provider: "Azure", x: 200, y: 110 },
+  { id: "eastus", label: "Azure East", provider: "Azure", x: 225, y: 145 },
+];
+
+/** Block size used by the HTML canvas nodes. Positions are block centers. */
+export const NODE_SIZE = { width: 188, height: 78 } as const;
+
+/**
+ * Railway/n8n-style layout: customers across the top, cells under them,
+ * shared release + database in the middle, clouds along the bottom.
+ */
+export const MAP_NODES: ContinuumMapNode[] = [
+  { id: "n-atlas", label: "Atlas Health", kind: "customer", x: 160, y: 90, health: "healthy", subtitle: "$84k ARR" },
+  { id: "n-northstar", label: "Northstar Legal", kind: "customer", x: 420, y: 90, health: "healthy", subtitle: "$62k ARR" },
+  { id: "n-lumen", label: "Lumen Finance", kind: "customer", x: 680, y: 90, health: "healthy", subtitle: "$38k ARR" },
+  { id: "n-cell-atlas", label: "Atlas cell", kind: "cell", x: 160, y: 230, health: "healthy", subtitle: "v1.0.46 · AWS" },
+  { id: "n-cell-northstar", label: "Northstar cell", kind: "cell", x: 420, y: 230, health: "healthy", subtitle: "v1.0.46 · AWS" },
+  { id: "n-cell-lumen", label: "Lumen cell", kind: "cell", x: 680, y: 230, health: "healthy", subtitle: "v1.0.46 · AWS" },
+  { id: "n-release", label: "v1.0.47", kind: "release", x: 420, y: 380, health: "healthy", subtitle: "Enterprise Roles" },
+  { id: "n-db", label: "Production DB", kind: "database", x: 420, y: 520, health: "healthy", subtitle: "both versions ok" },
+  { id: "n-aws", label: "AWS", kind: "provider", x: 200, y: 660, health: "healthy", subtitle: "us-east" },
+  { id: "n-gcp", label: "GCP", kind: "provider", x: 420, y: 660, health: "healthy", subtitle: "us-central" },
+  { id: "n-azure", label: "Azure", kind: "provider", x: 640, y: 660, health: "healthy", subtitle: "eastus" },
+];
+
+export const MAP_EDGES: ContinuumMapEdge[] = [
+  { id: "e-atlas-cell", source: "n-atlas", target: "n-cell-atlas", kind: "traffic", health: "healthy" },
+  { id: "e-ns-cell", source: "n-northstar", target: "n-cell-northstar", kind: "traffic", health: "healthy" },
+  { id: "e-lumen-cell", source: "n-lumen", target: "n-cell-lumen", kind: "traffic", health: "healthy" },
+  { id: "e-cell-a-rel", source: "n-cell-atlas", target: "n-release", kind: "traffic", health: "healthy" },
+  { id: "e-cell-n-rel", source: "n-cell-northstar", target: "n-release", kind: "traffic", health: "healthy" },
+  { id: "e-cell-l-rel", source: "n-cell-lumen", target: "n-release", kind: "traffic", health: "healthy" },
+  { id: "e-rel-db", source: "n-release", target: "n-db", kind: "traffic", health: "healthy" },
+  { id: "e-db-aws", source: "n-db", target: "n-aws", kind: "replication", health: "healthy", label: "primary" },
+  { id: "e-db-gcp", source: "n-db", target: "n-gcp", kind: "replication", health: "healthy", label: "standby" },
+  { id: "e-failover", source: "n-cell-atlas", target: "n-gcp", kind: "failover", health: "healthy", label: "warm standby" },
+];
+
+export const VIEWBOX = { width: 860, height: 760 } as const;
+
+export const CANVAS_BRANCHES = [
+  { id: "production", label: "production" },
+  { id: "feat-pricing", label: "feat-pricing" },
+  { id: "dev/maya", label: "dev/maya" },
+  { id: "clone/5gb-sample", label: "clone/5gb-sample" },
+] as const;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/types.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/fixtures/types.ts
@@ -1,0 +1,344 @@
+export type PlanTier = "free" | "starter" | "growth" | "enterprise";
+
+export type CellState =
+  | "healthy"
+  | "deploying"
+  | "degraded"
+  | "isolating"
+  | "failing_over"
+  | "protected"
+  | "recovering"
+  | "pinned";
+
+export type Tenant = {
+  id: string,
+  name: string,
+  plan: PlanTier,
+  arrUsd: number,
+  userCount: number,
+  residency: string,
+};
+
+export type RecoveryPolicy = {
+  mode: "warm-standby" | "cold" | "active-active",
+  standbyProvider: string,
+  standbyRegion: string,
+  rpoSeconds: number,
+  rtoSeconds: number,
+};
+
+export type TenantCell = {
+  id: string,
+  tenantId: string,
+  state: CellState,
+  releaseVersion: string,
+  dbBranchId: string,
+  regionId: string,
+  provider: string,
+  recovery: RecoveryPolicy,
+  replicationLagMs: number,
+  lastHealthyAt: string,
+};
+
+export type RolloutStageStatus = "pending" | "running" | "healthy" | "paused" | "skipped" | "complete";
+
+export type RolloutStage = {
+  id: string,
+  label: string,
+  segment: string,
+  users: number,
+  orgs: number,
+  arrUsd: number,
+  status: RolloutStageStatus,
+  healthGate: "waiting" | "passing" | "failing" | "blocked",
+};
+
+export type ReleaseCommit = {
+  sha: string,
+  message: string,
+  author: string,
+};
+
+export type FeatureFlag = {
+  id: string,
+  name: string,
+  description: string,
+};
+
+export type Release = {
+  id: string,
+  version: string,
+  title: string,
+  status: "draft" | "rolling_out" | "paused" | "complete" | "rolled_back",
+  commits: ReleaseCommit[],
+  migrationCount: number,
+  featureFlags: FeatureFlag[],
+  blastRadiusUsers: number,
+  blastRadiusArrUsd: number,
+  versionWindow: { from: string, to: string },
+  stages: RolloutStage[],
+  buildLog: BuildLogLine[],
+  framework: "Next.js" | "Vite" | "Remix",
+  connectedRepo: string,
+};
+
+export type BuildLogLine = {
+  id: string,
+  step: "install" | "build" | "deploy" | "check",
+  text: string,
+  delayMs: number,
+  level?: "info" | "success" | "warn",
+};
+
+export type SensitiveKind = "email" | "name" | "phone" | "freetext" | "ssn" | "address";
+
+export type SchemaColumn = {
+  name: string,
+  type: string,
+  nullable: boolean,
+  sensitive?: { kind: SensitiveKind },
+};
+
+export type SchemaTable = {
+  name: string,
+  columns: SchemaColumn[],
+};
+
+export type DbBranch = {
+  id: string,
+  name: string,
+  parentId: string | null,
+  kind: "production" | "preview" | "dev" | "forensic" | "clone",
+  releaseVersion?: string,
+  previewUrl?: string,
+  sizeGb: number,
+  createdAt: string,
+};
+
+export type MigrationStepKind = "expand" | "contract";
+
+export type MigrationStep = {
+  id: string,
+  kind: MigrationStepKind,
+  sql: string,
+  plainLabel: string,
+  heldBy?: string,
+  status: "applied" | "queued" | "deferred" | "released",
+};
+
+export type BlastRadius = {
+  nullRows: number,
+  orgsAffected: number,
+  enterpriseOrgs: number,
+  arrUsd: number,
+  plainSummary: string,
+  predictedOutcome: string,
+  recommendedSequence: string[],
+};
+
+export type Migration = {
+  id: string,
+  releaseVersion: string,
+  orm: "prisma" | "drizzle",
+  title: string,
+  steps: MigrationStep[],
+  beforeDiff: string,
+  afterDiff: string,
+  blastRadius: BlastRadius,
+  lockWarning?: string,
+};
+
+export type CompatVerdict = "green" | "amber" | "red";
+
+export type CompatMatrix = {
+  versions: string[],
+  schemaStates: string[],
+  cells: CompatVerdict[][],
+  activeWindow: { from: string, to: string },
+  headline: string,
+};
+
+export type ClonePreset = {
+  id: string,
+  targetSizeLabel: string,
+  targetSizeGb: number,
+  orgsPreserved: number,
+  enterpriseOrgs: number,
+  coverageNotes: string[],
+  redactionReport: { field: string, kind: SensitiveKind, example: string }[],
+};
+
+export type DbReplicaRole = "primary" | "sync-replica" | "async-replica" | "standby";
+
+export type DbReplica = {
+  id: string,
+  role: DbReplicaRole,
+  provider: string,
+  region: string,
+  lagMs: number,
+  state: "live" | "catching-up" | "paused",
+  promotable: boolean,
+};
+
+export type DbPointInTimeRecovery = {
+  retentionDays: number,
+  oldestRestorePoint: string,
+  lastSnapshotAt: string,
+  walArchiveLagSeconds: number,
+};
+
+export type SlowQuery = {
+  id: string,
+  sql: string,
+  p95Ms: number,
+  callsPerMin: number,
+  suggestedIndex: string,
+  plainHint: string,
+};
+
+export type ContinuumRegion = {
+  id: string,
+  label: string,
+  provider: string,
+  x: number,
+  y: number,
+};
+
+export type ContinuumMapEdge = {
+  id: string,
+  source: string,
+  target: string,
+  kind: "traffic" | "replication" | "failover",
+  health: "healthy" | "degraded" | "critical" | "active",
+  label?: string,
+};
+
+export type ContinuumMapNode = {
+  id: string,
+  label: string,
+  kind: "customer" | "cell" | "release" | "database" | "region" | "provider",
+  x: number,
+  y: number,
+  health: "healthy" | "degraded" | "critical" | "protected" | "pinned",
+  subtitle?: string,
+};
+
+export type IncidentGate = {
+  actionLabel: string,
+  preview: string,
+};
+
+export type IncidentStageOverride = {
+  cellStates?: Partial<Record<string, CellState>>,
+  edgeHealth?: Partial<Record<string, ContinuumMapEdge["health"]>>,
+  metrics?: { id: string, value: number }[],
+  logLines?: string[],
+};
+
+export type ContinuumIncidentStage = {
+  id: string,
+  act: 1 | 2 | 3 | 4 | 5,
+  offsetMs: number,
+  title: string,
+  summary: string,
+  overrides: IncidentStageOverride,
+  gate?: IncidentGate,
+};
+
+export type ContinuumIncidentStory = {
+  id: string,
+  title: string,
+  durationMs: number,
+  stages: ContinuumIncidentStage[],
+  closingCard: {
+    title: string,
+    bullets: string[],
+    avoidedDowntimeMinutes: number,
+    protectedArrUsd: number,
+  },
+};
+
+export type CopilotTurn = {
+  id: string,
+  role: "agent" | "system",
+  text: string,
+  delayMs: number,
+  approval?: {
+    id: string,
+    title: string,
+    detail: string,
+    expiresInMinutes: number,
+  },
+};
+
+export type PlatformRuntimeLog = {
+  id: string,
+  level: "info" | "warn" | "error",
+  route: string,
+  deployment: string,
+  message: string,
+  at: string,
+};
+
+export type PlatformFunction = {
+  id: string,
+  name: string,
+  kind: "serverless" | "edge" | "middleware",
+  invocations: number,
+  errors: number,
+  p99Ms: number,
+  coldStarts: number,
+};
+
+export type PlatformCron = {
+  id: string,
+  name: string,
+  schedule: string,
+  lastStatus: "ok" | "failed" | "skipped",
+  lastRunAt: string,
+};
+
+export type PlatformDomain = {
+  id: string,
+  hostname: string,
+  ssl: "active" | "pending",
+  dns: { type: string, name: string, value: string }[],
+};
+
+export type PlatformEnvVar = {
+  id: string,
+  key: string,
+  environments: ("dev" | "preview" | "prod")[],
+  encrypted: boolean,
+  branchOverride?: string,
+};
+
+export type PlatformFirewallEvent = {
+  id: string,
+  kind: "challenge" | "bot" | "blocked",
+  count: number,
+  country: string,
+};
+
+export type PlatformAnalytics = {
+  visitors: number,
+  pageViews: number,
+  topReferrers: { source: string, views: number }[],
+  topCountries: { country: string, views: number }[],
+};
+
+export type PlatformSpeedInsight = {
+  route: string,
+  lcp: number,
+  cls: number,
+  inp: number,
+  score: "good" | "needs-improvement" | "poor",
+};
+
+export type PlatformUsage = {
+  bandwidthGb: number,
+  functionInvocations: number,
+  buildMinutes: number,
+  projectedBillUsd: number,
+  spendCapUsd: number,
+};

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/incident/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/incident/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function Page(props: { params: Promise<{ projectId: string }> }) {
+  const params = await props.params;
+  redirect(`/projects/${encodeURIComponent(params.projectId)}/continuum`);
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/overview/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/overview/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function Page(props: { params: Promise<{ projectId: string }> }) {
+  const params = await props.params;
+  redirect(`/projects/${encodeURIComponent(params.projectId)}/continuum`);
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/page-client.tsx
@@ -1,0 +1,359 @@
+"use client";
+
+import { DesignButton } from "@/components/design-components";
+import {
+  Sheet,
+  SheetContent,
+  SheetDescription,
+  SheetHeader,
+  SheetTitle,
+} from "@/components/ui/sheet";
+import { DatabaseIcon, PlayIcon, RocketLaunchIcon, WarningCircleIcon } from "@phosphor-icons/react";
+import { useMemo, useState } from "react";
+import { AppEnabledGuard } from "../app-enabled-guard";
+import { PageLayout } from "../page-layout";
+import { ContinuumMap } from "./components/continuum-map";
+import { DatabaseWorkspace } from "./components/database-workspace";
+import { IncidentScrubber } from "./components/incident-scrubber";
+import { NodeInspector } from "./components/node-inspector";
+import { ProtectChecklist } from "./components/protect-checklist";
+import { ReleaseCockpit } from "./components/release-cockpit";
+import { ClosingBriefing } from "./components/closing-briefing";
+import { ForensicCloneLab } from "./components/forensic-clone-lab";
+import { CxChip } from "./components/ui-kit";
+import {
+  patchContinuumState,
+  resetContinuumState,
+  setCellState,
+  setIncidentBanner,
+} from "./continuum-store";
+import { CANVAS_BRANCHES, MAP_NODES } from "./fixtures/topology";
+import { CELLS, OVERVIEW_METRICS } from "./fixtures/tenants";
+import { ACTIVE_RELEASE_ID, releaseById } from "./fixtures/releases";
+import type { CellState, ContinuumMapNode } from "./fixtures/types";
+import { useContinuumStore, useIncidentPlayback } from "./use-incident-playback";
+
+type WorkspaceSheet = "deployments" | "incident" | "database" | null;
+
+function formatCurrency(value: number): string {
+  if (value === 0) return "$0";
+  if (value >= 1_000) return `$${Math.round(value / 1_000)}k`;
+  return `$${value}`;
+}
+
+function mapCellStateToNodeHealth(state: CellState): string {
+  switch (state) {
+    case "degraded": {
+      return "degraded";
+    }
+    case "protected":
+    case "isolating":
+    case "failing_over":
+    case "recovering": {
+      return "protected";
+    }
+    case "pinned": {
+      return "pinned";
+    }
+    case "healthy":
+    case "deploying": {
+      return "healthy";
+    }
+    default: {
+      const exhaustiveState: never = state;
+      return exhaustiveState;
+    }
+  }
+}
+
+export default function PageClient() {
+  const continuumState = useContinuumStore();
+  const playback = useIncidentPlayback();
+  const [selectedNodeId, setSelectedNodeId] = useState<string | null>(null);
+  const [branchId, setBranchId] = useState<string>(CANVAS_BRANCHES[0].id);
+  const [sheet, setSheet] = useState<WorkspaceSheet>(null);
+  const [cloneLabOpen, setCloneLabOpen] = useState(false);
+  const [agentAccessApproved, setAgentAccessApproved] = useState(false);
+
+  const healthyCells = CELLS.filter((cell) => {
+    const state = continuumState.cellStates.get(cell.id) ?? cell.state;
+    return state === "healthy" || state === "pinned" || state === "protected";
+  }).length;
+
+  const nodeHealthOverrides = useMemo(() => {
+    const fromStore = Array.from(continuumState.cellStates, ([cellId, state]) => [
+      `n-${cellId}`,
+      mapCellStateToNodeHealth(state),
+    ] as const);
+
+    // Incident stage overrides win while the incident sheet is open / active
+    const fromIncident = playback.activeStage.overrides.cellStates;
+    const incidentEntries: [string, string][] = [];
+    if (fromIncident != null) {
+      for (const [cellId, cellState] of Object.entries(fromIncident)) {
+        if (cellState == null) continue;
+        incidentEntries.push([`n-${cellId}`, mapCellStateToNodeHealth(cellState)]);
+      }
+    }
+    return new Map([...fromStore, ...incidentEntries]);
+  }, [continuumState.cellStates, playback.activeStage]);
+
+  const edgeHealthOverrides = useMemo(() => {
+    const edgeOverrides = playback.activeStage.overrides.edgeHealth;
+    if (edgeOverrides == null) return undefined;
+    return new Map(
+      Object.entries(edgeOverrides).flatMap(([edgeId, health]) =>
+        health == null ? [] : [[edgeId, health] as const],
+      ),
+    );
+  }, [playback.activeStage]);
+
+  const selectedNode: ContinuumMapNode | null = useMemo(() => {
+    if (selectedNodeId == null) return null;
+    return MAP_NODES.find((node) => node.id === selectedNodeId) ?? null;
+  }, [selectedNodeId]);
+
+  const cellStateOverrides = useMemo(() => {
+    return new Map(Array.from(continuumState.cellStates, ([id, state]) => [id, state]));
+  }, [continuumState.cellStates]);
+
+  const release = {
+    ...releaseById(ACTIVE_RELEASE_ID),
+    status: continuumState.releaseStatus,
+  };
+
+  const {
+    story,
+    elapsedMs,
+    isPlaying,
+    activeStage,
+    waitingOnGate,
+    clearedGates,
+    formatTime,
+    setElapsedMs,
+    setIsPlaying,
+    clearGate,
+  } = playback;
+
+  const lastStage = story.stages.at(-1);
+  if (lastStage == null) throw new Error("Incident story requires stages.");
+  const protectionActive = activeStage.act >= 3 && clearedGates.has("act2-break");
+  const showClosingBriefing = elapsedMs >= lastStage.offsetMs;
+
+  const handleGateAction = () => {
+    switch (activeStage.id) {
+      case "act1-ready": {
+        setIncidentBanner("v1.0.47 is rolling out to internal and free organizations first.");
+        setCellState("cell-internal", "deploying");
+        setCellState("cell-free-1", "deploying");
+        setCellState("cell-free-2", "deploying");
+        patchContinuumState((previous) => {
+          const stageStatuses = new Map(previous.stageStatuses);
+          stageStatuses.set("stage-1", "healthy");
+          stageStatuses.set("stage-2", "running");
+          return { ...previous, releaseStatus: "rolling_out", stageStatuses };
+        });
+        clearGate("act1-ready");
+        return;
+      }
+      case "act2-break": {
+        setCellState("cell-atlas", "pinned");
+        setCellState("cell-northstar", "protected");
+        setCellState("cell-lumen", "protected");
+        setIncidentBanner("3 of your biggest customers are protected — $184,000 ARR is no longer at risk.");
+        patchContinuumState((previous) => ({
+          ...previous,
+          releaseStatus: "paused",
+          pinnedVersions: new Map([
+            ...previous.pinnedVersions,
+            ["cell-atlas", "v1.0.46"],
+            ["cell-northstar", "v1.0.46"],
+            ["cell-lumen", "v1.0.46"],
+          ]),
+        }));
+        clearGate("act2-break");
+        return;
+      }
+      case "act3-protect": {
+        patchContinuumState({ forensicCloneReady: true });
+        setCloneLabOpen(true);
+        clearGate("act3-protect");
+        return;
+      }
+      case "act4-clone": {
+        setCloneLabOpen(true);
+        return;
+      }
+      case "act4-fix": {
+        setCellState("cell-atlas", "healthy");
+        setCellState("cell-northstar", "healthy");
+        setCellState("cell-lumen", "healthy");
+        setIncidentBanner("All customers healthy on v1.0.47. Deferred cleanup released.");
+        patchContinuumState({ releaseStatus: "complete", deferredReleased: true });
+        clearGate("act4-fix");
+        return;
+      }
+      default: {
+        throw new Error(`No gate action for "${activeStage.id}".`);
+      }
+    }
+  };
+
+  return (
+    <AppEnabledGuard appId="continuum">
+      <PageLayout fillWidth noPadding containedHeight>
+        <div className="flex min-h-0 flex-1 flex-col">
+          {/* Railway-style top bar */}
+          <div className="flex shrink-0 items-center justify-between gap-3 border-b border-black/[0.08] bg-background/80 px-4 py-2.5 backdrop-blur-md dark:border-white/[0.08]">
+            <div className="flex min-w-0 items-center gap-3">
+              <div>
+                <p className="text-[13px] font-semibold tracking-tight">Continuum</p>
+                <p className="text-[11px] text-muted-foreground">
+                  {formatCurrency(OVERVIEW_METRICS.revenueExposedUsd)} exposed · {healthyCells}/{OVERVIEW_METRICS.cellsTotal} healthy · {OVERVIEW_METRICS.recoveryFreshnessSeconds}s recovery
+                </p>
+              </div>
+              {continuumState.incidentBanner != null && (
+                <CxChip tone="warn">Incident active</CxChip>
+              )}
+            </div>
+            <div className="flex shrink-0 items-center gap-2">
+              <DesignButton
+                size="sm"
+                variant={sheet === "deployments" ? "default" : "outline"}
+                onClick={() => setSheet(sheet === "deployments" ? null : "deployments")}
+              >
+                <RocketLaunchIcon className="mr-1.5 size-3.5" />
+                Deployments
+              </DesignButton>
+              <DesignButton
+                size="sm"
+                variant={sheet === "database" ? "default" : "outline"}
+                onClick={() => setSheet(sheet === "database" ? null : "database")}
+              >
+                <DatabaseIcon className="mr-1.5 size-3.5" />
+                Database
+              </DesignButton>
+              <DesignButton
+                size="sm"
+                variant={sheet === "incident" ? "default" : "outline"}
+                onClick={() => setSheet(sheet === "incident" ? null : "incident")}
+              >
+                <WarningCircleIcon className="mr-1.5 size-3.5" />
+                Incident
+              </DesignButton>
+            </div>
+          </div>
+
+          {continuumState.incidentBanner != null && (
+            <div className="shrink-0 border-b border-amber-500/20 bg-amber-500/[0.08] px-4 py-2 text-[12px] text-amber-950 dark:text-amber-100">
+              {continuumState.incidentBanner}
+            </div>
+          )}
+
+          <div className="min-h-0 flex-1 p-3">
+            <ContinuumMap
+              nodeHealthOverrides={nodeHealthOverrides}
+              edgeHealthOverrides={edgeHealthOverrides}
+              selectedNodeId={selectedNodeId}
+              onSelectNode={(id) => {
+                const node = MAP_NODES.find((candidate) => candidate.id === id);
+                // Database nodes get the full workspace sheet (replication, branches,
+                // compat, safe copies) instead of the compact inspector.
+                if (node?.kind === "database") {
+                  setSelectedNodeId(null);
+                  setSheet("database");
+                  return;
+                }
+                setSelectedNodeId(id);
+                setSheet(null);
+              }}
+              branchId={branchId}
+              onBranchChange={setBranchId}
+            />
+          </div>
+        </div>
+
+        <NodeInspector
+          node={selectedNode}
+          onClose={() => setSelectedNodeId(null)}
+          cellStateOverrides={cellStateOverrides}
+        />
+
+        {/* Deployments sheet — same page, not a route */}
+        <Sheet open={sheet === "deployments"} onOpenChange={(open) => setSheet(open ? "deployments" : null)}>
+          <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-xl" hasCloseButton>
+            <SheetHeader className="space-y-1 border-b border-black/[0.08] px-5 py-4 text-left dark:border-white/[0.08]">
+              <SheetTitle className="text-base">Deployments</SheetTitle>
+              <SheetDescription className="text-xs">
+                Roll out by customer segment. Pin one tenant without rolling everyone back.
+              </SheetDescription>
+            </SheetHeader>
+            <div className="min-h-0 flex-1 overflow-y-auto p-4">
+              <ReleaseCockpit release={release} paused={release.status === "paused"} />
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        {/* Database workspace — replication, branches, compat, safe copies, schema, queries */}
+        <DatabaseWorkspace
+          open={sheet === "database"}
+          onOpenChange={(open) => setSheet(open ? "database" : null)}
+        />
+
+        {/* Incident sheet — gated playback lives here */}
+        <Sheet open={sheet === "incident"} onOpenChange={(open) => setSheet(open ? "incident" : null)}>
+          <SheetContent side="right" className="flex w-full flex-col gap-0 overflow-hidden p-0 sm:max-w-xl" hasCloseButton>
+            <SheetHeader className="space-y-1 border-b border-black/[0.08] px-5 py-4 text-left dark:border-white/[0.08]">
+              <SheetTitle className="text-base">Incident</SheetTitle>
+              <SheetDescription className="text-xs">{activeStage.summary}</SheetDescription>
+            </SheetHeader>
+            <div className="min-h-0 flex-1 space-y-3 overflow-y-auto p-4">
+              <IncidentScrubber
+                story={story}
+                elapsedMs={elapsedMs}
+                isPlaying={isPlaying}
+                waitingOnGate={waitingOnGate}
+                activeStageId={activeStage.id}
+                formatTime={formatTime}
+                onElapsedChange={setElapsedMs}
+                onPlayingChange={setIsPlaying}
+                onRestart={() => {
+                  playback.restart();
+                  resetContinuumState();
+                  setCloneLabOpen(false);
+                  setAgentAccessApproved(false);
+                }}
+              />
+
+              {waitingOnGate && activeStage.gate != null && (
+                <div className="rounded-lg border border-black/[0.08] p-4 dark:border-white/[0.08]">
+                  <p className="text-[13px] font-medium">{activeStage.gate.actionLabel}</p>
+                  <p className="mt-1 text-[12px] leading-5 text-muted-foreground">{activeStage.gate.preview}</p>
+                  <DesignButton size="sm" className="mt-3" onClick={handleGateAction}>
+                    <PlayIcon className="mr-1.5 size-3.5" />
+                    {activeStage.gate.actionLabel}
+                  </DesignButton>
+                </div>
+              )}
+
+              <ProtectChecklist active={protectionActive} />
+              {showClosingBriefing && <ClosingBriefing closingCard={story.closingCard} />}
+            </div>
+          </SheetContent>
+        </Sheet>
+
+        <ForensicCloneLab
+          open={cloneLabOpen}
+          onOpenChange={setCloneLabOpen}
+          cloneReady={continuumState.forensicCloneReady}
+          waitingOnApproval={waitingOnGate && activeStage.id === "act4-clone"}
+          approved={agentAccessApproved}
+          onApprove={() => {
+            setAgentAccessApproved(true);
+            clearGate("act4-clone");
+          }}
+        />
+      </PageLayout>
+    </AppEnabledGuard>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/page.tsx
@@ -1,0 +1,9 @@
+import PageClient from "./page-client";
+
+export const metadata = {
+  title: "Continuum",
+};
+
+export default function Page() {
+  return <PageClient />;
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/releases/page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/releases/page.tsx
@@ -1,0 +1,6 @@
+import { redirect } from "next/navigation";
+
+export default async function Page(props: { params: Promise<{ projectId: string }> }) {
+  const params = await props.params;
+  redirect(`/projects/${encodeURIComponent(params.projectId)}/continuum`);
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/use-demo-scripts.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/use-demo-scripts.ts
@@ -1,0 +1,81 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState } from "react";
+
+export type ScriptStep =
+  | { kind: "wait", ms: number }
+  | { kind: "line", text: string, level?: "info" | "success" | "warn" }
+  | { kind: "progress", id: string, label: string, status: "running" | "done" };
+
+export type DemoScriptState = {
+  lines: { id: string, text: string, level: "info" | "success" | "warn" }[],
+  progress: Map<string, { label: string, status: "running" | "done" }>,
+  finished: boolean,
+};
+
+export function useDemoScript(steps: ScriptStep[], autoStart = false) {
+  const [state, setState] = useState<DemoScriptState>({
+    lines: [],
+    progress: new Map(),
+    finished: false,
+  });
+  const timersRef = useRef<number[]>([]);
+  const startedRef = useRef(false);
+
+  const clearTimers = useCallback(() => {
+    for (const timer of timersRef.current) {
+      window.clearTimeout(timer);
+    }
+    timersRef.current = [];
+  }, []);
+
+  const start = useCallback(() => {
+    clearTimers();
+    startedRef.current = true;
+    setState({ lines: [], progress: new Map(), finished: false });
+
+    let cumulativeMs = 0;
+    steps.forEach((step, index) => {
+      if (step.kind === "wait") {
+        cumulativeMs += step.ms;
+        return;
+      }
+      const delay = cumulativeMs;
+      const timer = window.setTimeout(() => {
+        setState((prev) => {
+          if (step.kind === "line") {
+            return {
+              ...prev,
+              lines: [...prev.lines, { id: `line-${index}`, text: step.text, level: step.level ?? "info" }],
+            };
+          }
+          const progress = new Map(prev.progress);
+          progress.set(step.id, { label: step.label, status: step.status });
+          return { ...prev, progress };
+        });
+      }, delay);
+      timersRef.current.push(timer);
+      cumulativeMs += 80;
+    });
+
+    const doneTimer = window.setTimeout(() => {
+      setState((prev) => ({ ...prev, finished: true }));
+    }, cumulativeMs + 100);
+    timersRef.current.push(doneTimer);
+  }, [clearTimers, steps]);
+
+  const reset = useCallback(() => {
+    clearTimers();
+    startedRef.current = false;
+    setState({ lines: [], progress: new Map(), finished: false });
+  }, [clearTimers]);
+
+  useEffect(() => {
+    if (autoStart && !startedRef.current) {
+      start();
+    }
+    return clearTimers;
+  }, [autoStart, start, clearTimers]);
+
+  return { state, start, reset };
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/use-incident-playback.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/continuum/use-incident-playback.ts
@@ -1,0 +1,130 @@
+"use client";
+
+import { useCallback, useEffect, useRef, useState, useSyncExternalStore } from "react";
+import { getContinuumState, subscribeContinuum } from "./continuum-store";
+import { formatIncidentTime, getIncidentStage, getStageIndex, INCIDENT_STORY } from "./fixtures/incident";
+import type { ContinuumIncidentStage } from "./fixtures/types";
+
+const PLAYBACK_RATE = 12;
+
+export type IncidentPlayback = {
+  story: typeof INCIDENT_STORY,
+  elapsedMs: number,
+  isPlaying: boolean,
+  activeStage: ContinuumIncidentStage,
+  activeStageIndex: number,
+  waitingOnGate: boolean,
+  clearedGates: Set<string>,
+  formatTime: (ms: number) => string,
+  setElapsedMs: (ms: number) => void,
+  setIsPlaying: (playing: boolean) => void,
+  clearGate: (stageId: string) => void,
+  restart: () => void,
+};
+
+export function useIncidentPlayback(): IncidentPlayback {
+  const [elapsedMs, setElapsedMsState] = useState(0);
+  const [isPlaying, setIsPlaying] = useState(false);
+  const [clearedGates, setClearedGates] = useState<Set<string>>(() => new Set());
+  const elapsedMsRef = useRef(0);
+  const playbackAnchorRef = useRef<{ elapsedMs: number, startedAt: number } | null>(null);
+
+  const activeStage = getIncidentStage(INCIDENT_STORY, elapsedMs);
+  const activeStageIndex = getStageIndex(INCIDENT_STORY, elapsedMs);
+  const waitingOnGate = activeStage.gate != null && !clearedGates.has(activeStage.id);
+
+  const setElapsedMs = useCallback((next: number) => {
+    const clamped = Math.min(Math.max(next, 0), INCIDENT_STORY.durationMs);
+    elapsedMsRef.current = clamped;
+    setElapsedMsState(clamped);
+    if (isPlaying && !waitingOnGate) {
+      playbackAnchorRef.current = {
+        elapsedMs: clamped,
+        startedAt: performance.now(),
+      };
+    }
+  }, [isPlaying, waitingOnGate]);
+
+  const setIsPlayingSafe = useCallback((playing: boolean) => {
+    if (playing && waitingOnGate) return;
+    setIsPlaying(playing);
+    if (playing) {
+      playbackAnchorRef.current = {
+        elapsedMs: elapsedMsRef.current,
+        startedAt: performance.now(),
+      };
+    } else {
+      playbackAnchorRef.current = null;
+    }
+  }, [waitingOnGate]);
+
+  const clearGate = useCallback((stageId: string) => {
+    setClearedGates((prev) => {
+      const next = new Set(prev);
+      next.add(stageId);
+      return next;
+    });
+    setIsPlaying(true);
+    playbackAnchorRef.current = {
+      elapsedMs: elapsedMsRef.current,
+      startedAt: performance.now(),
+    };
+  }, []);
+
+  const restart = useCallback(() => {
+    setClearedGates(new Set());
+    setElapsedMs(0);
+    setIsPlaying(false);
+    playbackAnchorRef.current = null;
+  }, [setElapsedMs]);
+
+  useEffect(() => {
+    if (!isPlaying || waitingOnGate) return;
+
+    let frame = 0;
+    const tick = () => {
+      const anchor = playbackAnchorRef.current;
+      if (anchor == null) return;
+      const nextElapsed = anchor.elapsedMs + (performance.now() - anchor.startedAt) * PLAYBACK_RATE;
+      const stage = getIncidentStage(INCIDENT_STORY, nextElapsed);
+      if (stage.gate != null && !clearedGates.has(stage.id) && stage.offsetMs <= nextElapsed) {
+        elapsedMsRef.current = stage.offsetMs;
+        setElapsedMsState(stage.offsetMs);
+        setIsPlaying(false);
+        playbackAnchorRef.current = null;
+        return;
+      }
+      if (nextElapsed >= INCIDENT_STORY.durationMs) {
+        elapsedMsRef.current = INCIDENT_STORY.durationMs;
+        setElapsedMsState(INCIDENT_STORY.durationMs);
+        setIsPlaying(false);
+        playbackAnchorRef.current = null;
+        return;
+      }
+      elapsedMsRef.current = nextElapsed;
+      setElapsedMsState(nextElapsed);
+      frame = requestAnimationFrame(tick);
+    };
+    frame = requestAnimationFrame(tick);
+    return () => cancelAnimationFrame(frame);
+  }, [isPlaying, waitingOnGate, clearedGates]);
+
+  return {
+    story: INCIDENT_STORY,
+    elapsedMs,
+    isPlaying,
+    activeStage,
+    activeStageIndex,
+    waitingOnGate,
+    clearedGates,
+    formatTime: formatIncidentTime,
+    setElapsedMs,
+    setIsPlaying: setIsPlayingSafe,
+    clearGate,
+    restart,
+  };
+}
+
+export function useContinuumStore() {
+  return useSyncExternalStore(subscribeContinuum, getContinuumState, getContinuumState);
+}

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -387,6 +387,7 @@ export const ALL_APPS_FRONTEND = {
     icon: ChartLineIcon,
     href: "analytics",
     navigationItems: [
+      { displayName: "Mission Control", href: "./mission-control" },
       { displayName: "Tables", href: "./tables" },
       { displayName: "Traces", href: "./spans-events" },
       { displayName: "Replays", href: "../session-replays" },

--- a/apps/dashboard/src/lib/apps-frontend.tsx
+++ b/apps/dashboard/src/lib/apps-frontend.tsx
@@ -1,6 +1,6 @@
 import type { JSX } from "react";
 import { Link } from "@/components/link";
-import { ChartLineIcon, ChatCircleDotsIcon, ClipboardTextIcon, CodeIcon, CreditCardIcon, CursorClickIcon, EnvelopeSimpleIcon, FingerprintSimpleIcon, KeyIcon, MailboxIcon, MonitorPlayIcon, RocketIcon, ShieldCheckIcon, SparkleIcon, TelevisionSimpleIcon, TriangleIcon, UserGearIcon, UsersIcon, VaultIcon, WebhooksLogoIcon } from "@phosphor-icons/react";
+import { ChartLineIcon, ChatCircleDotsIcon, ClipboardTextIcon, CodeIcon, CreditCardIcon, CursorClickIcon, EnvelopeSimpleIcon, FingerprintSimpleIcon, HexagonIcon, KeyIcon, MailboxIcon, MonitorPlayIcon, RocketIcon, ShieldCheckIcon, SparkleIcon, TelevisionSimpleIcon, TriangleIcon, UserGearIcon, UsersIcon, VaultIcon, WebhooksLogoIcon } from "@phosphor-icons/react";
 import { StackAdminApp } from "@hexclave/next";
 import type { AppId } from "@hexclave/shared/dist/apps/apps-config";
 import { getRelativePart, isChildUrl } from "@hexclave/shared/dist/utils/urls";
@@ -421,6 +421,21 @@ export const ALL_APPS_FRONTEND = {
       <>
         <p>Session Replays let you watch real user sessions to understand how people use your app.</p>
         <p>Built on the same analytics pipeline, replays are scoped per user and surfaced inline on the user page.</p>
+      </>
+    ),
+  },
+  continuum: {
+    icon: HexagonIcon,
+    href: "continuum",
+    navigationItems: [
+      { displayName: "Canvas", href: "." },
+    ],
+    screenshots: getScreenshots('continuum', 0),
+    storeDescription: (
+      <>
+        <p>Continuum protects individual customers — not just infrastructure.</p>
+        <p>Deploy, roll back, isolate, clone, or fail over one tenant without touching anyone else. Cells carry each customer&apos;s app version, database branch, auth policies, and recovery plan.</p>
+        <p>When a release breaks three enterprise accounts, pin them back while everyone else stays on the new version — and keep their sessions alive across a cross-cloud failover.</p>
       </>
     ),
   },

--- a/packages/shared/src/apps/apps-config.ts
+++ b/packages/shared/src/apps/apps-config.ts
@@ -186,6 +186,12 @@ export const ALL_APPS = {
     stage: "stable",
     parentAppId: "analytics",
   },
+  "continuum": {
+    displayName: "Continuum",
+    subtitle: "Per-customer deploys, databases, and recovery — protect individual tenants",
+    tags: ["operations", "developers", "storage"],
+    stage: "alpha",
+  },
 } as const satisfies Record<string, App>;
 
 export function getParentAppId(appId: AppId): AppId | null {


### PR DESCRIPTION
## Summary
- Mock Mission Control page under Analytics with incident playback, telemetry investigation, and evidence panels
- Seeded incident stories + nav entry; client-only, no backend changes
- Stacked on #1750 (`mock/support-app`)

## Test plan
- [ ] Open Analytics → Mission Control
- [ ] Switch incident stories and scrub/play the timeline
- [ ] Confirm telemetry waterfall, evidence, and remediation panels update with playback


Made with [Cursor](https://cursor.com)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add a client-only Mission Control page for incident response playback and a new Continuum app that demos per-tenant deploys, databases, and recovery with a topology map and staged rollout. Uses deterministic seed data; no backend changes.

- **New Features**
  - Mission Control: timeline playback with scrubbing, telemetry investigation (topology, spans, metrics, logs, errors), and evidence/remediation panel tied to stages.
  - Seeds four deterministic incident stories with helpers and tests.
  - Continuum app: per-tenant map with node inspector, incident scrubber, and local demo state store.
  - Database workspace: schema browser, query insights, clone wizard, and forensic clone lab with scripted copilot hints.
  - Release cockpit: staged rollout view, compatibility matrix, blast radius, and protect checklist.

- **Migration**
  - No backend or external config changes required.
  - Access via Analytics → Mission Control and Apps → Continuum.

<sup>Written for commit fefcf9601eaba49a1aae6693b6ad1dab390ebdfd. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1754?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

