### PR TITLE
fix(build): mark tsdown ESM output as ES modules

### DIFF
--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -8,6 +8,58 @@ const customNoExternal = new Set([
   "oauth4webapi",
 ]);
 
+type PackageJsonValue = string | PackageJsonValue[] | { [key: string]: PackageJsonValue };
+
+const rewriteEsmExportTarget = (target: string): string | undefined => {
+  if (target.startsWith("./dist/esm/")) {
+    return `./${target.slice("./dist/esm/".length)}`;
+  }
+
+  if (target.startsWith("./dist/")) {
+    return `./${target.slice("./dist/".length)}`;
+  }
+
+  return undefined;
+};
+
+const createEsmExports = (value: unknown): PackageJsonValue | undefined => {
+  if (typeof value === "string") {
+    return rewriteEsmExportTarget(value);
+  }
+
+  if (Array.isArray(value)) {
+    const rewrittenValues: PackageJsonValue[] = [];
+    for (const item of value) {
+      const rewrittenItem = createEsmExports(item);
+      if (rewrittenItem != null) {
+        rewrittenValues.push(rewrittenItem);
+      }
+    }
+
+    return rewrittenValues.length > 0 ? rewrittenValues : undefined;
+  }
+
+  if (value == null || typeof value !== "object") {
+    return undefined;
+  }
+
+  const rewrittenEntries: Array<[string, PackageJsonValue]> = [];
+  for (const [key, item] of Object.entries(value)) {
+    if (key === "require") {
+      continue;
+    }
+
+    const rewrittenItem = createEsmExports(item);
+    if (rewrittenItem != null) {
+      rewrittenEntries.push([key, rewrittenItem]);
+    }
+  }
+
+  return rewrittenEntries.length > 0
+    ? Object.fromEntries(rewrittenEntries)
+    : undefined;
+};
+
 // https://github.com/egoist/tsup/issues/953
 const fixImportExtensions = (extension: string = ".js"): Rolldown.Plugin => ({
   name: "fix-import-extensions",
@@ -123,8 +175,22 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
             return;
           }
 
+          const packageJsonPath = path.resolve(outputOptions.dir, '../../package.json');
+          const packageJson: {
+            name?: string;
+            exports?: unknown;
+          } = JSON.parse(fs.readFileSync(packageJsonPath, 'utf-8'));
+
           // Strict runtimes like tsx parse ESM output as CJS without this marker.
-          fs.writeFileSync(path.join(outputOptions.dir, 'package.json'), '{"type":"module"}\n');
+          // Preserve self-referencing exports because this file becomes a nested package scope.
+          fs.writeFileSync(
+            path.join(outputOptions.dir, 'package.json'),
+            `${JSON.stringify({
+              name: packageJson.name,
+              type: 'module',
+              exports: createEsmExports(packageJson.exports),
+            }, null, 2)}\n`,
+          );
         },
       },
     ],

--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -115,7 +115,18 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
             external: true,
           };
         },
-      }
+      },
+      {
+        name: 'stackframe: mark esm output as modules',
+        writeBundle(outputOptions) {
+          if (outputOptions.dir == null || path.basename(outputOptions.dir) !== 'esm') {
+            return;
+          }
+
+          // Strict runtimes like tsx parse ESM output as CJS without this marker.
+          fs.writeFileSync(path.join(outputOptions.dir, 'package.json'), '{"type":"module"}\n');
+        },
+      },
     ],
   }));
 }


### PR DESCRIPTION
## Problem

The published `@hexclave/*` packages emit their ESM build into `dist/esm/*.js` and point the exports-map `import` condition there, but neither the package root nor `dist/esm/` carries a `"type": "module"` marker. So `.js` files under `dist/esm/` default to CommonJS.

Strict runtimes (tsx / esbuild loader, older Node) then parse the ESM output as CJS, fail to find the ESM named exports, and throw `SyntaxError: The requested module '@hexclave/js' does not provide an export named 'HexclaveServerApp'` (or `ERR_MODULE_NOT_FOUND`). Plain Node >=20.19/22 papers over it via automatic ESM syntax detection, so it only surfaces for ESM consumers (`"type": "module"`) run under tsx — a common scaffold setup. The misleading error sends people chasing renamed-export / resolution rabbit holes.

## Fix

`js-library.ts` now emits a `dist/esm/package.json` = `{"type":"module"}` at build time (a rolldown `writeBundle` hook keyed on the ESM output dir). This scopes only the ESM output as ESM; Node/tsx find that nested `package.json` before the root one, so `dist/*.js` stays CommonJS for `require()` consumers.

Applies to every package built through the shared tsdown config (js, next, react, tanstack-start, shared, ui, sc, shared-backend, dashboard-ui-components) — a per-package fix would just move the error one dependency deeper.

## Validation

Reproduced against a freshly built `dist`, consumed from an ESM project via tsx: before, the SyntaxError above; after, `loaded: function`. Confirmed the marker lands in `dist/esm/package.json` only, never in the CJS `dist/` root.


Link to Devin session: https://app.devin.ai/sessions/637056927f8642fbb51e512ac6caa93b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Mark ESM outputs as ES modules by writing a nested `package.json` in `dist/esm` with `type: "module"` and ESM-only `exports`. This fixes broken named exports for ESM consumers (e.g. `tsx`) in `@hexclave/*` packages.

- **Bug Fixes**
  - Added a `writeBundle` hook in `configs/tsdown/js-library.ts` to emit `dist/esm/package.json` and preserve self-referencing ESM exports (drops `require` targets, rewrites paths).
  - Keeps CommonJS `dist/` behavior for `require()` and applies to all packages using the shared `tsdown` config.

<sup>Written for commit a97685c08506e80231cf8f925c6e83b5e7321936. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1790?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved compatibility for ESM builds by ensuring the generated `dist/esm` package metadata is correctly marked as JavaScript modules.
  * Prevented strict runtimes from misinterpreting ESM output by rewriting `exports` so the correct module targets are exposed and CommonJS conditions are omitted.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->