### PR TITLE
Editable grid component design improvements

### DIFF
--- a/apps/dashboard/DESIGN-GUIDE.md
+++ b/apps/dashboard/DESIGN-GUIDE.md
@@ -520,14 +520,22 @@ Use for:
 Props:
 
 - `items` (typed union: `text`, `boolean`, `dropdown`, `custom-dropdown`, `custom-button`, `custom`)
+- shared item metadata: `itemKey`, `icon`, `name`, optional `description` and `tooltip`
 - `columns`: `1 | 2`
+- `size`: `"sm" | "md"`
 - `deferredSave`, `hasChanges`, `onSave`, `onDiscard`
 - `externalModifiedKeys`
 
 Rules:
 
 - prefer this for config forms that are row-based and editable inline
+- layout is a flat label/value grid (no per-field cards); editable values use white controls in light mode
 - use deferred save mode when many fields should be committed together
+- text values enter an explicit edit state; Enter saves and Escape cancels
+- omit `onUpdate` or set `readOnly` for a non-editable value
+- use `description` for persistent context and `tooltip` only for secondary details
+- `custom-dropdown` owns its popover; provide both `triggerContent` and `popoverContent`
+- for page-local editable triggers outside the typed union, reuse `designEditableGridControlClassName` / `designEditableGridPopoverClassName`
 
 ### 4.12 `DataGrid` + `useDataSource` + `createDefaultDataGridState`
 

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/playground/page-client.tsx
@@ -536,6 +536,7 @@ export default function PageClient() {
         type: "text",
         icon: <FileText className="h-4 w-4" />,
         name: "Display Name",
+        description: "The customer-facing name for this product.",
         value: "Widget Pro",
         readOnly: false,
         onUpdate: async () => {
@@ -548,6 +549,7 @@ export default function PageClient() {
         type: "boolean",
         icon: <StackSimple className="h-4 w-4" />,
         name: "Active",
+        description: "Controls whether this product can be purchased.",
         value: true,
         readOnly: false,
         trueLabel: "Yes",
@@ -562,6 +564,7 @@ export default function PageClient() {
         type: "dropdown",
         icon: <Sliders className="h-4 w-4" />,
         name: "Category",
+        description: "Used to organize this product in the catalog.",
         value: "hardware",
         options: [
           { value: "hardware", label: "Hardware" },
@@ -579,6 +582,7 @@ export default function PageClient() {
         type: "custom",
         icon: <Tag className="h-4 w-4" />,
         name: "Price",
+        description: "Current base price before discounts.",
         children: <span className="text-sm text-foreground">$29.99</span>,
       },
     ];
@@ -591,6 +595,7 @@ export default function PageClient() {
           type: "custom-dropdown",
           icon: <Sparkle className="h-4 w-4" />,
           name: "Custom Dropdown",
+          description: "A composed control with custom popover content.",
           triggerContent: <span>Open custom panel</span>,
           popoverContent: <div>Custom content</div>,
           disabled: false,
@@ -600,6 +605,7 @@ export default function PageClient() {
           type: "custom-button",
           icon: <Cube className="h-4 w-4" />,
           name: "Custom Button",
+          description: "Runs a custom action with built-in loading behavior.",
           onClick: () => setGridActionLog("Clicked custom button"),
           children: <span>Run action</span>,
           disabled: false,
@@ -1082,28 +1088,28 @@ export default function PageClient() {
     if (selected === "editable-grid") {
       return (
         <div className="w-full max-w-3xl">
-          <div className="rounded-2xl overflow-hidden bg-white/90 dark:bg-[hsl(240,10%,5.5%)] border border-black/[0.12] dark:border-foreground/[0.12] shadow-sm">
+          <div className="overflow-hidden rounded-2xl border border-black/[0.1] bg-white shadow-sm dark:border-white/[0.1] dark:bg-zinc-950">
             <div className="p-4 sm:p-5">
               <DesignEditableGrid
-                items={editableItems}
                 columns={gridCols}
-                size={gridSize}
-                editMode={gridEditMode}
                 deferredSave={gridDeferredSave}
+                editMode={gridEditMode}
+                externalModifiedKeys={gridShowModified ? new Set(["display-name", "category"]) : undefined}
                 hasChanges={gridHasChanges}
-                onSave={gridDeferredSave ? async () => {
-                  await new Promise((r) => setTimeout(r, 400));
-                  setGridActionLog("Saved deferred changes");
-                  setGridHasChanges(false);
-                } : undefined}
+                items={editableItems}
                 onDiscard={gridDeferredSave ? () => {
                   setGridActionLog("Discarded deferred changes");
                   setGridHasChanges(false);
                 } : undefined}
-                externalModifiedKeys={gridShowModified ? new Set(["display-name", "category"]) : undefined}
+                onSave={gridDeferredSave ? async () => {
+                  await new Promise((resolve) => setTimeout(resolve, 400));
+                  setGridActionLog("Saved deferred changes");
+                  setGridHasChanges(false);
+                } : undefined}
+                size={gridSize}
               />
               {gridActionLog && (
-                <Typography variant="secondary" className="text-xs mt-2">
+                <Typography className="mt-3 text-xs" variant="secondary">
                   Last action: {gridActionLog}
                 </Typography>
               )}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
@@ -1,6 +1,12 @@
 "use client";
 
-import { DesignEditableGrid, type DesignEditableGridItem } from "@/components/design-components";
+import {
+  DesignEditableGrid,
+  DesignButton,
+  DesignInput,
+  DesignSelectorDropdown,
+  type DesignEditableGridItem,
+} from "@/components/design-components";
 import { EditableInput } from "@/components/editable-input";
 import { Link, StyledLink } from "@/components/link";
 import { ItemDialog } from "@/components/payments/item-dialog";
@@ -26,9 +32,6 @@ import {
   DropdownMenuTrigger,
   Input,
   Label,
-  Popover,
-  PopoverContent,
-  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -647,69 +650,54 @@ function ProductDetailsSection({ productId, product, config }: ProductDetailsSec
       ) : 'No',
     },
     {
-      type: 'custom',
+      type: 'custom-dropdown',
       itemKey: 'freeTrial',
       icon: <ClockIcon size={16} />,
       name: "Free Trial",
       tooltip: "Free trial period before billing starts. Customers won't be charged during this period.",
-      children: (
-        <Popover open={freeTrialPopoverOpen} onOpenChange={setFreeTrialPopoverOpen}>
-          <PopoverTrigger asChild>
-            <button
-              className={cn(
-                "w-full px-1 py-0 h-[unset] border-transparent rounded text-left text-foreground",
-                "hover:ring-1 hover:ring-slate-300 dark:hover:ring-gray-500 hover:bg-slate-50 dark:hover:bg-gray-800 hover:cursor-pointer",
-                "focus:outline-none focus-visible:ring-1 focus-visible:ring-slate-500 dark:focus-visible:ring-gray-50",
-                "transition-colors duration-150 hover:transition-none"
-              )}
+      open: freeTrialPopoverOpen,
+      onOpenChange: setFreeTrialPopoverOpen,
+      triggerContent: localFreeTrialDisplayText,
+      popoverContent: (
+        <div className="space-y-3">
+          <div className="flex items-center gap-2">
+            <DesignInput
+              className="w-20 bg-white dark:bg-zinc-950"
+              type="number"
+              min={1}
+              value={freeTrialCount}
+              onChange={(e) => setFreeTrialCount(parseInt(e.target.value) || 1)}
+            />
+            <DesignSelectorDropdown
+              className="w-28"
+              triggerClassName="bg-white dark:bg-zinc-950 border-black/[0.1] dark:border-white/[0.1]"
+              value={freeTrialUnit}
+              onValueChange={(v) => setFreeTrialUnit(v as DayInterval[1])}
+              options={DEFAULT_INTERVAL_UNITS.map((unit) => ({
+                value: unit,
+                label: `${unit}${freeTrialCount !== 1 ? 's' : ''}`,
+              }))}
+            />
+          </div>
+          <div className="flex gap-2">
+            <DesignButton
+              size="sm"
+              className="flex-1"
+              onClick={() => handleFreeTrialSave(freeTrialCount, freeTrialUnit)}
             >
-              {localFreeTrialDisplayText}
-            </button>
-          </PopoverTrigger>
-          <PopoverContent className="w-64 p-3">
-            <div className="space-y-3">
-              <div className="flex items-center gap-2">
-                <Input
-                  className="w-20"
-                  type="number"
-                  min={1}
-                  value={freeTrialCount}
-                  onChange={(e) => setFreeTrialCount(parseInt(e.target.value) || 1)}
-                />
-                <Select value={freeTrialUnit} onValueChange={(v) => setFreeTrialUnit(v as DayInterval[1])}>
-                  <SelectTrigger className="w-24">
-                    <SelectValue />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {DEFAULT_INTERVAL_UNITS.map((unit) => (
-                      <SelectItem key={unit} value={unit}>
-                        {unit}{freeTrialCount !== 1 ? 's' : ''}
-                      </SelectItem>
-                    ))}
-                  </SelectContent>
-                </Select>
-              </div>
-              <div className="flex gap-2">
-                <Button
-                  size="sm"
-                  className="flex-1"
-                  onClick={() => handleFreeTrialSave(freeTrialCount, freeTrialUnit)}
-                >
-                  Apply
-                </Button>
-                {localFreeTrial && (
-                  <Button
-                    size="sm"
-                    variant="outline"
-                    onClick={handleRemoveFreeTrial}
-                  >
-                    Remove
-                  </Button>
-                )}
-              </div>
-            </div>
-          </PopoverContent>
-        </Popover>
+              Apply
+            </DesignButton>
+            {localFreeTrial && (
+              <DesignButton
+                size="sm"
+                variant="outline"
+                onClick={handleRemoveFreeTrial}
+              >
+                Remove
+              </DesignButton>
+            )}
+          </div>
+        </div>
       ),
     },
     {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
@@ -241,7 +241,9 @@ function ProductTitleEditor({
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.nativeEvent.isComposing) {
               event.preventDefault();
-              runAsynchronouslyWithAlert(save());
+              if (draftValue !== storedDisplayName && !isSaving) {
+                runAsynchronouslyWithAlert(save());
+              }
             }
             if (event.key === "Escape") {
               cancelEditing();
@@ -351,6 +353,12 @@ function ProductHeader({ productId, product, productLineName }: ProductHeaderPro
                   label: "View in Product Lines",
                   icon: <FolderOpenIcon className="h-4 w-4" />,
                   onClick: () => router.push(`/projects/${projectId}/payments/product-lines#product-${productId}`),
+                },
+                {
+                  id: "edit",
+                  label: "Edit full details",
+                  icon: <PencilSimpleIcon className="h-4 w-4" />,
+                  onClick: () => router.push(`/projects/${projectId}/payments/products/${productId}/edit`),
                 },
               ]}
             />
@@ -690,6 +698,14 @@ function ProductDetailsSection({ productId, product, config }: ProductDetailsSec
     setFreeTrialPopoverOpen(false);
   };
 
+  const handleFreeTrialPopoverOpenChange = (open: boolean) => {
+    setFreeTrialPopoverOpen(open);
+    if (open) {
+      setFreeTrialCount(localFreeTrial ? localFreeTrial[0] : 7);
+      setFreeTrialUnit(localFreeTrial ? localFreeTrial[1] : 'day');
+    }
+  };
+
   // ===== PRICES HANDLERS (for deferred save) =====
   const handlePricesChange = (newPrices: Product['prices']) => {
     // Clear the "needs at least one price" error as soon as the user adds one back.
@@ -785,7 +801,7 @@ function ProductDetailsSection({ productId, product, config }: ProductDetailsSec
       name: "Free Trial",
       tooltip: "Free trial period before billing starts. Customers won't be charged during this period.",
       open: freeTrialPopoverOpen,
-      onOpenChange: setFreeTrialPopoverOpen,
+      onOpenChange: handleFreeTrialPopoverOpenChange,
       triggerContent: localFreeTrialDisplayText,
       popoverContent: (
         <div className="space-y-3">
@@ -795,7 +811,7 @@ function ProductDetailsSection({ productId, product, config }: ProductDetailsSec
               type="number"
               min={1}
               value={freeTrialCount}
-              onChange={(e) => setFreeTrialCount(parseInt(e.target.value) || 1)}
+              onChange={(e) => setFreeTrialCount(Math.max(1, parseInt(e.target.value) || 1))}
             />
             <DesignSelectorDropdown
               className="w-28"

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/payments/products/[productId]/page-client.tsx
@@ -1,13 +1,15 @@
 "use client";
 
 import {
+  DesignBadge,
   DesignEditableGrid,
   DesignButton,
   DesignInput,
+  DesignMenu,
   DesignSelectorDropdown,
+  type DesignBadgeColor,
   type DesignEditableGridItem,
 } from "@/components/design-components";
-import { EditableInput } from "@/components/editable-input";
 import { Link, StyledLink } from "@/components/link";
 import { ItemDialog } from "@/components/payments/item-dialog";
 import { useRouter } from "@/components/router";
@@ -26,10 +28,6 @@ import {
   DialogFooter,
   DialogHeader,
   DialogTitle,
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
   Input,
   Label,
   Select,
@@ -45,7 +43,8 @@ import {
 } from "@/components/ui";
 import { createDefaultDataGridState, DataGrid, useDataGridUrlState, useDataSource, type DataGridColumnDef } from "@hexclave/dashboard-ui-components";
 import { useUpdateConfig } from "@/components/config-update";
-import { ArrowLeftIcon, ClockIcon, CopyIcon, CurrencyDollarIcon, DotsThreeIcon, FolderOpenIcon, GiftIcon, HardDriveIcon, PackageIcon, PencilSimpleIcon, PlusIcon, PuzzlePieceIcon, ShoppingCartIcon, StackIcon, TagIcon, TrashIcon, UsersIcon } from "@phosphor-icons/react";
+import { ArrowLeftIcon, Check, ClockIcon, CopyIcon, CurrencyDollarIcon, FolderOpenIcon, GiftIcon, HardDriveIcon, PackageIcon, PencilSimpleIcon, PlusIcon, PuzzlePieceIcon, ShoppingCartIcon, StackIcon, TagIcon, TrashIcon, UsersIcon, X } from "@phosphor-icons/react";
+import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
 import { CreateCheckoutDialog } from "@/components/payments/create-checkout-dialog";
 import type { CustomerType } from "@/components/payments/customer-selector";
 import type { CompleteConfig } from "@hexclave/shared/dist/config/schema";
@@ -54,8 +53,7 @@ import type { DayInterval } from "@hexclave/shared/dist/utils/dates";
 import { fromNow } from "@hexclave/shared/dist/utils/dates";
 import { prettyPrintWithMagnitudes } from "@hexclave/shared/dist/utils/numbers";
 import { typedEntries } from "@hexclave/shared/dist/utils/objects";
-import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
-import { Suspense, useMemo, useState } from "react";
+import { Suspense, useMemo, useRef, useState } from "react";
 import { PageLayout } from "../../../page-layout";
 import { useAdminApp, useProjectId } from "../../../use-admin-app";
 import { CreateProductLineDialog } from "../create-product-line-dialog";
@@ -73,6 +71,16 @@ const CUSTOMER_TYPE_COLORS = {
   team: 'bg-emerald-500/15 text-emerald-600 dark:bg-emerald-500/20 dark:text-emerald-400 ring-emerald-500/30',
   custom: 'bg-amber-500/15 text-amber-600 dark:bg-amber-500/20 dark:text-amber-400 ring-amber-500/30',
 } as const;
+
+const CUSTOMER_TYPE_BADGE_COLORS = new Map<string, DesignBadgeColor>([
+  ["user", "blue"],
+  ["team", "green"],
+  ["custom", "orange"],
+]);
+
+function getCustomerTypeBadgeColor(customerType: string): DesignBadgeColor {
+  return CUSTOMER_TYPE_BADGE_COLORS.get(customerType) ?? "blue";
+}
 
 export default function PageClient({ productId }: { productId: string }) {
   const adminApp = useAdminApp();
@@ -116,15 +124,15 @@ function ProductPage({ productId, product, config }: ProductPageProps) {
     <PageLayout>
       <div className="flex flex-col gap-6">
         {canGoBack && (
-          <Button
+          <DesignButton
             variant="ghost"
             size="sm"
-            className="w-fit -ml-2 text-muted-foreground hover:text-foreground"
+            className="w-fit -ml-2 h-8 gap-1.5 rounded-lg px-2 text-muted-foreground hover:text-foreground"
             onClick={() => router.back()}
           >
-            <ArrowLeftIcon className="h-4 w-4 mr-1" />
+            <ArrowLeftIcon className="h-4 w-4" />
             Back
-          </Button>
+          </DesignButton>
         )}
         <ProductHeader productId={productId} product={product} productLineName={productLineName} />
         <Separator />
@@ -144,119 +152,240 @@ type ProductHeaderProps = {
   productLineName: string | null,
 };
 
+function ProductTitleEditor({
+  productId,
+  displayName,
+  storedDisplayName,
+}: {
+  productId: string,
+  displayName: string,
+  storedDisplayName: string,
+}) {
+  const adminApp = useAdminApp();
+  const updateConfig = useUpdateConfig();
+  const [editing, setEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState(storedDisplayName);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const beginEditing = () => {
+    setDraftValue(storedDisplayName);
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setDraftValue(storedDisplayName);
+    setEditing(false);
+  };
+
+  const save = async () => {
+    setIsSaving(true);
+    try {
+      const success = await updateConfig({
+        adminApp,
+        configUpdate: {
+          [`payments.products.${productId}.displayName`]: draftValue || null,
+        },
+        pushable: true,
+      });
+      if (success) {
+        toast({ title: "Product name updated" });
+        setEditing(false);
+      }
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
+  return (
+    <div
+      role={editing ? undefined : "button"}
+      tabIndex={editing ? undefined : 0}
+      aria-label={editing ? undefined : "Edit display name"}
+      className={cn(
+        "group flex h-9 min-w-0 flex-1 items-center gap-1.5 rounded-lg border px-2.5",
+        "border-black/[0.1] bg-white cursor-text",
+        "hover:border-black/[0.16] hover:bg-zinc-50",
+        "dark:border-white/[0.1] dark:bg-zinc-950 dark:hover:border-white/[0.18] dark:hover:bg-zinc-900",
+        "transition-colors duration-150 hover:transition-none",
+        editing && "border-black/[0.28] dark:border-white/[0.32]",
+      )}
+      onClick={() => {
+        if (!editing) {
+          beginEditing();
+        } else {
+          inputRef.current?.focus();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (editing) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          beginEditing();
+        }
+      }}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          autoFocus
+          aria-label="Display name"
+          autoComplete="off"
+          disabled={isSaving}
+          value={draftValue}
+          placeholder={productId}
+          onClick={(event) => event.stopPropagation()}
+          onChange={(event) => setDraftValue(event.target.value)}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+              event.preventDefault();
+              runAsynchronouslyWithAlert(save());
+            }
+            if (event.key === "Escape") {
+              cancelEditing();
+            }
+          }}
+          className="min-w-0 flex-1 bg-transparent text-lg font-semibold leading-none tracking-tight text-foreground outline-none placeholder:text-muted-foreground/60 disabled:opacity-50"
+        />
+      ) : (
+        <h1 className="min-w-0 flex-1 truncate text-lg font-semibold leading-none tracking-tight text-foreground">
+          {displayName}
+        </h1>
+      )}
+      {editing ? (
+        <div className="flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
+          <DesignButton
+            aria-label="Save display name"
+            className="h-6 w-6 rounded-md p-0 text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-700 dark:text-emerald-400"
+            disabled={draftValue === storedDisplayName || isSaving}
+            loading={isSaving}
+            onClick={save}
+            size="icon"
+            variant="ghost"
+          >
+            <Check aria-hidden className="h-3.5 w-3.5" weight="bold" />
+          </DesignButton>
+          <DesignButton
+            aria-label="Cancel editing display name"
+            className="h-6 w-6 rounded-md p-0 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400"
+            disabled={isSaving}
+            onClick={cancelEditing}
+            size="icon"
+            variant="ghost"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" weight="bold" />
+          </DesignButton>
+        </div>
+      ) : (
+        <PencilSimpleIcon
+          aria-hidden
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground transition-colors duration-150 group-hover:text-foreground group-hover:transition-none"
+        />
+      )}
+    </div>
+  );
+}
+
 function ProductHeader({ productId, product, productLineName }: ProductHeaderProps) {
   const projectId = useProjectId();
   const adminApp = useAdminApp();
   const project = adminApp.useProject();
   const config = project.useConfig();
-  const updateConfig = useUpdateConfig();
   const router = useRouter();
   const [isCheckoutOpen, setIsCheckoutOpen] = useState(false);
   const displayName = product.displayName || productId;
-  const isAddOn = product.isAddOnTo !== false && typeof product.isAddOnTo === 'object';
+  const isAddOn = product.isAddOnTo !== false && typeof product.isAddOnTo === "object";
 
-  // Find add-on parent products
   const addOnParents = useMemo(() => {
-    if (product.isAddOnTo === false || typeof product.isAddOnTo !== 'object') return [];
-    return Object.keys(product.isAddOnTo).map((parentId: string) => ({
+    if (product.isAddOnTo === false || typeof product.isAddOnTo !== "object") {
+      return [];
+    }
+    return Object.keys(product.isAddOnTo).map((parentId) => ({
       id: parentId,
       displayName: config.payments.products[parentId].displayName || parentId,
     }));
   }, [product.isAddOnTo, config.payments.products]);
 
   return (
-    <div className="flex gap-4 items-start">
-      <div className={cn(
-        "flex h-16 w-16 items-center justify-center rounded-xl shrink-0",
-        "bg-gradient-to-br from-primary/20 to-primary/5",
-        "border border-primary/20"
-      )}>
+    <div className="flex items-start gap-4">
+      <div className="flex h-14 w-14 shrink-0 items-center justify-center rounded-xl border border-black/[0.1] bg-white text-muted-foreground dark:border-white/[0.1] dark:bg-zinc-950">
         {isAddOn ? (
-          <PuzzlePieceIcon className="h-8 w-8 text-primary" />
+          <PuzzlePieceIcon className="h-7 w-7" />
         ) : (
-          <PackageIcon className="h-8 w-8 text-primary" />
+          <PackageIcon className="h-7 w-7" />
         )}
       </div>
-      <div className="flex-grow min-w-0 flex flex-col">
+
+      <div className="flex min-w-0 flex-1 flex-col gap-2">
         <div className="flex items-center gap-2">
-          <div className="flex-1 min-w-0">
-            <EditableInput
-              value={displayName}
-              initialEditValue={product.displayName || ""}
-              placeholder={productId}
-              shiftTextToLeft
-              inputClassName="text-2xl font-semibold tracking-tight w-full"
-              onUpdate={async (newName) => {
-                const success = await updateConfig({ adminApp, configUpdate: {
-                  [`payments.products.${productId}.displayName`]: newName || null,
-                }, pushable: true });
-                if (success) {
-                  toast({ title: "Product name updated" });
-                }
-              }}
+          <ProductTitleEditor
+            productId={productId}
+            displayName={displayName}
+            storedDisplayName={product.displayName || ""}
+          />
+          <div className="flex shrink-0 items-center">
+            <CreateCheckoutDialog
+              open={isCheckoutOpen}
+              onOpenChange={setIsCheckoutOpen}
+              customerType={product.customerType as CustomerType}
+              productId={productId}
+              lockProduct
+            />
+            <DesignMenu
+              variant="actions"
+              trigger="icon"
+              triggerLabel="Product actions"
+              align="end"
+              withIcons
+              items={[
+                {
+                  id: "checkout",
+                  label: "Create checkout",
+                  icon: <ShoppingCartIcon className="h-4 w-4" />,
+                  onClick: () => setIsCheckoutOpen(true),
+                },
+                {
+                  id: "product-lines",
+                  label: "View in Product Lines",
+                  icon: <FolderOpenIcon className="h-4 w-4" />,
+                  onClick: () => router.push(`/projects/${projectId}/payments/product-lines#product-${productId}`),
+                },
+              ]}
             />
           </div>
-          <Button
-            variant="outline"
-            size="sm"
-            className="shrink-0 gap-1.5"
-            onClick={() => router.push(`/projects/${projectId}/payments/products/${productId}/edit`)}
-          >
-            <PencilSimpleIcon className="h-4 w-4" />
-            Edit
-          </Button>
-          <CreateCheckoutDialog
-            open={isCheckoutOpen}
-            onOpenChange={setIsCheckoutOpen}
-            customerType={product.customerType as CustomerType}
-            productId={productId}
-            lockProduct
-          />
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button variant="ghost" size="icon" className="shrink-0">
-                <DotsThreeIcon className="h-5 w-5" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end">
-              <DropdownMenuItem icon={<ShoppingCartIcon className="h-4 w-4" />} onClick={() => setIsCheckoutOpen(true)}>
-                Create checkout
-              </DropdownMenuItem>
-              <DropdownMenuItem onClick={() => router.push(`/projects/${projectId}/payments/product-lines#product-${productId}`)}>
-                View in Product Lines
-              </DropdownMenuItem>
-            </DropdownMenuContent>
-          </DropdownMenu>
         </div>
-        <div className="flex items-center gap-2 mt-1 text-sm text-muted-foreground flex-wrap">
-          <span className={cn(
-            "inline-flex items-center px-2 py-0.5 rounded-full text-[10px] font-semibold uppercase tracking-wide ring-1",
-            CUSTOMER_TYPE_COLORS[product.customerType as keyof typeof CUSTOMER_TYPE_COLORS]
-          )}>
-            {product.customerType}
+
+        <div className="flex flex-wrap items-center gap-2">
+          <DesignBadge
+            label={product.customerType.toUpperCase()}
+            color={getCustomerTypeBadgeColor(product.customerType)}
+            size="sm"
+            contentMode="text"
+          />
+          <span className="inline-flex items-center rounded-md border border-black/[0.08] bg-white px-2 py-0.5 font-mono text-[11px] text-muted-foreground dark:border-white/[0.1] dark:bg-zinc-950">
+            ID: {productId}
           </span>
-          <span className="font-mono text-xs bg-muted px-2 py-0.5 rounded">ID: {productId}</span>
-          {productLineName && (
-            <>
-              <span>•</span>
-              <span>Product Line: {productLineName}</span>
-            </>
+          {productLineName != null && (
+            <span className="inline-flex items-center gap-1.5 text-xs text-muted-foreground">
+              <span className="text-muted-foreground/40">·</span>
+              Product Line: <span className="font-medium text-foreground">{productLineName}</span>
+            </span>
           )}
           {addOnParents.length > 0 && (
-            <>
-              <span>•</span>
-              <span className="flex items-center gap-1">
-                Add-on to{' '}
-                {addOnParents.map((p: { id: string, displayName: string }, i: number) => (
-                  <span key={p.id}>
-                    {i > 0 && ", "}
-                    <StyledLink href={`/projects/${adminApp.projectId}/payments/products/${p.id}`}>
-                      {p.displayName}
-                    </StyledLink>
-                  </span>
-                ))}
-              </span>
-            </>
+            <span className="inline-flex flex-wrap items-center gap-1 text-xs text-muted-foreground">
+              <span className="text-muted-foreground/40">·</span>
+              Add-on to{" "}
+              {addOnParents.map((parent, index) => (
+                <span key={parent.id} className="inline-flex items-center">
+                  {index > 0 && <span className="mr-1 text-muted-foreground/50">,</span>}
+                  <StyledLink href={`/projects/${adminApp.projectId}/payments/products/${parent.id}`}>
+                    {parent.displayName}
+                  </StyledLink>
+                </span>
+              ))}
+            </span>
           )}
         </div>
       </div>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/sidebar-layout.tsx
@@ -614,7 +614,7 @@ function SidebarContent({
       </div>
 
       <div className={cn(
-        "sticky bottom-0 border-t border-black/[0.06] dark:border-foreground/10 py-3 transition-all duration-200 dark:backdrop-blur-xl",
+        "sticky bottom-0 border-t border-black/[0.06] dark:border-foreground/10 py-3 transition-all duration-200 bg-black/[0.03] dark:bg-foreground/[0.06] dark:backdrop-blur-xl",
         !isDrawer && "dark:rounded-b-2xl",
         isCollapsed ? "px-2" : "px-3",
       )}>

--- a/apps/dashboard/src/components/design-components/editable-grid.tsx
+++ b/apps/dashboard/src/components/design-components/editable-grid.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import {
+  Checkbox,
   Popover,
   PopoverContent,
   PopoverTrigger,
@@ -348,6 +349,71 @@ function EditableTextField({
   );
 }
 
+function EditableBooleanField({
+  item,
+  editMode,
+  size,
+}: {
+  item: BooleanItem,
+  editMode: boolean,
+  size: FieldSizeConfig,
+}) {
+  const [isUpdating, setIsUpdating] = useState(false);
+  const canEdit = item.readOnly !== true && item.onUpdate != null;
+  const trueLabel = item.trueLabel ?? "Yes";
+  const falseLabel = item.falseLabel ?? "No";
+  const statusLabel = item.value ? trueLabel : falseLabel;
+
+  if (!canEdit) {
+    return (
+      <div className={cn("flex w-full items-center", size.controlHeight, size.controlPadding)}>
+        <ReadOnlyValue>{statusLabel}</ReadOnlyValue>
+      </div>
+    );
+  }
+
+  const updateValue = async (nextValue: boolean) => {
+    if (item.onUpdate == null) {
+      throw new Error(`Editable boolean item "${item.name}" requires an onUpdate handler.`);
+    }
+    setIsUpdating(true);
+    try {
+      await item.onUpdate(nextValue);
+    } finally {
+      setIsUpdating(false);
+    }
+  };
+
+  return (
+    <label
+      className={cn(
+        "flex w-full cursor-pointer items-center gap-2.5",
+        size.controlHeight,
+        size.controlPadding,
+        designEditableGridControlClassName,
+        editMode && "border-black/[0.18] dark:border-white/[0.22]",
+        isUpdating && "opacity-70",
+      )}
+    >
+      <Checkbox
+        aria-label={item.name}
+        checked={item.value}
+        disabled={isUpdating}
+        onCheckedChange={(checked) => {
+          if (checked === "indeterminate") {
+            return;
+          }
+          runAsynchronouslyWithAlert(updateValue(checked));
+        }}
+        className="border-black/[0.2] shadow-none data-[state=checked]:border-foreground data-[state=checked]:bg-foreground data-[state=checked]:text-background dark:border-white/[0.25] dark:data-[state=checked]:border-white dark:data-[state=checked]:bg-white dark:data-[state=checked]:text-zinc-950"
+      />
+      <span className={cn("min-w-0 truncate", size.controlText, "text-foreground")}>
+        {statusLabel}
+      </span>
+    </label>
+  );
+}
+
 function AsyncSelectField({
   value,
   options,
@@ -510,21 +576,7 @@ function ItemValue({
       return <EditableTextField editMode={editMode} item={item} size={size} />;
     }
     case "boolean": {
-      const onUpdate = item.onUpdate;
-      return (
-        <AsyncSelectField
-          editMode={editMode}
-          name={item.name}
-          onUpdate={onUpdate == null ? undefined : async (value) => await onUpdate(value === "true")}
-          options={[
-            { value: "true", label: item.trueLabel ?? "Yes" },
-            { value: "false", label: item.falseLabel ?? "No" },
-          ]}
-          readOnly={item.readOnly}
-          size={size}
-          value={item.value ? "true" : "false"}
-        />
-      );
+      return <EditableBooleanField editMode={editMode} item={item} size={size} />;
     }
     case "dropdown": {
       return (

--- a/apps/dashboard/src/components/design-components/editable-grid.tsx
+++ b/apps/dashboard/src/components/design-components/editable-grid.tsx
@@ -296,7 +296,9 @@ function EditableTextField({
           onKeyDown={(event) => {
             if (event.key === "Enter" && !event.nativeEvent.isComposing) {
               event.preventDefault();
-              runAsynchronouslyWithAlert(save());
+              if (draftValue !== item.value && !isSaving) {
+                runAsynchronouslyWithAlert(save());
+              }
             }
             if (event.key === "Escape") {
               cancelEditing();
@@ -598,10 +600,10 @@ function ItemValue({
     }
     case "custom-button": {
       return (
-        <button
-          type="button"
+        <DesignButton
+          variant="plain"
           disabled={item.disabled}
-          onClick={() => runAsynchronouslyWithAlert(item.onClick())}
+          onClick={() => item.onClick()}
           className={cn(
             "flex w-full items-center justify-start gap-2 text-left font-normal",
             size.controlHeight,
@@ -609,11 +611,10 @@ function ItemValue({
             size.controlText,
             designEditableGridControlClassName,
             editMode && "border-black/[0.18] dark:border-white/[0.22]",
-            item.disabled && "cursor-not-allowed opacity-50",
           )}
         >
           <span className="min-w-0 truncate">{item.children}</span>
-        </button>
+        </DesignButton>
       );
     }
     case "custom": {
@@ -673,6 +674,17 @@ function SaveBar({
   onDiscard: () => void,
   onSave: () => Promise<void>,
 }) {
+  const [isSaving, setIsSaving] = useState(false);
+
+  const handleSave = async () => {
+    setIsSaving(true);
+    try {
+      await onSave();
+    } finally {
+      setIsSaving(false);
+    }
+  };
+
   return (
     <div
       aria-live="polite"
@@ -685,13 +697,19 @@ function SaveBar({
       <div className="flex items-center justify-end gap-1.5">
         <DesignButton
           className="h-8 rounded-lg px-3 text-xs text-muted-foreground"
+          disabled={isSaving}
           onClick={onDiscard}
           size="sm"
           variant="ghost"
         >
           Discard
         </DesignButton>
-        <DesignButton className="h-8 rounded-lg px-3 text-xs" onClick={onSave} size="sm">
+        <DesignButton
+          className="h-8 rounded-lg px-3 text-xs"
+          loading={isSaving}
+          onClick={handleSave}
+          size="sm"
+        >
           Save changes
         </DesignButton>
       </div>
@@ -734,7 +752,7 @@ export function DesignEditableGrid({
           "grid items-center text-sm",
           resolvedSize.gapX,
           resolvedSize.gapY,
-          columns === 2 && "lg:[&>*:nth-child(4n+3)]:pl-4",
+          columns === 2 && "lg:[&>div:nth-child(even)>:first-child]:pl-4",
           gridCols,
           className,
         )}

--- a/apps/dashboard/src/components/design-components/editable-grid.tsx
+++ b/apps/dashboard/src/components/design-components/editable-grid.tsx
@@ -1,6 +1,9 @@
 "use client";
 
 import {
+  Popover,
+  PopoverContent,
+  PopoverTrigger,
   Select,
   SelectContent,
   SelectItem,
@@ -10,29 +13,23 @@ import {
   Spinner,
 } from "@/components/ui";
 import { cn } from "@/lib/utils";
-import { useAsyncCallback } from "@hexclave/shared/dist/hooks/use-async-callback";
-import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
-import { ArrowCounterClockwise, Check, FloppyDisk, X } from "@phosphor-icons/react";
-import { useRef, useState } from "react";
-import { DesignButton, useDesignEditMode, DesignInput } from "@hexclave/dashboard-ui-components";
+import { DesignButton, useDesignEditMode } from "@hexclave/dashboard-ui-components";
+import {
+  CaretDown,
+  Check,
+  PencilSimple,
+  X,
+} from "@phosphor-icons/react";
+import { useRef, useState, type HTMLAttributes, type ReactNode } from "react";
 
 export type DesignEditableGridSize = "sm" | "md";
 
-const sizeConfig = {
-  sm: { height: "h-7", minHeight: "min-h-7", padding: "px-2", customPl: "pl-2", gapX: "gap-x-1.5", interColPl: "lg:[&>*:nth-child(4n+3)]:pl-3" },
-  md: { height: "h-8", minHeight: "min-h-8", padding: "px-3", customPl: "pl-3", gapX: "gap-x-3", interColPl: "lg:[&>*:nth-child(4n+3)]:pl-5" },
-} as const;
-
-// Ghost mode: hide visual decorations (bg, border, shadow, ring) by default
-const ghostFieldClasses = "bg-transparent dark:bg-transparent border-transparent dark:border-transparent shadow-none ring-0";
-// Ghost mode: reveal visual decorations on hover
-const ghostFieldHoverClasses = "hover:bg-white/80 dark:hover:bg-foreground/[0.03] hover:border-black/[0.08] dark:hover:border-white/[0.06] hover:shadow-sm hover:ring-1 hover:ring-black/[0.08] dark:hover:ring-white/[0.06]";
-
 type BaseItemProps = {
   itemKey?: string,
-  icon: React.ReactNode,
+  icon: ReactNode,
   name: string,
+  description?: string,
   tooltip?: string,
 };
 
@@ -43,6 +40,7 @@ type TextItem = BaseItemProps & {
   normalizeInput?: (value: string) => string,
   readOnly?: boolean,
   placeholder?: string,
+  inputMode?: HTMLAttributes<HTMLInputElement>["inputMode"],
 };
 
 type BooleanItem = BaseItemProps & {
@@ -54,7 +52,7 @@ type BooleanItem = BaseItemProps & {
   falseLabel?: string,
 };
 
-type DropdownOption = {
+export type DesignEditableGridDropdownOption = {
   value: string,
   label: string,
   disabled?: boolean,
@@ -64,19 +62,20 @@ type DropdownOption = {
 type DropdownItem = BaseItemProps & {
   type: "dropdown",
   value: string,
-  options: DropdownOption[],
+  options: DesignEditableGridDropdownOption[],
   onUpdate?: (value: string) => Promise<void>,
   readOnly?: boolean,
+  placeholder?: string,
   extraAction?: {
     label: string,
-    onClick: () => void,
+    onClick: () => void | Promise<void>,
   },
 };
 
 type CustomDropdownItem = BaseItemProps & {
   type: "custom-dropdown",
-  triggerContent: React.ReactNode,
-  popoverContent: React.ReactNode,
+  triggerContent: ReactNode,
+  popoverContent: ReactNode,
   open?: boolean,
   onOpenChange?: (open: boolean) => void,
   disabled?: boolean,
@@ -84,14 +83,14 @@ type CustomDropdownItem = BaseItemProps & {
 
 type CustomButtonItem = BaseItemProps & {
   type: "custom-button",
-  children: React.ReactNode,
-  onClick: () => void,
+  children: ReactNode,
+  onClick: () => void | Promise<void>,
   disabled?: boolean,
 };
 
 type CustomContentItem = BaseItemProps & {
   type: "custom",
-  children: React.ReactNode,
+  children: ReactNode,
 };
 
 export type DesignEditableGridItem =
@@ -102,7 +101,7 @@ export type DesignEditableGridItem =
   | CustomButtonItem
   | CustomContentItem;
 
-type DesignEditableGridProps = {
+export type DesignEditableGridProps = {
   items: DesignEditableGridItem[],
   columns?: 1 | 2,
   size?: DesignEditableGridSize,
@@ -112,564 +111,538 @@ type DesignEditableGridProps = {
   hasChanges?: boolean,
   onSave?: () => Promise<void>,
   onDiscard?: () => void,
-  externalModifiedKeys?: Set<string>,
+  externalModifiedKeys?: ReadonlySet<string>,
+  "aria-label"?: string,
 };
 
-type DesignEditableInputProps = {
-  value: string,
-  onUpdate?: (value: string) => Promise<void>,
-  normalizeInput?: (value: string) => string,
-  readOnly?: boolean,
-  placeholder?: string,
-  inputClassName?: string,
-  shiftTextToLeft?: boolean,
-  mode?: "text" | "password",
+type FieldSizeConfig = {
+  control: "sm" | "md",
+  controlHeight: string,
+  controlPadding: string,
+  controlText: string,
+  labelHeight: string,
+  iconSize: string,
+  gapX: string,
+  gapY: string,
 };
 
-function DesignEditableInput({
-  value,
-  onUpdate,
-  normalizeInput,
-  readOnly,
-  placeholder,
-  inputClassName,
-  shiftTextToLeft,
-  mode = "text",
-  editMode,
-  sz,
-}: DesignEditableInputProps & { editMode: boolean, sz: typeof sizeConfig[DesignEditableGridSize] }) {
-  const [editValue, setEditValue] = useState<string | null>(null);
-  const [hasChanged, setHasChanged] = useState(false);
-  const editing = editValue !== null;
-  const forceAllowBlur = useRef(false);
-  const containerRef = useRef<HTMLDivElement>(null);
-  const inputRef = useRef<HTMLInputElement>(null);
-  const acceptRef = useRef<HTMLButtonElement>(null);
-  const [handleUpdate, isLoading] = useAsyncCallback(async (nextValue: string) => {
-    await onUpdate?.(nextValue);
-  }, [onUpdate]);
+const sizeConfig = new Map<DesignEditableGridSize, FieldSizeConfig>([
+  ["sm", {
+    control: "sm",
+    controlHeight: "h-8",
+    controlPadding: "px-2.5",
+    controlText: "text-sm",
+    labelHeight: "min-h-8",
+    iconSize: "h-6 w-6",
+    gapX: "gap-x-3",
+    gapY: "gap-y-3",
+  }],
+  ["md", {
+    control: "md",
+    controlHeight: "h-9",
+    controlPadding: "px-3",
+    controlText: "text-sm",
+    labelHeight: "min-h-9",
+    iconSize: "h-7 w-7",
+    gapX: "gap-x-4",
+    gapY: "gap-y-4",
+  }],
+]);
 
-  return <div
-    ref={containerRef}
-    className="flex items-center relative w-full"
-    onFocus={() => {
-      if (!readOnly) {
-        setEditValue(editValue ?? value);
-      }
-    }}
-    onBlur={() => {
-      if (forceAllowBlur.current) return;
-      if (!hasChanged) {
-        setEditValue(null);
-      } else if (confirm("You have unapplied changes. Would you like to save them?")) {
-        acceptRef.current?.click();
-      } else {
-        setEditValue(null);
-        setHasChanged(false);
-      }
-    }}
-    onMouseDown={(ev) => {
-      if (containerRef.current?.contains(ev.target as Node)) {
-        ev.preventDefault();
-        return false;
-      }
-    }}
-  >
-    <DesignInput
-      type={mode === "password" ? "password" : "text"}
-      ref={inputRef}
-      readOnly={readOnly}
-      disabled={isLoading}
-      placeholder={placeholder}
-      tabIndex={readOnly ? -1 : undefined}
-      size="sm"
-      className={cn(
-        "w-full text-sm", sz.height, sz.padding,
-        !readOnly && "hover:cursor-pointer",
-        !readOnly && "focus:cursor-[unset]",
-        readOnly && "focus-visible:ring-0 cursor-default text-muted-foreground",
-        shiftTextToLeft && "ml-[-7px]",
-        !editMode && ghostFieldClasses,
-        !editMode && !readOnly && ghostFieldHoverClasses,
-        inputClassName,
-      )}
-      value={editValue ?? value}
-      autoComplete="off"
-      style={{ textOverflow: "ellipsis" }}
-      onChange={(e) => {
-        setEditValue(normalizeInput?.(e.target.value) ?? e.target.value);
-        setHasChanged(true);
-      }}
-      onKeyDown={(e) => {
-        if (e.key === "Enter") {
-          acceptRef.current?.click();
-        }
-      }}
-      onMouseDown={(ev) => {
-        ev.stopPropagation();
-      }}
-    />
-    <div
-      className="flex gap-1 overflow-hidden transition-all duration-200 ease-in-out"
-      style={{
-        width: editing ? "4rem" : 0,
-        marginLeft: editing ? "0.5rem" : 0,
-        opacity: editing ? 1 : 0,
-      }}
-    >
-      {["accept", "reject"].map((action) => (
-        <DesignButton
-          ref={action === "accept" ? acceptRef : undefined}
-          key={action}
-          disabled={isLoading}
-          type="button"
-          variant="plain"
-          size="icon"
-          className={cn(
-            "h-7 w-7 rounded-lg flex items-center justify-center backdrop-blur-sm",
-            "border border-black/[0.08] dark:border-white/[0.08]",
-            "bg-white/75 dark:bg-foreground/[0.04]",
-            "shadow-sm ring-1 ring-black/[0.06] dark:ring-white/[0.06]",
-            "transition-colors duration-150 hover:transition-none",
-            action === "accept"
-              ? "text-emerald-600 dark:text-emerald-400 hover:bg-emerald-500/[0.12] hover:ring-emerald-500/30"
-              : "text-red-600 dark:text-red-400 hover:bg-red-500/[0.12] hover:ring-red-500/30",
-          )}
-          onClick={() => runAsynchronouslyWithAlert(async () => {
-            try {
-              forceAllowBlur.current = true;
-              inputRef.current?.blur();
-              if (action === "accept") {
-                await handleUpdate(editValue ?? throwErr("No value to update"));
-              }
-              setEditValue(null);
-              setHasChanged(false);
-            } finally {
-              forceAllowBlur.current = false;
-            }
-          })}
-        >
-          {action === "accept"
-            ? <Check weight="bold" className="h-3.5 w-3.5" />
-            : <X weight="bold" className="h-3.5 w-3.5" />}
-        </DesignButton>
-      ))}
-    </div>
-  </div>;
+/**
+ * Shared editable control surface for DesignEditableGrid and page-local
+ * custom triggers that sit inside a grid value cell. White / neutral only —
+ * never tinted theme backgrounds that read as purple on glass pages.
+ */
+export const designEditableGridControlClassName = cn(
+  "rounded-lg border border-black/[0.1] bg-white text-foreground shadow-none",
+  "hover:bg-zinc-50 hover:border-black/[0.16]",
+  "focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-black/[0.12]",
+  "dark:border-white/[0.1] dark:bg-zinc-950 dark:hover:bg-zinc-900 dark:hover:border-white/[0.18]",
+  "dark:focus-visible:ring-white/[0.16]",
+  "transition-colors duration-150 hover:transition-none",
+);
+
+export const designEditableGridPopoverClassName = cn(
+  "w-64 rounded-xl border border-black/[0.1] bg-white p-3 shadow-lg",
+  "dark:border-white/[0.1] dark:bg-zinc-950",
+);
+
+function getSizeConfig(size: DesignEditableGridSize) {
+  const config = sizeConfig.get(size);
+  if (config == null) {
+    throw new Error(`DesignEditableGrid does not define styles for size "${size}".`);
+  }
+  return config;
 }
 
-function GridLabel({
-  icon,
-  name,
-  tooltip,
-  isModified,
-  sz,
+function ReadOnlyValue({
+  children,
+  placeholder,
 }: {
-  icon: React.ReactNode,
-  name: string,
-  tooltip?: string,
-  isModified?: boolean,
-  sz: typeof sizeConfig[DesignEditableGridSize],
+  children: ReactNode,
+  placeholder?: string,
 }) {
-  const label = (
-    <span className={cn("flex items-center gap-2 text-xs font-semibold text-foreground", sz.height)}>
-      <span className="flex h-6 w-6 items-center justify-center rounded-lg bg-foreground/[0.04] text-muted-foreground">
-        {icon}
-      </span>
-      <span className="whitespace-nowrap">{name}</span>
-      <span className={cn("h-1.5 w-1.5 rounded-full bg-amber-500 transition-opacity duration-150", isModified ? "opacity-100" : "opacity-0")} />
+  const hasValue = children !== "";
+
+  return (
+    <span className={cn(
+      "block min-w-0 truncate text-sm",
+      hasValue ? "text-foreground" : "text-muted-foreground/70",
+    )}>
+      {hasValue ? children : (placeholder ?? "—")}
     </span>
   );
-
-  if (tooltip) {
-    return (
-      <SimpleTooltip tooltip={tooltip}>
-        {label}
-      </SimpleTooltip>
-    );
-  }
-
-  return label;
 }
 
-function EditableBooleanField({
-  value,
-  onUpdate,
-  readOnly,
-  trueLabel = "Yes",
-  falseLabel = "No",
+function EditableTextField({
+  item,
   editMode,
-  sz,
+  size,
 }: {
-  value: boolean,
-  onUpdate?: (value: boolean) => Promise<void>,
-  readOnly?: boolean,
-  trueLabel?: string,
-  falseLabel?: string,
+  item: TextItem,
   editMode: boolean,
-  sz: typeof sizeConfig[DesignEditableGridSize],
+  size: FieldSizeConfig,
 }) {
-  const [isUpdating, setIsUpdating] = useState(false);
+  const [editing, setEditing] = useState(false);
+  const [draftValue, setDraftValue] = useState(item.value);
+  const [isSaving, setIsSaving] = useState(false);
+  const inputRef = useRef<HTMLInputElement>(null);
+  const canEdit = item.readOnly !== true && item.onUpdate != null;
 
-  const handleChange = async (newValue: string) => {
-    if (!onUpdate) return;
-    setIsUpdating(true);
+  const beginEditing = () => {
+    if (!canEdit) {
+      return;
+    }
+    setDraftValue(item.value);
+    setEditing(true);
+  };
+
+  const cancelEditing = () => {
+    setDraftValue(item.value);
+    setEditing(false);
+  };
+
+  const save = async () => {
+    if (item.onUpdate == null) {
+      throw new Error(`Editable text item "${item.name}" requires an onUpdate handler.`);
+    }
+
+    setIsSaving(true);
     try {
-      await onUpdate(newValue === "true");
+      await item.onUpdate(draftValue);
+      setEditing(false);
     } finally {
-      setIsUpdating(false);
+      setIsSaving(false);
     }
   };
 
-  if (readOnly) {
+  if (!canEdit && !editing) {
     return (
-      <span className={cn(
-        "flex w-full items-center rounded-xl text-sm text-muted-foreground", sz.height, sz.padding,
-        editMode
-          ? "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06] shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]"
-          : "border border-transparent"
-      )}>
-        {value ? trueLabel : falseLabel}
-      </span>
+      <div className={cn("flex w-full items-center", size.controlHeight, size.controlPadding)}>
+        <ReadOnlyValue placeholder={item.placeholder}>{item.value}</ReadOnlyValue>
+      </div>
     );
   }
 
+  // Idle and edit share the same shell so height/width/radius never jump —
+  // only the border weight and trailing actions change.
   return (
-    <div className="relative w-full">
-      <Select
-        value={value ? "true" : "false"}
-        onValueChange={(nextValue) => runAsynchronouslyWithAlert(handleChange(nextValue))}
-        disabled={isUpdating}
-      >
-        <SelectTrigger
+    <div
+      role={editing ? undefined : "button"}
+      tabIndex={editing ? undefined : 0}
+      aria-label={editing ? undefined : `Edit ${item.name}`}
+      className={cn(
+        "flex w-full min-w-0 items-center gap-1",
+        size.controlHeight,
+        size.controlPadding,
+        designEditableGridControlClassName,
+        editing
+          ? "border-black/[0.28] dark:border-white/[0.32]"
+          : editMode && "border-black/[0.18] dark:border-white/[0.22]",
+        !editing && "cursor-text",
+      )}
+      onClick={() => {
+        if (!editing) {
+          beginEditing();
+        } else {
+          inputRef.current?.focus();
+        }
+      }}
+      onKeyDown={(event) => {
+        if (editing) {
+          return;
+        }
+        if (event.key === "Enter" || event.key === " ") {
+          event.preventDefault();
+          beginEditing();
+        }
+      }}
+    >
+      {editing ? (
+        <input
+          ref={inputRef}
+          autoFocus
+          aria-label={item.name}
+          autoComplete="off"
+          disabled={isSaving}
+          inputMode={item.inputMode}
+          onChange={(event) => {
+            const nextValue = event.target.value;
+            setDraftValue(item.normalizeInput?.(nextValue) ?? nextValue);
+          }}
+          onClick={(event) => event.stopPropagation()}
+          onKeyDown={(event) => {
+            if (event.key === "Enter" && !event.nativeEvent.isComposing) {
+              event.preventDefault();
+              runAsynchronouslyWithAlert(save());
+            }
+            if (event.key === "Escape") {
+              cancelEditing();
+            }
+          }}
+          placeholder={item.placeholder}
+          value={draftValue}
           className={cn(
-            "w-full rounded-xl text-sm text-foreground", sz.height, sz.padding,
-            "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06]",
-            "shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]",
-            "hover:text-foreground hover:bg-white dark:hover:bg-foreground/[0.06]",
-            "transition-colors duration-150 hover:transition-none",
-            "[&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-50",
-            isUpdating && "[&_span]:invisible",
-            !editMode && ghostFieldClasses,
-            !editMode && ghostFieldHoverClasses,
-            !editMode && "[&>svg]:opacity-0 hover:[&>svg]:opacity-50",
+            "min-w-0 flex-1 bg-transparent text-sm text-foreground outline-none",
+            "placeholder:text-muted-foreground/70",
+            "disabled:cursor-not-allowed disabled:opacity-50",
           )}
-        >
-          <SelectValue />
-        </SelectTrigger>
-        <SelectContent>
-          <SelectItem value="true">{trueLabel}</SelectItem>
-          <SelectItem value="false">{falseLabel}</SelectItem>
-        </SelectContent>
-      </Select>
-      {isUpdating && (
-        <Spinner
-          size={14}
-          className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"
+        />
+      ) : (
+        <span className="min-w-0 flex-1">
+          <ReadOnlyValue placeholder={item.placeholder}>{item.value}</ReadOnlyValue>
+        </span>
+      )}
+      {editing ? (
+        <div className="flex shrink-0 items-center gap-0.5" onClick={(event) => event.stopPropagation()}>
+          <DesignButton
+            aria-label={`Save ${item.name}`}
+            className="h-6 w-6 rounded-md p-0 text-emerald-600 hover:bg-emerald-500/10 hover:text-emerald-700 dark:text-emerald-400 dark:hover:text-emerald-300"
+            disabled={draftValue === item.value || isSaving}
+            loading={isSaving}
+            onClick={save}
+            size="icon"
+            variant="ghost"
+          >
+            <Check aria-hidden className="h-3.5 w-3.5" weight="bold" />
+          </DesignButton>
+          <DesignButton
+            aria-label={`Cancel editing ${item.name}`}
+            className="h-6 w-6 rounded-md p-0 text-red-600 hover:bg-red-500/10 hover:text-red-700 dark:text-red-400 dark:hover:text-red-300"
+            disabled={isSaving}
+            onClick={cancelEditing}
+            size="icon"
+            variant="ghost"
+          >
+            <X aria-hidden className="h-3.5 w-3.5" weight="bold" />
+          </DesignButton>
+        </div>
+      ) : (
+        <PencilSimple
+          aria-hidden
+          className="h-3.5 w-3.5 shrink-0 text-muted-foreground"
         />
       )}
     </div>
   );
 }
 
-function EditableDropdownField({
+function AsyncSelectField({
   value,
   options,
   onUpdate,
   readOnly,
-  extraAction,
+  placeholder,
+  name,
   editMode,
-  sz,
+  size,
+  extraAction,
 }: {
   value: string,
-  options: DropdownOption[],
+  options: DesignEditableGridDropdownOption[],
   onUpdate?: (value: string) => Promise<void>,
   readOnly?: boolean,
-  extraAction?: { label: string, onClick: () => void },
+  placeholder?: string,
+  name: string,
   editMode: boolean,
-  sz: typeof sizeConfig[DesignEditableGridSize],
+  size: FieldSizeConfig,
+  extraAction?: DropdownItem["extraAction"],
 }) {
   const [isUpdating, setIsUpdating] = useState(false);
+  const selectedOption = options.find((option) => option.value === value);
+  const canEdit = readOnly !== true && onUpdate != null;
 
-  const handleChange = async (newValue: string) => {
-    if (!onUpdate) return;
+  if (!canEdit) {
+    return (
+      <div className={cn("flex w-full items-center", size.controlHeight, size.controlPadding)}>
+        <ReadOnlyValue placeholder={placeholder}>{selectedOption?.label ?? value}</ReadOnlyValue>
+      </div>
+    );
+  }
+
+  const updateValue = async (nextValue: string) => {
     setIsUpdating(true);
     try {
-      await onUpdate(newValue);
+      await onUpdate(nextValue);
     } finally {
       setIsUpdating(false);
     }
   };
 
-  const selectedOption = options.find(option => option.value === value);
-
-  if (readOnly) {
-    return (
-      <span className={cn(
-        "flex w-full items-center rounded-xl text-sm text-muted-foreground", sz.height, sz.padding,
-        editMode
-          ? "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06] shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]"
-          : "border border-transparent"
-      )}>
-        {selectedOption?.label ?? value}
-      </span>
-    );
-  }
-
   return (
     <div className="relative w-full">
       <Select
-        value={value}
-        onValueChange={(nextValue) => runAsynchronouslyWithAlert(handleChange(nextValue))}
         disabled={isUpdating}
+        onValueChange={(nextValue) => runAsynchronouslyWithAlert(updateValue(nextValue))}
+        value={value}
       >
         <SelectTrigger
+          aria-label={name}
           className={cn(
-            "w-full rounded-xl text-sm text-foreground", sz.height, sz.padding,
-            "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06]",
-            "shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]",
-            "hover:text-foreground hover:bg-white dark:hover:bg-foreground/[0.06]",
-            "transition-colors duration-150 hover:transition-none",
-            "[&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-50",
-            isUpdating && "[&_span]:invisible",
-            !editMode && ghostFieldClasses,
-            !editMode && ghostFieldHoverClasses,
-            !editMode && "[&>svg]:opacity-0 hover:[&>svg]:opacity-50",
+            "w-full shadow-none ring-0 [&>svg]:h-3.5 [&>svg]:w-3.5 [&>svg]:opacity-50",
+            size.controlHeight,
+            size.controlPadding,
+            size.controlText,
+            designEditableGridControlClassName,
+            editMode && "border-black/[0.18] dark:border-white/[0.22]",
+            isUpdating && "[&>span]:opacity-0",
           )}
         >
-          <SelectValue />
+          <SelectValue placeholder={placeholder} />
         </SelectTrigger>
-        <SelectContent>
+        <SelectContent className="bg-white dark:bg-zinc-950 border-black/[0.1] dark:border-white/[0.1]">
           {options.map((option) => {
-            const optionItem = (
+            const optionContent = (
               <SelectItem
+                className={option.disabled ? "opacity-50" : undefined}
+                disabled={option.disabled}
                 key={option.value}
                 value={option.value}
-                disabled={option.disabled}
-                className={option.disabled ? "opacity-50" : undefined}
               >
                 {option.label}
               </SelectItem>
             );
-            if (option.disabled && option.disabledReason) {
+
+            if (option.disabled && option.disabledReason != null) {
               return (
                 <SimpleTooltip key={option.value} tooltip={option.disabledReason}>
-                  <div>{optionItem}</div>
+                  <div>{optionContent}</div>
                 </SimpleTooltip>
               );
             }
-            return optionItem;
+            return optionContent;
           })}
-          {extraAction && (
+          {extraAction != null && (
             <>
-              <div className="h-px bg-border my-1" />
-              <button
-                type="button"
-                className="w-full px-2 py-1.5 text-left text-sm text-primary hover:bg-accent rounded-sm cursor-pointer"
-                onClick={(e) => {
-                e.preventDefault();
-                extraAction.onClick();
-                }}
+              <div className="my-1 h-px bg-black/[0.08] dark:bg-white/[0.1]" />
+              <DesignButton
+                className="h-8 w-full justify-start rounded-md px-2 text-xs"
+                onClick={extraAction.onClick}
+                size="sm"
+                variant="ghost"
               >
                 {extraAction.label}
-              </button>
+              </DesignButton>
             </>
           )}
         </SelectContent>
       </Select>
       {isUpdating && (
         <Spinner
+          aria-label={`Updating ${name}`}
+          className="pointer-events-none absolute right-3 top-1/2 -translate-y-1/2"
           size={14}
-          className="absolute right-3 top-1/2 -translate-y-1/2 pointer-events-none"
         />
       )}
     </div>
   );
 }
 
-function CustomButtonField({
-  children,
-  onClick,
-  disabled,
-  editMode,
-  sz,
-}: {
-  children: React.ReactNode,
-  onClick: () => void | Promise<void>,
-  disabled?: boolean,
-  editMode: boolean,
-  sz: typeof sizeConfig[DesignEditableGridSize],
-}) {
-  return (
-    <DesignButton
-      variant="outline"
-      size="sm"
-      className={cn(
-        "w-full rounded-xl text-left text-sm text-foreground truncate justify-start", sz.height, sz.padding,
-        "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06]",
-        "shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]",
-        !disabled && "hover:text-foreground hover:bg-white dark:hover:bg-foreground/[0.06] hover:cursor-pointer",
-        "transition-colors duration-150 hover:transition-none",
-        disabled && "opacity-50 cursor-not-allowed",
-        !editMode && ghostFieldClasses,
-        !editMode && !disabled && ghostFieldHoverClasses,
-      )}
-      onClick={onClick}
-      disabled={disabled}
-    >
-      {children}
-    </DesignButton>
-  );
-}
-
 function CustomDropdownField({
-  triggerContent,
-  disabled,
+  item,
   editMode,
-  sz,
+  size,
 }: {
-  triggerContent: React.ReactNode,
-  disabled?: boolean,
+  item: CustomDropdownItem,
   editMode: boolean,
-  sz: typeof sizeConfig[DesignEditableGridSize],
+  size: FieldSizeConfig,
 }) {
   return (
-    <button
-      disabled={disabled}
-      className={cn(
-        "w-full rounded-xl text-left text-sm text-foreground truncate", sz.height, sz.padding,
-        "bg-white/80 dark:bg-foreground/[0.03] border border-black/[0.08] dark:border-white/[0.06]",
-        "shadow-sm ring-1 ring-black/[0.08] dark:ring-white/[0.06]",
-        !disabled && "hover:text-foreground hover:bg-white dark:hover:bg-foreground/[0.06] hover:cursor-pointer",
-        "focus:outline-none focus-visible:ring-1 focus-visible:ring-foreground/[0.1]",
-        "transition-colors duration-150 hover:transition-none",
-        disabled && "opacity-50 cursor-not-allowed",
-        !editMode && ghostFieldClasses,
-        !editMode && !disabled && ghostFieldHoverClasses,
-      )}
-    >
-      {triggerContent}
-    </button>
+    <Popover open={item.open} onOpenChange={item.onOpenChange}>
+      <PopoverTrigger asChild>
+        <button
+          type="button"
+          aria-label={item.name}
+          disabled={item.disabled}
+          className={cn(
+            "flex w-full items-center justify-between gap-2 text-left font-normal",
+            size.controlHeight,
+            size.controlPadding,
+            size.controlText,
+            designEditableGridControlClassName,
+            editMode && "border-black/[0.18] dark:border-white/[0.22]",
+            item.disabled && "cursor-not-allowed opacity-50",
+          )}
+        >
+          <span className="min-w-0 truncate">{item.triggerContent}</span>
+          <CaretDown aria-hidden className="h-3.5 w-3.5 shrink-0 text-muted-foreground" />
+        </button>
+      </PopoverTrigger>
+      <PopoverContent align="start" className={designEditableGridPopoverClassName}>
+        {item.popoverContent}
+      </PopoverContent>
+    </Popover>
   );
 }
 
-function GridItemValue({ item, editMode, sz }: { item: DesignEditableGridItem, editMode: boolean, sz: typeof sizeConfig[DesignEditableGridSize] }) {
+function ItemValue({
+  item,
+  editMode,
+  size,
+}: {
+  item: DesignEditableGridItem,
+  editMode: boolean,
+  size: FieldSizeConfig,
+}) {
   switch (item.type) {
     case "text": {
-      return (
-        <DesignEditableInput
-          value={item.value}
-          onUpdate={item.onUpdate}
-          normalizeInput={item.normalizeInput}
-          readOnly={item.readOnly}
-          placeholder={item.placeholder}
-          editMode={editMode}
-          sz={sz}
-        />
-      );
+      return <EditableTextField editMode={editMode} item={item} size={size} />;
     }
     case "boolean": {
+      const onUpdate = item.onUpdate;
       return (
-        <EditableBooleanField
-          value={item.value}
-          onUpdate={item.onUpdate}
-          readOnly={item.readOnly}
-          trueLabel={item.trueLabel}
-          falseLabel={item.falseLabel}
+        <AsyncSelectField
           editMode={editMode}
-          sz={sz}
+          name={item.name}
+          onUpdate={onUpdate == null ? undefined : async (value) => await onUpdate(value === "true")}
+          options={[
+            { value: "true", label: item.trueLabel ?? "Yes" },
+            { value: "false", label: item.falseLabel ?? "No" },
+          ]}
+          readOnly={item.readOnly}
+          size={size}
+          value={item.value ? "true" : "false"}
         />
       );
     }
     case "dropdown": {
       return (
-        <EditableDropdownField
-          value={item.value}
-          options={item.options}
-          onUpdate={item.onUpdate}
-          readOnly={item.readOnly}
-          extraAction={item.extraAction}
+        <AsyncSelectField
           editMode={editMode}
-          sz={sz}
+          extraAction={item.extraAction}
+          name={item.name}
+          onUpdate={item.onUpdate}
+          options={item.options}
+          placeholder={item.placeholder}
+          readOnly={item.readOnly}
+          size={size}
+          value={item.value}
         />
       );
     }
     case "custom-dropdown": {
-      return (
-        <CustomDropdownField
-          triggerContent={item.triggerContent}
-          disabled={item.disabled}
-          editMode={editMode}
-          sz={sz}
-        />
-      );
+      return <CustomDropdownField editMode={editMode} item={item} size={size} />;
     }
     case "custom-button": {
       return (
-        <CustomButtonField
-          onClick={item.onClick}
+        <button
+          type="button"
           disabled={item.disabled}
-          editMode={editMode}
-          sz={sz}
+          onClick={() => runAsynchronouslyWithAlert(item.onClick())}
+          className={cn(
+            "flex w-full items-center justify-start gap-2 text-left font-normal",
+            size.controlHeight,
+            size.controlPadding,
+            size.controlText,
+            designEditableGridControlClassName,
+            editMode && "border-black/[0.18] dark:border-white/[0.22]",
+            item.disabled && "cursor-not-allowed opacity-50",
+          )}
         >
-          {item.children}
-        </CustomButtonField>
+          <span className="min-w-0 truncate">{item.children}</span>
+        </button>
       );
     }
     case "custom": {
-      return <div className={cn("w-full", sz.customPl)}>{item.children}</div>;
+      return <div className="min-w-0 w-full text-sm text-foreground">{item.children}</div>;
     }
   }
 }
 
-function GridItemContent({ item, isModified, editMode, sz }: { item: DesignEditableGridItem, isModified?: boolean, editMode: boolean, sz: typeof sizeConfig[DesignEditableGridSize] }) {
-  return (
-    <>
-      <GridLabel icon={item.icon} name={item.name} tooltip={item.tooltip} isModified={isModified} sz={sz} />
-      <div className={cn("min-w-0 w-full flex items-center", sz.minHeight)}>
-        <GridItemValue item={item} editMode={editMode} sz={sz} />
-      </div>
-    </>
+function ItemLabel({
+  item,
+  isModified,
+  size,
+}: {
+  item: DesignEditableGridItem,
+  isModified: boolean,
+  size: FieldSizeConfig,
+}) {
+  const label = (
+    <div className={cn("flex min-w-0 items-center gap-2", size.labelHeight)}>
+      <span className={cn(
+        "flex shrink-0 items-center justify-center rounded-md bg-zinc-100 text-muted-foreground",
+        "dark:bg-zinc-900",
+        size.iconSize,
+      )}>
+        {item.icon}
+      </span>
+      <span className="min-w-0">
+        <span className="flex items-center gap-2">
+          <span className="truncate text-xs font-semibold text-foreground">{item.name}</span>
+          {isModified && (
+            <span
+              aria-label="Modified"
+              className="h-1.5 w-1.5 shrink-0 rounded-full bg-amber-500"
+            />
+          )}
+        </span>
+        {item.description != null && (
+          <span className="mt-0.5 block line-clamp-2 text-[11px] leading-4 text-muted-foreground">
+            {item.description}
+          </span>
+        )}
+      </span>
+    </div>
   );
+
+  if (item.tooltip == null) {
+    return label;
+  }
+
+  return <SimpleTooltip tooltip={item.tooltip}>{label}</SimpleTooltip>;
 }
 
-function DesignInlineSaveDiscard({
-  hasChanges,
-  onSave,
+function SaveBar({
   onDiscard,
+  onSave,
 }: {
-  hasChanges: boolean,
-  onSave: () => Promise<void>,
   onDiscard: () => void,
+  onSave: () => Promise<void>,
 }) {
-  const [handleSave, isSaving] = useAsyncCallback(onSave, [onSave]);
-
   return (
     <div
-      className={cn(
-        "flex items-center justify-end gap-2 transition-all duration-200 ease-out",
-        hasChanges ? "opacity-100 max-h-12 pt-1.5" : "opacity-0 max-h-0 overflow-hidden pt-0"
-      )}
+      aria-live="polite"
+      className="flex flex-col gap-3 rounded-xl border border-amber-500/25 bg-amber-50 px-3 py-2.5 sm:flex-row sm:items-center sm:justify-between dark:border-amber-500/20 dark:bg-amber-500/[0.08]"
     >
-      <DesignButton
-        variant="ghost"
-        size="sm"
-        onClick={onDiscard}
-        disabled={isSaving}
-        className="h-8 px-3 text-xs font-medium text-muted-foreground hover:text-foreground hover:bg-foreground/[0.05] rounded-lg transition-colors duration-150 hover:transition-none gap-1.5"
-      >
-        <ArrowCounterClockwise className="h-3 w-3" />
-        <span>Discard</span>
-      </DesignButton>
-      <DesignButton
-        size="sm"
-        onClick={handleSave}
-        disabled={isSaving}
-        className="h-8 px-4 text-xs font-medium rounded-lg gap-1.5"
-      >
-        <FloppyDisk className="h-3 w-3" />
-        <span>Save</span>
-      </DesignButton>
+      <div className="flex items-center gap-2 text-xs font-medium text-foreground">
+        <span className="h-2 w-2 rounded-full bg-amber-500" />
+        Unsaved changes
+      </div>
+      <div className="flex items-center justify-end gap-1.5">
+        <DesignButton
+          className="h-8 rounded-lg px-3 text-xs text-muted-foreground"
+          onClick={onDiscard}
+          size="sm"
+          variant="ghost"
+        >
+          Discard
+        </DesignButton>
+        <DesignButton className="h-8 rounded-lg px-3 text-xs" onClick={onSave} size="sm">
+          Save changes
+        </DesignButton>
+      </div>
     </div>
   );
 }
@@ -681,44 +654,54 @@ export function DesignEditableGrid({
   className,
   editMode: editModeProp,
   deferredSave = true,
-  hasChanges,
+  hasChanges = false,
   onSave,
   onDiscard,
   externalModifiedKeys,
+  "aria-label": ariaLabel = "Editable settings",
 }: DesignEditableGridProps) {
   const contextEditMode = useDesignEditMode();
   const editMode = editModeProp ?? contextEditMode;
-  const sz = sizeConfig[size];
+  const resolvedSize = getSizeConfig(size);
+
+  if ((onSave == null) !== (onDiscard == null)) {
+    throw new Error("DesignEditableGrid requires both onSave and onDiscard when either callback is provided.");
+  }
+  if (deferredSave && hasChanges && (onSave == null || onDiscard == null)) {
+    throw new Error("DesignEditableGrid cannot display pending changes without onSave and onDiscard callbacks.");
+  }
 
   const gridCols = columns === 1
-    ? "grid-cols-[min-content_1fr]"
-    : "grid-cols-[min-content_1fr] lg:grid-cols-[min-content_1fr_min-content_1fr]";
+    ? "grid-cols-[minmax(7.5rem,max-content)_minmax(0,1fr)]"
+    : "grid-cols-[minmax(7.5rem,max-content)_minmax(0,1fr)] lg:grid-cols-[minmax(7.5rem,max-content)_minmax(0,1fr)_minmax(7.5rem,max-content)_minmax(0,1fr)]";
 
   return (
-    <div className="space-y-2">
-      <div className={cn(
-        "grid text-sm items-center",
-        editMode ? cn(sz.gapX, "gap-y-3") : cn(sz.gapX, "gap-y-0.5"),
-        columns === 2 && sz.interColPl,
-        gridCols,
-        className
-      )}>
-        {items.map((item, index) => (
-          <GridItemContent
-            key={index}
-            item={item}
-            isModified={item.itemKey ? externalModifiedKeys?.has(item.itemKey) : false}
-            editMode={editMode}
-            sz={sz}
-          />
-        ))}
+    <div aria-label={ariaLabel} className="space-y-3" role="group">
+      <div
+        className={cn(
+          "grid items-center text-sm",
+          resolvedSize.gapX,
+          resolvedSize.gapY,
+          columns === 2 && "lg:[&>*:nth-child(4n+3)]:pl-4",
+          gridCols,
+          className,
+        )}
+      >
+        {items.map((item, index) => {
+          const isModified = item.itemKey != null && externalModifiedKeys?.has(item.itemKey) === true;
+          const key = item.itemKey ?? `${item.type}-${item.name}-${index}`;
+          return (
+            <div key={key} className="contents">
+              <ItemLabel isModified={isModified} item={item} size={resolvedSize} />
+              <div className="min-w-0 w-full">
+                <ItemValue editMode={editMode} item={item} size={resolvedSize} />
+              </div>
+            </div>
+          );
+        })}
       </div>
-      {deferredSave && onSave && onDiscard && (
-        <DesignInlineSaveDiscard
-          hasChanges={!!hasChanges}
-          onSave={onSave}
-          onDiscard={onDiscard}
-        />
+      {deferredSave && hasChanges && onSave != null && onDiscard != null && (
+        <SaveBar onDiscard={onDiscard} onSave={onSave} />
       )}
     </div>
   );

--- a/apps/dashboard/src/components/design-components/index.ts
+++ b/apps/dashboard/src/components/design-components/index.ts
@@ -14,8 +14,17 @@ export type {
 } from "../../../../../packages/dashboard-ui-components/src/components/dialog";
 export * from "./analytics-card";
 export * from "./design-tokens";
-export * from "./editable-grid.tsx";
-export type * from "./editable-grid.tsx";
+export {
+  DesignEditableGrid,
+  designEditableGridControlClassName,
+  designEditableGridPopoverClassName,
+} from "./editable-grid";
+export type {
+  DesignEditableGridDropdownOption,
+  DesignEditableGridItem,
+  DesignEditableGridProps,
+  DesignEditableGridSize,
+} from "./editable-grid";
 export * from "./list";
 export * from "./menu";
 export * from "./select";

--- a/apps/dashboard/src/components/design-components/index.ts
+++ b/apps/dashboard/src/components/design-components/index.ts
@@ -14,7 +14,8 @@ export type {
 } from "../../../../../packages/dashboard-ui-components/src/components/dialog";
 export * from "./analytics-card";
 export * from "./design-tokens";
-export * from "./editable-grid";
+export * from "./editable-grid.tsx";
+export type * from "./editable-grid.tsx";
 export * from "./list";
 export * from "./menu";
 export * from "./select";


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

Review feedback applied:
- Restored "Edit full details" navigation to the full product editor.
- Free-trial draft fields reset each time the popover opens, and negative/invalid counts are clamped to a minimum of 1.
- Enter-key saves in `EditableTextField` and `ProductTitleEditor` now match the disabled save-button state.
- `custom-button` and `SaveBar` use `DesignButton` / local pending state to prevent concurrent async actions.
- Two-column grid inter-column spacing selector now targets the rendered child of each second wrapper.

## UI

![After](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGwzT2d1STVWMXBYcTUwUCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19obDNPZ3VJNVYxcFhxNTBQLzlmOWUyMWExLWNiYTctNGExNS1iOTU1LWIzZDRkMmI4MDhmOSIsImlhdCI6MTc4NDIyMjQ3MCwiZXhwIjoxNzg0ODI3MjcwLCJmaWxlbmFtZSI6ImVkaXRhYmxlX2dyaWRfYWZ0ZXIucG5nIn0.5tEKltmv3jewZboboM8vVyDN3Q3cKZ8LMrB_LKwCiQw)

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Redesigned the `DesignEditableGrid` for a flatter, clearer editing experience with explicit edit states and shared white controls. Adopted the new grid patterns in the product page and docs, plus a subtle sidebar footer background for better readability.

- **Refactors**
  - Rebuilt `DesignEditableGrid` with a flat label/value layout and white control surfaces; added item `description`, `size`, and `aria-label`.
  - Text fields now edit inline with save/cancel (Enter/Escape); boolean uses a checkbox; dropdowns support `placeholder` and async `extraAction`.
  - `custom-dropdown` now owns its popover; exported `designEditableGridControlClassName` and `designEditableGridPopoverClassName`; stricter deferred-save validation.
  - Adopted in products: inline title editor, `custom-dropdown` free-trial editor, lighter actions menu; updated playground and design guide.

- **Migration**
  - If `deferredSave` and `hasChanges`, provide both `onSave` and `onDiscard` (required).
  - For read-only values, omit `onUpdate` or set `readOnly`.
  - For `custom-dropdown`, provide `triggerContent` and `popoverContent` (use `open`/`onOpenChange` if controlled).
  - Reuse `designEditableGridControlClassName` / `designEditableGridPopoverClassName` for page-local triggers.

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1772?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Refreshed editable settings grid with field-based editing (text/boolean/dropdown/custom), optional descriptions/tooltips, and deferred save/discard workflow.
  - Product page now includes a dedicated product-title editor (Enter/Escape, async save with feedback).
  - Free-trial editor moved to an Apply/Remove dropdown grid control.

- **UI Improvements**
  - Updated product action menu and badge coloring behavior; enhanced playground editable-grid previews and adjusted sidebar translucency styling.

- **Documentation**
  - Expanded DesignEditableGrid usage guidance with a more complete prop list and interaction rules.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->


Link to Devin session: https://app.devin.ai/sessions/5bb8d6cab0e64371be0ccb5aad6aab2b
Requested by: @Developing-Gamer