### PR TITLE
Improve development environment cleanup diagnostics

### DIFF
--- a/package.json
+++ b/package.json
@@ -57,7 +57,7 @@
     "dev:docs": "pnpm pre && concurrently -k \"pnpm run generate-setup-prompt-docs:watch\" \"turbo run dev --concurrency 99999 --filter=@hexclave/docs-mintlify\"",
     "dev:named": "pnpm pre && concurrently -k \"pnpm run dev\" \"node -e \\\"process.title='node (stack-named-dev-server)'; process.stdin.resume();\\\"\"",
     "kill-dev:named": "(pgrep -f 'stack-named-dev-server' | xargs -r -n1 pkill -P); echo 'Killed named dev server (if found). Sleeping to give some time for it to shut down...' && sleep 10",
-    "kms": "PREFIX=${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}; for p in 00 01 02 03 04 06 14 42; do pids=$(lsof -i :$PREFIX$p 2>/dev/null | grep LISTEN | awk '$1 != \"OrbStack\" {print $2}' | sort -u); [ -n \"$pids\" ] && echo $pids | xargs kill -9 2>/dev/null; done; echo Done.",
+    "kms": "PREFIX=${NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX:-81}; for p in 00 01 02 03 04 06 14 42 43 44 45 46; do pids=$(lsof -i :$PREFIX$p 2>/dev/null | grep LISTEN | awk '$1 != \"OrbStack\" {print $2}' | sort -u); [ -n \"$pids\" ] && echo $pids | xargs kill -9 2>/dev/null; done; echo Done.",
     "start": "pnpm pre && turbo run start --concurrency 99999",
     "start:backend": "pnpm pre && turbo run start --concurrency 99999 --filter=@hexclave/backend",
     "start:mcp": "pnpm pre && turbo run start --concurrency 99999 --filter=@hexclave/mcp",

--- a/scripts/reseed-bulldozer.sh
+++ b/scripts/reseed-bulldozer.sh
@@ -82,8 +82,15 @@ cleanup() {
 trap cleanup EXIT
 
 if port_is_open; then
-  echo "Cannot re-seed bulldozer-js: port $BULLDOZER_PORT is already in use." >&2
-  echo "Stop the existing bulldozer-js process and run restart-deps again." >&2
+  # The usual culprit is the bulldozer-js instance of a still-running `pnpm dev`
+  # (its tsx-watch child survives many ad-hoc cleanup paths), so identify the
+  # holder for the user instead of making them hunt it down themselves.
+  echo "Cannot re-seed bulldozer-js: port $BULLDOZER_PORT is already in use by:" >&2
+  if command -v lsof >/dev/null 2>&1; then
+    lsof -nP -iTCP:"$BULLDOZER_PORT" -sTCP:LISTEN >&2 || echo "  (could not determine the process holding the port)" >&2
+  fi
+  echo "This is usually a running dev server (bulldozer-js is started by 'pnpm dev')." >&2
+  echo "Stop it (Ctrl-C the dev server, or 'pnpm kms' to kill all dev server ports) and run restart-deps again." >&2
   exit 1
 fi
 


### PR DESCRIPTION
## What changed

- Extend `pnpm kms` to stop the additional development-environment service ports.
- Report the process holding the Bulldozer port when reseeding cannot start.
- Point developers to the appropriate cleanup command before retrying dependency startup.

## Why

A surviving development server can keep the Bulldozer port occupied, while the previous error only reported that the port was unavailable. The cleanup command also omitted several newer service ports.

## Impact

Development-environment cleanup is more complete, and port conflicts now identify the process that must be stopped.

## Validation

- `bash -n scripts/reseed-bulldozer.sh`
- Parsed `package.json` with Node.js
- `git diff --check`

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Improves dev environment cleanup and diagnostics. `pnpm kms` now stops more dev service ports (43-46), and the Bulldozer reseed script prints the process holding the port and guides you to stop the dev server or run `pnpm kms` before retrying.

<sup>Written for commit 7ee852361e35b7ed09b70aec7a542f91f64d6c08. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1799?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved development environment cleanup by terminating processes on additional ports.
  * Enhanced diagnostics when the bulldozer port is occupied, including clearer guidance for stopping conflicting development servers.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->