### PR TITLE
Coalesce Overview globe hover hit-testing to one per frame

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/globe.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/globe.tsx
@@ -533,6 +533,8 @@ function GlobeSectionInner({ countryData, totalUsers, activeUsersByCountry, sate
   selectedCountryRef.current = selectedCountry;
 
   const pendingCountryClearTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
+  const pendingHoverHitTestRafRef = useRef<number | null>(null);
+  const latestPointerPositionRef = useRef<{ clientX: number, clientY: number } | null>(null);
   const clearPendingCountryClear = () => {
     if (pendingCountryClearTimeoutRef.current != null) {
       clearTimeout(pendingCountryClearTimeoutRef.current);
@@ -589,6 +591,14 @@ function GlobeSectionInner({ countryData, totalUsers, activeUsersByCountry, sate
     updateSelectedCountry(findCountryAt(globeCoords.lat, globeCoords.lng, countries.features));
   };
 
+  const cancelPendingHoverHitTest = () => {
+    if (pendingHoverHitTestRafRef.current != null) {
+      cancelAnimationFrame(pendingHoverHitTestRafRef.current);
+      pendingHoverHitTestRafRef.current = null;
+    }
+    latestPointerPositionRef.current = null;
+  };
+
   useEffect(() => {
     if (selectedCountry) {
       setPreviousSelectedCountry(selectedCountry);
@@ -600,6 +610,10 @@ function GlobeSectionInner({ countryData, totalUsers, activeUsersByCountry, sate
       if (pendingCountryClearTimeoutRef.current != null) {
         clearTimeout(pendingCountryClearTimeoutRef.current);
       }
+      if (pendingHoverHitTestRafRef.current != null) {
+        cancelAnimationFrame(pendingHoverHitTestRafRef.current);
+      }
+      latestPointerPositionRef.current = null;
     };
   }, []);
 
@@ -1107,13 +1121,25 @@ function GlobeSectionInner({ countryData, totalUsers, activeUsersByCountry, sate
               }}
               onMouseMoveCapture={(e) => {
                 resumeRender();
-                updateSelectedCountryFromPointerPosition(e.clientX, e.clientY);
+                latestPointerPositionRef.current = { clientX: e.clientX, clientY: e.clientY };
+                // Mousemove can fire many times between paints; coalesce the expensive
+                // globe raycast and country scan to one hit-test per animation frame.
+                if (pendingHoverHitTestRafRef.current == null) {
+                  pendingHoverHitTestRafRef.current = requestAnimationFrame(() => {
+                    pendingHoverHitTestRafRef.current = null;
+                    const pointerPosition = latestPointerPositionRef.current;
+                    if (pointerPosition != null) {
+                      updateSelectedCountryFromPointerPosition(pointerPosition.clientX, pointerPosition.clientY);
+                    }
+                  });
+                }
                 if (tooltipRef.current) {
                   tooltipRef.current.style.transform = `translate(${e.clientX}px, ${e.clientY}px)`;
                 }
               }}
               onMouseLeave={() => {
                 // Only clear when leaving the entire globe area
+                cancelPendingHoverHitTest();
                 updateSelectedCountry(null, { immediateClear: true });
                 if (globeRef.current) {
                   //globeRef.current.controls().autoRotate = true;


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Client-side performance tweak in overview UI with explicit RAF cleanup; hover semantics stay the same aside from using the latest pointer position each frame.
> 
> **Overview**
> **Overview globe hover** no longer runs the expensive `toGlobeCoords` raycast and GeoJSON country lookup on every `mousemove`. Pointer position is stored in a ref and **country selection is updated at most once per animation frame** via `requestAnimationFrame`.
> 
> Pending frame callbacks are **cancelled on mouse leave** and on **unmount**, so hover state still clears immediately when the pointer leaves the globe and no stale hit-tests run after teardown. Tooltip positioning on `mousemove` is unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6dbd6cfe89ca677db43770c9b4119c517a93583e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Coalesced overview globe hover hit-testing to run once per animation frame using requestAnimationFrame, reducing costly raycasts and country lookups on mousemove. Stores the latest pointer position, keeps tooltip behavior, and cancels pending frames on mouse leave and unmount for clean teardown.

<sup>Written for commit 6dbd6cfe89ca677db43770c9b4119c517a93583e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1758?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved globe hover responsiveness and stability.
  * Reduced unnecessary processing while moving the pointer across countries.
  * Prevented stale hover highlights after the pointer leaves the globe.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->