### PR TITLE
Devin/1784837606 setup prompt api url

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/setup-page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/setup-page.tsx
@@ -8,6 +8,7 @@ import { Tabs, TabsList, TabsTrigger, Typography, cn } from "@/components/ui";
 import { getPublicEnvVar } from '@/lib/env';
 import { useThemeWatcher } from '@/lib/theme';
 import { BookIcon, XIcon } from "@phosphor-icons/react";
+import { getHexclaveApiBaseUrl } from '@hexclave/shared/dist/utils/cloud-hosts';
 import { remindersPrompt } from '@hexclave/shared/dist/ai/unified-prompts/reminders';
 import { use } from "@hexclave/shared/dist/utils/react";
 import { deindent } from '@hexclave/shared/dist/utils/strings';
@@ -65,7 +66,9 @@ function getManualSetupDocsUrl() {
 }
 
 function getSetupApiBaseUrl() {
-  return getPublicEnvVar('NEXT_PUBLIC_STACK_API_URL') ?? PROD_API_BASE_URL;
+  // Prefer the hexclave-branded host post-rebrand: the deployment env var may still be set to the
+  // legacy api.stack-auth.com, but the two cloud hosts are equivalent, so show the hexclave brand.
+  return getHexclaveApiBaseUrl(getPublicEnvVar('NEXT_PUBLIC_STACK_API_URL') ?? PROD_API_BASE_URL);
 }
 
 function buildCloudSetupPrompt(options: {
@@ -76,6 +79,31 @@ function buildCloudSetupPrompt(options: {
   const { docsBaseUrl, projectId, apiBaseUrl } = options;
   const normalizedDocsBaseUrl = docsBaseUrl.replace(/\/$/, '');
   const reminders = remindersPrompt.replaceAll(PROD_DOCS_BASE_URL, normalizedDocsBaseUrl);
+
+  // The SDK's baked-in default base URL is the production cloud API (api.hexclave.com). Both cloud
+  // brands (api.stack-auth.com / api.hexclave.com) resolve to it, so when this deployment is the
+  // production cloud there's no point telling the agent to set a custom API URL — it's already the
+  // default. Omit it in that case; otherwise surface the hexclave-branded URL (dev/staging cloud
+  // deployments and self-host custom domains).
+  const hexclaveApiBaseUrl = getHexclaveApiBaseUrl(apiBaseUrl);
+  const isDefaultApiBaseUrl = hexclaveApiBaseUrl === PROD_API_BASE_URL;
+
+  const projectValues = isDefaultApiBaseUrl
+    ? deindent`
+      - Hexclave project ID: ${projectId}
+    `
+    : deindent`
+      - Hexclave API URL: ${hexclaveApiBaseUrl}
+      - Hexclave project ID: ${projectId}
+    `;
+
+  const envVarInstructions = isDefaultApiBaseUrl
+    ? deindent`
+      Create the framework-specific public environment variable for the Hexclave project ID. For example, Next.js uses NEXT_PUBLIC_HEXCLAVE_PROJECT_ID, while Vite-based frameworks use VITE_HEXCLAVE_PROJECT_ID. If the Hexclave docs for this framework specify a different environment variable name, use the docs' framework-specific name with the value above.
+    `
+    : deindent`
+      Create the framework-specific public environment variables for the Hexclave API URL and project ID. For example, Next.js uses NEXT_PUBLIC_HEXCLAVE_API_URL and NEXT_PUBLIC_HEXCLAVE_PROJECT_ID, while Vite-based frameworks use VITE_HEXCLAVE_API_URL and VITE_HEXCLAVE_PROJECT_ID. If the Hexclave docs for this framework specify different environment variable names, use the docs' framework-specific names with the values above.
+    `;
 
   return deindent`
     Install and set up Hexclave in this project by following these instructions:
@@ -88,10 +116,9 @@ function buildCloudSetupPrompt(options: {
 
     Use these Hexclave project values when creating environment variables:
 
-    - Hexclave API URL: ${apiBaseUrl}
-    - Hexclave project ID: ${projectId}
+    ${projectValues}
 
-    Create the framework-specific public environment variables for the Hexclave API URL and project ID. For example, Next.js uses NEXT_PUBLIC_HEXCLAVE_API_URL and NEXT_PUBLIC_HEXCLAVE_PROJECT_ID, while Vite-based frameworks use VITE_HEXCLAVE_API_URL and VITE_HEXCLAVE_PROJECT_ID. If the Hexclave docs for this framework specify different environment variable names, use the docs' framework-specific names with the values above.
+    ${envVarInstructions}
 
     After setup finishes, verify that the Hexclave MCP server is registered in your AI client config — name: \`hexclave\`, transport: \`http\`, URL: \`https://mcp.hexclave.com/mcp\`. If it is not registered, add it manually so future agents have live access to Hexclave docs and APIs.
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/setup-page.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/setup-page.tsx
@@ -8,7 +8,6 @@ import { Tabs, TabsList, TabsTrigger, Typography, cn } from "@/components/ui";
 import { getPublicEnvVar } from '@/lib/env';
 import { useThemeWatcher } from '@/lib/theme';
 import { BookIcon, XIcon } from "@phosphor-icons/react";
-import { getHexclaveApiBaseUrl } from '@hexclave/shared/dist/utils/cloud-hosts';
 import { remindersPrompt } from '@hexclave/shared/dist/ai/unified-prompts/reminders';
 import { use } from "@hexclave/shared/dist/utils/react";
 import { deindent } from '@hexclave/shared/dist/utils/strings';
@@ -66,9 +65,7 @@ function getManualSetupDocsUrl() {
 }
 
 function getSetupApiBaseUrl() {
-  // Prefer the hexclave-branded host post-rebrand: the deployment env var may still be set to the
-  // legacy api.stack-auth.com, but the two cloud hosts are equivalent, so show the hexclave brand.
-  return getHexclaveApiBaseUrl(getPublicEnvVar('NEXT_PUBLIC_STACK_API_URL') ?? PROD_API_BASE_URL);
+  return getPublicEnvVar('NEXT_PUBLIC_STACK_API_URL') ?? PROD_API_BASE_URL;
 }
 
 function buildCloudSetupPrompt(options: {
@@ -80,20 +77,17 @@ function buildCloudSetupPrompt(options: {
   const normalizedDocsBaseUrl = docsBaseUrl.replace(/\/$/, '');
   const reminders = remindersPrompt.replaceAll(PROD_DOCS_BASE_URL, normalizedDocsBaseUrl);
 
-  // The SDK's baked-in default base URL is the production cloud API (api.hexclave.com). Both cloud
-  // brands (api.stack-auth.com / api.hexclave.com) resolve to it, so when this deployment is the
-  // production cloud there's no point telling the agent to set a custom API URL — it's already the
-  // default. Omit it in that case; otherwise surface the hexclave-branded URL (dev/staging cloud
-  // deployments and self-host custom domains).
-  const hexclaveApiBaseUrl = getHexclaveApiBaseUrl(apiBaseUrl);
-  const isDefaultApiBaseUrl = hexclaveApiBaseUrl === PROD_API_BASE_URL;
+  // The SDK's baked-in default base URL is the production cloud API, so there's no point telling
+  // the agent to set a custom API URL when the deployment already uses it — omit the line in that
+  // case. Non-default deployments (dev/staging cloud, self-host custom domains) still show it.
+  const isDefaultApiBaseUrl = apiBaseUrl === PROD_API_BASE_URL;
 
   const projectValues = isDefaultApiBaseUrl
     ? deindent`
       - Hexclave project ID: ${projectId}
     `
     : deindent`
-      - Hexclave API URL: ${hexclaveApiBaseUrl}
+      - Hexclave API URL: ${apiBaseUrl}
       - Hexclave project ID: ${projectId}
     `;
 


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Copy-only change in onboarding prompt generation; no auth, API, or runtime behavior changes.
> 
> **Overview**
> **Cloud AI setup prompt** now adapts when the dashboard’s API base URL is the production default (`https://api.hexclave.com`).
> 
> For that case, the copy-paste prompt **drops** the Hexclave API URL bullet and tells agents to set only the **public project ID** env var (framework-specific names unchanged). Staging, dev, and self-hosted/custom API URLs still include the API URL line and instructions for both `*_API_URL` and `*_PROJECT_ID` variables.
> 
> Rationale in code: the JS SDK already defaults to production API, so prompting for a redundant API URL env var on standard cloud onboarding is avoided.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5a7e520383abd2004f8f82e35b90206ed215caca. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Update the cloud setup prompt to omit the Hexclave API URL when the dashboard uses the default production base (`https://api.hexclave.com`). In that case, the prompt only asks for the public project ID; non-default bases still show both values with the correct framework-specific env var names.

<sup>Written for commit 5a7e520383abd2004f8f82e35b90206ed215caca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1800?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated cloud setup instructions to provide the correct environment variables based on the configured API endpoint.
  * Production cloud setups now only require the project ID, while custom endpoints include both the API URL and project ID.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->