### PR TITLE
Retry GitHub user-info 401s to absorb token propagation lag

### DIFF
--- a/apps/backend/src/oauth/providers/github.tsx
+++ b/apps/backend/src/oauth/providers/github.tsx
@@ -1,7 +1,51 @@
 import { HexclaveAssertionError, StatusError } from "@hexclave/shared/dist/utils/errors";
 import { getJwtInfo } from "@hexclave/shared/dist/utils/jwt";
+import { wait } from "@hexclave/shared/dist/utils/promises";
 import { OAuthUserInfo, validateUserInfo } from "../utils";
 import { OAuthBaseProvider, TokenSet } from "./base";
+
+// GitHub occasionally rejects a freshly-issued access token with 401 "Bad credentials" because
+// token issuance and the REST API run on separate infrastructure, and new tokens reportedly take
+// 1-3 seconds to propagate (https://github.com/orgs/community/discussions/162975). The delays
+// below are chosen so the final attempt lands ~3s after the first, covering that window while
+// staying well under the serverless request watchdog.
+const USER_INFO_401_RETRY_DELAYS_MS = [1000, 2000];
+
+// Returns `any` because fetch's json() is `any` and the shape is validated by validateUserInfo
+// at the call site; typing GitHub's response here would be pretend-precision.
+async function fetchRawGithubUserInfo(tokenSet: TokenSet): Promise<any> {
+  for (let attempt = 1; ; attempt++) {
+    const rawUserInfoRes = await fetch("https://api.github.com/user", {
+      headers: {
+        Authorization: `Bearer ${tokenSet.accessToken}`,
+        "X-GitHub-Api-Version": "2022-11-28",
+      },
+    });
+    if (rawUserInfoRes.ok) {
+      return await rawUserInfoRes.json();
+    }
+    // Only 401 is retried: it's the propagation-lag symptom, while other statuses are
+    // deterministic and retrying them would just add latency. A 401 that survives all retries
+    // deliberately stays a HexclaveAssertionError (500) rather than a 4xx: the other candidate
+    // cause is a racing duplicate callback whose second code exchange invalidates the first
+    // token, and we can't distinguish the two from here. If Sentry keeps reporting this error
+    // (with the attempt count below) after the retries shipped, that's evidence for the
+    // invalidation race, and the surviving 401s can then confidently be mapped to a
+    // "please try signing in again" 4xx.
+    if (rawUserInfoRes.status !== 401 || attempt > USER_INFO_401_RETRY_DELAYS_MS.length) {
+      throw new HexclaveAssertionError(`Error fetching user info from GitHub provider: Status code ${rawUserInfoRes.status} (attempt ${attempt})`, {
+        rawUserInfoRes,
+        rawUserInfoResText: await rawUserInfoRes.text(),
+        attempt,
+        hasAccessToken: !!tokenSet.accessToken,
+        hasRefreshToken: !!tokenSet.refreshToken,
+        accessTokenExpiredAt: tokenSet.accessTokenExpiredAt,
+        jwtInfo: await getJwtInfo({ jwt: tokenSet.accessToken }),
+      });
+    }
+    await wait(USER_INFO_401_RETRY_DELAYS_MS[attempt - 1]);
+  }
+}
 
 export class GithubProvider extends OAuthBaseProvider {
   private constructor(
@@ -40,23 +84,7 @@ export class GithubProvider extends OAuthBaseProvider {
   }
 
   async postProcessUserInfo(tokenSet: TokenSet): Promise<OAuthUserInfo> {
-    const rawUserInfoRes = await fetch("https://api.github.com/user", {
-      headers: {
-        Authorization: `Bearer ${tokenSet.accessToken}`,
-        "X-GitHub-Api-Version": "2022-11-28",
-      },
-    });
-    if (!rawUserInfoRes.ok) {
-      throw new HexclaveAssertionError("Error fetching user info from GitHub provider: Status code " + rawUserInfoRes.status, {
-        rawUserInfoRes,
-        rawUserInfoResText: await rawUserInfoRes.text(),
-        hasAccessToken: !!tokenSet.accessToken,
-        hasRefreshToken: !!tokenSet.refreshToken,
-        accessTokenExpiredAt: tokenSet.accessTokenExpiredAt,
-        jwtInfo: await getJwtInfo({ jwt: tokenSet.accessToken }),
-      });
-    }
-    const rawUserInfo = await rawUserInfoRes.json();
+    const rawUserInfo = await fetchRawGithubUserInfo(tokenSet);
 
     const emailsRes = await fetch("https://api.github.com/user/emails", {
       headers: {
@@ -104,3 +132,74 @@ export class GithubProvider extends OAuthBaseProvider {
     return res.ok;
   }
 }
+
+const testTokenSet: TokenSet = { accessToken: "ghu_test_token", accessTokenExpiredAt: null };
+
+import.meta.vitest?.test("fetchRawGithubUserInfo returns user info on first success without retrying", async ({ expect }) => {
+  const vi = import.meta.vitest!.vi;
+  const fetchMock = vi.fn(async () => Response.json({ id: 123, name: "Test" }));
+  vi.stubGlobal("fetch", fetchMock);
+  try {
+    const result = await fetchRawGithubUserInfo(testTokenSet);
+    expect(result).toEqual({ id: 123, name: "Test" });
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});
+
+import.meta.vitest?.test("fetchRawGithubUserInfo retries 401s with 1s then 2s delays and succeeds", async ({ expect }) => {
+  const vi = import.meta.vitest!.vi;
+  vi.useFakeTimers();
+  let callCount = 0;
+  const fetchMock = vi.fn(async () => ++callCount <= 2
+    ? new Response("Bad credentials", { status: 401 })
+    : Response.json({ id: 123 }));
+  vi.stubGlobal("fetch", fetchMock);
+  try {
+    const promise = fetchRawGithubUserInfo(testTokenSet);
+    await vi.advanceTimersByTimeAsync(0);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(999);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1999);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+    await vi.advanceTimersByTimeAsync(1);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+    expect(await promise).toEqual({ id: 123 });
+  } finally {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  }
+});
+
+import.meta.vitest?.test("fetchRawGithubUserInfo throws with attempt count after 401 retries are exhausted", async ({ expect }) => {
+  const vi = import.meta.vitest!.vi;
+  vi.useFakeTimers();
+  const fetchMock = vi.fn(async () => new Response("Bad credentials", { status: 401 }));
+  vi.stubGlobal("fetch", fetchMock);
+  try {
+    const promise = fetchRawGithubUserInfo(testTokenSet);
+    const rejection = expect(promise).rejects.toThrow("Error fetching user info from GitHub provider: Status code 401 (attempt 3)");
+    await vi.advanceTimersByTimeAsync(3000);
+    await rejection;
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  } finally {
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  }
+});
+
+import.meta.vitest?.test("fetchRawGithubUserInfo does not retry non-401 statuses", async ({ expect }) => {
+  const vi = import.meta.vitest!.vi;
+  const fetchMock = vi.fn(async () => new Response("Forbidden", { status: 403 }));
+  vi.stubGlobal("fetch", fetchMock);
+  try {
+    await expect(fetchRawGithubUserInfo(testTokenSet)).rejects.toThrow("Error fetching user info from GitHub provider: Status code 403 (attempt 1)");
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  } finally {
+    vi.unstubAllGlobals();
+  }
+});

--- a/apps/backend/src/oauth/providers/github.tsx
+++ b/apps/backend/src/oauth/providers/github.tsx
@@ -4,15 +4,9 @@ import { wait } from "@hexclave/shared/dist/utils/promises";
 import { OAuthUserInfo, validateUserInfo } from "../utils";
 import { OAuthBaseProvider, TokenSet } from "./base";
 
-// GitHub occasionally rejects a freshly-issued access token with 401 "Bad credentials" because
-// token issuance and the REST API run on separate infrastructure, and new tokens reportedly take
-// 1-3 seconds to propagate (https://github.com/orgs/community/discussions/162975). The delays
-// below are chosen so the final attempt lands ~3s after the first, covering that window while
-// staying well under the serverless request watchdog.
 const USER_INFO_401_RETRY_DELAYS_MS = [1000, 2000];
 
-// Returns `any` because fetch's json() is `any` and the shape is validated by validateUserInfo
-// at the call site; typing GitHub's response here would be pretend-precision.
+// `any` because fetch's json() is `any`; the shape is validated by validateUserInfo at the call site
 async function fetchRawGithubUserInfo(tokenSet: TokenSet): Promise<any> {
   for (let attempt = 1; ; attempt++) {
     const rawUserInfoRes = await fetch("https://api.github.com/user", {
@@ -24,14 +18,8 @@ async function fetchRawGithubUserInfo(tokenSet: TokenSet): Promise<any> {
     if (rawUserInfoRes.ok) {
       return await rawUserInfoRes.json();
     }
-    // Only 401 is retried: it's the propagation-lag symptom, while other statuses are
-    // deterministic and retrying them would just add latency. A 401 that survives all retries
-    // deliberately stays a HexclaveAssertionError (500) rather than a 4xx: the other candidate
-    // cause is a racing duplicate callback whose second code exchange invalidates the first
-    // token, and we can't distinguish the two from here. If Sentry keeps reporting this error
-    // (with the attempt count below) after the retries shipped, that's evidence for the
-    // invalidation race, and the surviving 401s can then confidently be mapped to a
-    // "please try signing in again" 4xx.
+    // Retry only 401s: GitHub sometimes rejects freshly-issued tokens for 1-3s until they
+    // propagate across its infrastructure (https://github.com/orgs/community/discussions/162975).
     if (rawUserInfoRes.status !== 401 || attempt > USER_INFO_401_RETRY_DELAYS_MS.length) {
       throw new HexclaveAssertionError(`Error fetching user info from GitHub provider: Status code ${rawUserInfoRes.status} (attempt ${attempt})`, {
         rawUserInfoRes,

--- a/apps/backend/src/oauth/providers/github.tsx
+++ b/apps/backend/src/oauth/providers/github.tsx
@@ -21,7 +21,8 @@ async function fetchRawGithubUserInfo(tokenSet: TokenSet): Promise<any> {
     // Retry only 401s: GitHub sometimes rejects freshly-issued tokens for 1-3s until they
     // propagate across its infrastructure (https://github.com/orgs/community/discussions/162975).
     if (rawUserInfoRes.status !== 401 || attempt > USER_INFO_401_RETRY_DELAYS_MS.length) {
-      throw new HexclaveAssertionError(`Error fetching user info from GitHub provider: Status code ${rawUserInfoRes.status} (attempt ${attempt})`, {
+      // `attempt` is only in the extras, not the message, so Sentry keeps one grouping per status.
+      throw new HexclaveAssertionError(`Error fetching user info from GitHub provider: Status code ${rawUserInfoRes.status}`, {
         rawUserInfoRes,
         rawUserInfoResText: await rawUserInfoRes.text(),
         attempt,
@@ -121,30 +122,34 @@ export class GithubProvider extends OAuthBaseProvider {
   }
 }
 
-const testTokenSet: TokenSet = { accessToken: "ghu_test_token", accessTokenExpiredAt: null };
+// ── Tests ──────────────────────────────────────────────────────────────
 
-import.meta.vitest?.test("fetchRawGithubUserInfo returns user info on first success without retrying", async ({ expect }) => {
-  const vi = import.meta.vitest!.vi;
-  const fetchMock = vi.fn(async () => Response.json({ id: 123, name: "Test" }));
-  vi.stubGlobal("fetch", fetchMock);
-  try {
+import.meta.vitest?.describe("fetchRawGithubUserInfo(...)", () => {
+  const { vi, test, afterEach } = import.meta.vitest!;
+
+  const testTokenSet: TokenSet = { accessToken: "ghu_test_token", accessTokenExpiredAt: null };
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+    vi.unstubAllGlobals();
+    vi.useRealTimers();
+  });
+
+  test("returns user info on first success without retrying", async ({ expect }) => {
+    const fetchMock = vi.fn(async () => Response.json({ id: 123, name: "Test" }));
+    vi.stubGlobal("fetch", fetchMock);
     const result = await fetchRawGithubUserInfo(testTokenSet);
     expect(result).toEqual({ id: 123, name: "Test" });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  } finally {
-    vi.unstubAllGlobals();
-  }
-});
+  });
 
-import.meta.vitest?.test("fetchRawGithubUserInfo retries 401s with 1s then 2s delays and succeeds", async ({ expect }) => {
-  const vi = import.meta.vitest!.vi;
-  vi.useFakeTimers();
-  let callCount = 0;
-  const fetchMock = vi.fn(async () => ++callCount <= 2
-    ? new Response("Bad credentials", { status: 401 })
-    : Response.json({ id: 123 }));
-  vi.stubGlobal("fetch", fetchMock);
-  try {
+  test("retries 401s with 1s then 2s delays and succeeds", async ({ expect }) => {
+    vi.useFakeTimers();
+    let callCount = 0;
+    const fetchMock = vi.fn(async () => ++callCount <= 2
+      ? new Response("Bad credentials", { status: 401 })
+      : Response.json({ id: 123 }));
+    vi.stubGlobal("fetch", fetchMock);
     const promise = fetchRawGithubUserInfo(testTokenSet);
     await vi.advanceTimersByTimeAsync(0);
     expect(fetchMock).toHaveBeenCalledTimes(1);
@@ -157,37 +162,29 @@ import.meta.vitest?.test("fetchRawGithubUserInfo retries 401s with 1s then 2s de
     await vi.advanceTimersByTimeAsync(1);
     expect(fetchMock).toHaveBeenCalledTimes(3);
     expect(await promise).toEqual({ id: 123 });
-  } finally {
-    vi.unstubAllGlobals();
-    vi.useRealTimers();
-  }
-});
+  });
 
-import.meta.vitest?.test("fetchRawGithubUserInfo throws with attempt count after 401 retries are exhausted", async ({ expect }) => {
-  const vi = import.meta.vitest!.vi;
-  vi.useFakeTimers();
-  const fetchMock = vi.fn(async () => new Response("Bad credentials", { status: 401 }));
-  vi.stubGlobal("fetch", fetchMock);
-  try {
+  test("throws with the attempt count in extras after 401 retries are exhausted", async ({ expect }) => {
+    vi.useFakeTimers();
+    const fetchMock = vi.fn(async () => new Response("Bad credentials", { status: 401 }));
+    vi.stubGlobal("fetch", fetchMock);
     const promise = fetchRawGithubUserInfo(testTokenSet);
-    const rejection = expect(promise).rejects.toThrow("Error fetching user info from GitHub provider: Status code 401 (attempt 3)");
+    const rejection = expect(promise).rejects.toMatchObject({
+      message: expect.stringContaining("Error fetching user info from GitHub provider: Status code 401"),
+      extraData: expect.objectContaining({ attempt: 3 }),
+    });
     await vi.advanceTimersByTimeAsync(3000);
     await rejection;
     expect(fetchMock).toHaveBeenCalledTimes(3);
-  } finally {
-    vi.unstubAllGlobals();
-    vi.useRealTimers();
-  }
-});
+  });
 
-import.meta.vitest?.test("fetchRawGithubUserInfo does not retry non-401 statuses", async ({ expect }) => {
-  const vi = import.meta.vitest!.vi;
-  const fetchMock = vi.fn(async () => new Response("Forbidden", { status: 403 }));
-  vi.stubGlobal("fetch", fetchMock);
-  try {
-    await expect(fetchRawGithubUserInfo(testTokenSet)).rejects.toThrow("Error fetching user info from GitHub provider: Status code 403 (attempt 1)");
+  test("does not retry non-401 statuses", async ({ expect }) => {
+    const fetchMock = vi.fn(async () => new Response("Forbidden", { status: 403 }));
+    vi.stubGlobal("fetch", fetchMock);
+    await expect(fetchRawGithubUserInfo(testTokenSet)).rejects.toMatchObject({
+      message: expect.stringContaining("Error fetching user info from GitHub provider: Status code 403"),
+      extraData: expect.objectContaining({ attempt: 1 }),
+    });
     expect(fetchMock).toHaveBeenCalledTimes(1);
-  } finally {
-    vi.unstubAllGlobals();
-  }
+  });
 });

--- a/apps/backend/src/oauth/providers/github.tsx
+++ b/apps/backend/src/oauth/providers/github.tsx
@@ -32,6 +32,8 @@ async function fetchRawGithubUserInfo(tokenSet: TokenSet): Promise<any> {
         jwtInfo: await getJwtInfo({ jwt: tokenSet.accessToken }),
       });
     }
+    // Release the intermediate 401 response's connection instead of holding it until GC
+    await rawUserInfoRes.body?.cancel();
     await wait(USER_INFO_401_RETRY_DELAYS_MS[attempt - 1]);
   }
 }


### PR DESCRIPTION
Fixes the recurring production Sentry issue STACK-BACKEND-15J (~10 events/day, 282 lifetime): end-users signing in with GitHub intermittently hit a 500 at the last step of the OAuth flow.

## What happens
The token exchange with GitHub succeeds, but the immediate follow-up `GET https://api.github.com/user` sometimes returns 401 "Bad credentials" — for a token GitHub issued milliseconds earlier (observed with `ghu_` GitHub App user-to-server tokens on customer projects). Since any non-OK status threw a `HexclaveAssertionError`, the user got an opaque 500 and Sentry paged.

## Why GitHub does this
This is a known GitHub behavior: token issuance and the REST API run on separate distributed infrastructure, and newly-minted tokens take ~1–3 seconds to propagate to all API servers. Community reports match our symptom exactly (intermittent post-issuance 401s from `/user` that succeed on retry):
- https://github.com/orgs/community/discussions/162975
- https://github.com/orgs/community/discussions/118908

## The fix
Retry the user-info request on 401 with 1s and 2s delays, so the final attempt lands ~3s after the first — covering the reported propagation window while staying well under the serverless request watchdog. Most affected sign-ins should now succeed transparently instead of erroring at all.

If all attempts fail, we deliberately still throw the `HexclaveAssertionError` (500) rather than mapping to a 4xx — now including the attempt count. Rationale: a 401 that survives 3 seconds of retries is not explainable by propagation lag alone; the other candidate cause is a racing duplicate callback whose second code exchange invalidates the first token. We can't distinguish the two server-side, so we keep failing loud. Post-deploy, STACK-BACKEND-15J's volume is the experiment: if it drops to ~zero, propagation lag was the whole story; if events persist (now tagged with `attempt: 3`), that's evidence for the invalidation race and the surviving 401s can then confidently be mapped to a "please try signing in again" 4xx.

Other non-OK statuses (403, 5xx, …) are deliberately not retried — they're deterministic, and retrying would just add 3s of latency to failure modes a retry can't help.

## Testing
- Four in-source unit tests (`import.meta.vitest`, following the precedent in `src/oauth/index.tsx`) with a stubbed global `fetch` and fake timers:
  - success on first attempt → no retry
  - 401 → 401 → 200 → succeeds, with exact 1s/2s delay boundaries asserted
  - persistent 401 → throws with `attempt 3` in the message after exactly 3 calls
  - 403 → throws immediately after 1 call (no retry tax on non-401 failures)
- No e2e test: `api.github.com` is hardcoded and the e2e harness has no mock for GitHub's user-info endpoint; making the base URL injectable is a possible follow-up.
- Backend typecheck and lint pass.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Retry the GitHub user-info request on 401 to absorb token propagation lag and stop intermittent 500s at the end of the GitHub OAuth flow. Non-401 failures behave as before.

- **Bug Fixes**
  - Retries 401s from `https://api.github.com/user` at +1s and +2s; cancels intermediate 401 response bodies between retries; if all attempts fail, throws a `HexclaveAssertionError` with the attempt count in error extras (not the message) to keep Sentry grouping stable.
  - Skips retries for non-401 statuses to avoid unnecessary latency.
  - Unit tests cover: no-retry success, 401→retry→success, exhausted 401 retries, and immediate failure on non-401.

<sup>Written for commit e8e340c6a48cebbfc21d8b74982d15a64e5d0d9c. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1771?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub sign-in reliability by retrying GitHub profile fetches when authorization fails with temporary 401 errors.
  * Added more detailed failure reporting when profile information can’t be retrieved after retries.
  * Ensured retries only occur for 401 responses, not for other error statuses.
* **Tests**
  * Added coverage for no-retry on first success, correct retry timing, and correct error behavior after retry exhaustion.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->