### PR TITLE
fix(build): make ESM marker resolve per-package so `tsdown -W` works

### DIFF
--- a/configs/tsdown/js-library.ts
+++ b/configs/tsdown/js-library.ts
@@ -60,6 +60,55 @@ const createEsmExports = (value: unknown): PackageJsonValue | undefined => {
     : undefined;
 };
 
+const findPackageRootFromSource = (sourcePath: string): string => {
+  let currentPath = path.dirname(path.resolve(sourcePath));
+  while (true) {
+    if (fs.existsSync(path.join(currentPath, 'package.json'))) {
+      return currentPath;
+    }
+
+    const parentPath = path.dirname(currentPath);
+    if (parentPath === currentPath) {
+      break;
+    }
+    currentPath = parentPath;
+  }
+
+  throw new Error(`Could not find a package.json for ESM source path ${sourcePath}`);
+};
+
+const findPackageRoot = (bundle: Rolldown.OutputBundle): string => {
+  let fallbackSourcePath: string | undefined;
+
+  for (const output of Object.values(bundle)) {
+    if (output.type !== 'chunk' || !output.isEntry) {
+      continue;
+    }
+
+    if (output.facadeModuleId != null && !output.facadeModuleId.startsWith('\0')) {
+      return findPackageRootFromSource(output.facadeModuleId);
+    }
+
+    fallbackSourcePath = output.moduleIds.find((moduleId) => !moduleId.startsWith('\0'));
+    if (fallbackSourcePath != null) {
+      return findPackageRootFromSource(fallbackSourcePath);
+    }
+  }
+
+  for (const output of Object.values(bundle)) {
+    if (output.type !== 'chunk') {
+      continue;
+    }
+
+    fallbackSourcePath ??= output.moduleIds.find((moduleId) => !moduleId.startsWith('\0'));
+    if (fallbackSourcePath != null) {
+      return findPackageRootFromSource(fallbackSourcePath);
+    }
+  }
+
+  throw new Error('Could not determine the package source path from the ESM output bundle');
+};
+
 // https://github.com/egoist/tsup/issues/953
 const fixImportExtensions = (extension: string = ".js"): Rolldown.Plugin => ({
   name: "fix-import-extensions",
@@ -170,12 +219,14 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
       },
       {
         name: 'stackframe: mark esm output as modules',
-        writeBundle(outputOptions) {
+        writeBundle(outputOptions, bundle) {
           if (outputOptions.dir == null || path.basename(outputOptions.dir) !== 'esm') {
             return;
           }
 
-          const packageJsonPath = path.resolve(outputOptions.dir, '../../package.json');
+          const packageRoot = findPackageRoot(bundle);
+          const esmOutputDir = path.resolve(packageRoot, outputOptions.dir);
+          const packageJsonPath = path.join(packageRoot, 'package.json');
           const packageJson: {
             name?: string;
             exports?: unknown;
@@ -183,8 +234,9 @@ export default function createJsLibraryTsupConfig(_options: { barrelFiles?: stri
 
           // Strict runtimes like tsx parse ESM output as CJS without this marker.
           // Preserve self-referencing exports because this file becomes a nested package scope.
+          fs.mkdirSync(esmOutputDir, { recursive: true });
           fs.writeFileSync(
-            path.join(outputOptions.dir, 'package.json'),
+            path.join(esmOutputDir, 'package.json'),
             `${JSON.stringify({
               name: packageJson.name,
               type: 'module',


### PR DESCRIPTION
## Summary
Follow-up to #1790. The `stackframe: mark esm output as modules` hook (which writes `dist/esm/package.json`) assumed `outputOptions.dir` resolves relative to the package directory. That holds for per-package builds (CI/turbo, cwd = package) and for `tsdown -W --watch` (where `dir` is an absolute per-package path), but **not** for non-watch `tsdown -W` (workspace mode) — the first command in `build-packages:watch` — where `dir` is relative (`"dist/esm"`) while `process.cwd()` is the repo root.

Result: the hook read the repo-root `package.json` (`@hexclave/monorepo`) and tried to write `<repo-root>/dist/esm/package.json`, which doesn't exist → `ENOENT`, killing `build-packages:watch` startup so setup workflows never started. (Even with the dir force-created, it wrote one useless root-derived marker and marked zero real packages.)

Fix: derive the package root from the output bundle instead of cwd, so it's correct in all three build modes.

```ts
// before: cwd-relative, breaks under `tsdown -W`
const packageJsonPath = path.resolve(outputOptions.dir, '../../package.json');
fs.writeFileSync(path.join(outputOptions.dir, 'package.json'), ...);

// after: locate the package from an entry chunk's absolute source path
const packageRoot = findPackageRoot(bundle);            // walk up from facadeModuleId to nearest package.json
const esmOutputDir = path.resolve(packageRoot, outputOptions.dir); // abs dir wins; relative resolves against the pkg
const packageJsonPath = path.join(packageRoot, 'package.json');
fs.mkdirSync(esmOutputDir, { recursive: true });
fs.writeFileSync(path.join(esmOutputDir, 'package.json'), ...);
```

The marker contents (name + `type:"module"` + rewritten ESM-only `exports`, `require` branches stripped, self-referencing subpaths preserved) are unchanged.

## Validation
From a clean tree (`rm -rf packages/*/dist dist`):
- `tsdown -W` → exit 0, no `ENOENT`, no stray `<repo-root>/dist`, and all 10 shared-config packages get a correct `dist/esm/package.json` (right `name`, rewritten `exports`); CJS `dist/` roots have no `type:module`.
- `tsdown -W --watch` startup → no `ENOENT`, markers present.


Link to Devin session: https://app.devin.ai/sessions/637056927f8642fbb51e512ac6caa93b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix ESM marker generation to resolve per package, so workspace builds with `tsdown -W` write `dist/esm/package.json` to the correct package and no longer crash on startup.

- **Bug Fixes**
  - Derive the package root from the output bundle’s entry module instead of `process.cwd()`, working for per-package, workspace, and watch builds.
  - Resolve the ESM output dir against the package root and create it before writing, preventing `ENOENT` and avoiding `<repo>/dist/esm`.
  - Marker contents unchanged (name, `type: "module"`, ESM-only `exports`; CJS roots remain unmarked).

<sup>Written for commit 664b6f0339894663dca13c79cd3b6c1f918c8a1a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1792?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved ESM package generation to locate the correct package metadata automatically.
  - Ensured required ESM output directories are created before package metadata is written.
  - Added clearer error handling when the package source location cannot be determined.
  - Improved support for packages with nested or nonstandard output paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->