### PR TITLE
update deployment skill

### DIFF
--- a/apps/skills/src/app/deployments/route.ts
+++ b/apps/skills/src/app/deployments/route.ts
@@ -9,5 +9,12 @@ export const { GET, HEAD } = createSkillPageRoute({
   heading: "The Hexclave Deployments Skill",
   description: "The full Hexclave agent skill plus everything specific to the Deployments app — services, env vars, deploying, and custom domains.",
   ledeHtml: `This endpoint serves the full Hexclave <span translate="no">SKILL.md</span> followed by the deeper Deployments material — configuring services, env vars, deploying with <span translate="no">hexclave deploy</span>, and custom domains.`,
+  // Deployments has no getting-started docs page of its own, so the prompt points
+  // the agent back at this URL (which serves the markdown below) instead of at the
+  // general setup docs — pasting those would set up the SDK and never deploy anything.
+  setupPrompt: {
+    blurb: "Copy this prompt into your coding agent. It points the agent at this page, which carries the full Hexclave skill plus everything needed to configure and ship a deployment.",
+    text: "Read https://skill.hexclave.com/deployments and use it to set up Hexclave in this folder",
+  },
   skillMarkdown: deploymentsSkillSitePrompt,
 });

--- a/apps/skills/src/app/route.ts
+++ b/apps/skills/src/app/route.ts
@@ -6,5 +6,9 @@ export const { GET, HEAD } = createSkillPageRoute({
   heading: "The Hexclave Agent Skill",
   description: "The Hexclave agent skill — user management, auth, payments, emails, analytics, and the Hexclave CLI.",
   ledeHtml: `This endpoint serves the canonical <span translate="no">SKILL.md</span> that teaches coding agents how to wire Hexclave into a project — auth, orgs, payments, emails, analytics, and the <span translate="no">hexclave-cli</span>.`,
+  setupPrompt: {
+    blurb: "Copy the canonical setup prompt into your coding agent. It contains the current Hexclave setup instructions and links back to this skill for follow-up questions.",
+    text: "https://docs.hexclave.com/guides/getting-started/setup",
+  },
   skillMarkdown: skillSitePrompt,
 });

--- a/apps/skills/src/skill-page.test.ts
+++ b/apps/skills/src/skill-page.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from "vitest";
+
+import { GET as deploymentsGet } from "./app/deployments/route";
+import { GET as skillGet } from "./app/route";
+import { createSkillPageRoute } from "./skill-page";
+
+const HTML_ACCEPT = "text/html,application/xhtml+xml,application/xml;q=0.9,*/*;q=0.8";
+
+function htmlRequest(url: string) {
+  return new Request(url, { headers: { accept: HTML_ACCEPT } });
+}
+
+function markdownRequest(url: string) {
+  return new Request(url, { headers: { accept: "*/*" } });
+}
+
+describe("skill page shell", () => {
+  it("renders the page's own setup prompt in the copy box", async () => {
+    const { GET } = createSkillPageRoute({
+      tabTitle: "Tab",
+      heading: "Heading",
+      description: "Description",
+      ledeHtml: "Lede",
+      setupPrompt: { blurb: "Blurb goes here.", text: "Do the thing at https://example.com" },
+      skillMarkdown: "# Skill",
+    });
+
+    const html = await GET(htmlRequest("https://skill.hexclave.com/")).text();
+
+    expect(html).toContain("Blurb goes here.");
+    expect(html).toContain(`data-copy="Do the thing at https://example.com"`);
+  });
+
+  it("escapes setup prompts so they cannot break out of the copy box", async () => {
+    const { GET } = createSkillPageRoute({
+      tabTitle: "Tab",
+      heading: "Heading",
+      description: "Description",
+      ledeHtml: "Lede",
+      setupPrompt: { blurb: `Blurb & "quotes"`, text: `<script>alert(1)</script>` },
+      skillMarkdown: "# Skill",
+    });
+
+    const html = await GET(htmlRequest("https://skill.hexclave.com/")).text();
+
+    expect(html).not.toContain("<script>alert(1)</script>");
+    expect(html).toContain("&lt;script&gt;alert(1)&lt;/script&gt;");
+    expect(html).toContain(`Blurb &amp; &quot;quotes&quot;`);
+  });
+});
+
+describe("skill site pages", () => {
+  it("serves the general setup docs URL on the root skill page", async () => {
+    const html = await skillGet(htmlRequest("https://skill.hexclave.com/")).text();
+
+    expect(html).toContain("https://docs.hexclave.com/guides/getting-started/setup");
+  });
+
+  it("serves a Deployments-specific setup prompt on /deployments", async () => {
+    const html = await deploymentsGet(htmlRequest("https://skill.hexclave.com/deployments")).text();
+
+    // The generic getting-started URL is what this page used to inherit from the
+    // shared shell; it must not be what the copy button hands to the agent.
+    expect(html).not.toContain(`data-copy="https://docs.hexclave.com/guides/getting-started/setup"`);
+    expect(html).toContain(`data-copy="Read https://skill.hexclave.com/deployments and use it to set up Hexclave in this folder"`);
+  });
+
+  it("still serves the Deployments skill markdown to non-browser clients", async () => {
+    const response = deploymentsGet(markdownRequest("https://skill.hexclave.com/deployments"));
+
+    expect(response.headers.get("Content-Type")).toBe("text/markdown; charset=utf-8");
+    await expect(response.text()).resolves.toContain("# Hexclave Deployments");
+  });
+});

--- a/apps/skills/src/skill-page.ts
+++ b/apps/skills/src/skill-page.ts
@@ -2,8 +2,8 @@
 // Every such page is the same document: a content-negotiated endpoint that
 // serves styled HTML to browsers and raw `text/markdown` to agents/curl, with
 // the skill markdown embedded verbatim in a <details> block. Only the title,
-// description, lede, and the skill markdown itself differ per page, so those are
-// the parameters — everything else (styles, setup-prompt section, cards, footer,
+// description, lede, setup prompt, and the skill markdown itself differ per
+// page, so those are the parameters — everything else (styles, cards, footer,
 // copy script) is identical and lives here.
 
 const COMMON_HEADERS = {
@@ -15,7 +15,17 @@ const COMMON_HEADERS = {
   "Access-Control-Allow-Headers": "*",
 } as const;
 
-const SETUP_PROMPT_URL = "https://docs.hexclave.com/guides/getting-started/setup";
+export type SkillPageSetupPrompt = {
+  /** The sentence under the "Set Up with the Prompt" heading (plain text; escaped). */
+  blurb: string,
+  /**
+   * The exact text the copy button puts on the clipboard. For the general skill
+   * this is just the canonical setup docs URL — the agent fetches it and follows
+   * it. Per-app pages have no equivalent docs page, so they carry a one-line
+   * instruction that points the agent at their own skill URL instead.
+   */
+  text: string,
+};
 
 export type SkillPageContent = {
   /** Browser tab <title> (plain text; escaped). */
@@ -31,6 +41,8 @@ export type SkillPageContent = {
    * author-controlled literal content, never user input, so it is not escaped.
    */
   ledeHtml: string,
+  /** The copyable prompt shown in the "Set Up with the Prompt" section. */
+  setupPrompt: SkillPageSetupPrompt,
   /** The skill markdown: served raw to agents and embedded in the HTML page. */
   skillMarkdown: string,
 };
@@ -49,7 +61,8 @@ function renderHtml(content: SkillPageContent): string {
   const headingEscaped = escapeHtml(content.heading);
   const descriptionEscaped = escapeHtml(content.description);
   const skillEscaped = escapeHtml(content.skillMarkdown);
-  const setupPromptUrlEscaped = escapeHtml(SETUP_PROMPT_URL);
+  const setupPromptBlurbEscaped = escapeHtml(content.setupPrompt.blurb);
+  const setupPromptTextEscaped = escapeHtml(content.setupPrompt.text);
   return `<!doctype html>
 <html lang="en">
 <head>
@@ -116,6 +129,7 @@ function renderHtml(content: SkillPageContent): string {
   p { margin: 0 0 12px; }
   .install {
     display: flex; align-items: stretch; gap: 0;
+    /* The button must stay on one line next to the (possibly wrapping) prompt. */
     border: 1px solid var(--border); border-radius: 8px; overflow: hidden;
     background: var(--surface);
   }
@@ -124,8 +138,10 @@ function renderHtml(content: SkillPageContent): string {
     padding: 12px 14px;
     font-family: ui-monospace, SFMono-Regular, Menlo, Consolas, monospace;
     font-size: 14px;
-    overflow-x: auto;
-    white-space: nowrap;
+    /* Prompts are full sentences, not one-line commands, so they wrap rather
+       than scroll sideways; long URLs inside them break instead of overflowing. */
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
     font-variant-numeric: tabular-nums;
   }
   .copy-btn {
@@ -192,10 +208,10 @@ function renderHtml(content: SkillPageContent): string {
   <p class="lede">${content.ledeHtml}</p>
 
   <h2>Set Up with the Prompt</h2>
-  <p>Copy the canonical setup prompt into your coding agent. It contains the current Hexclave setup instructions and links back to this skill for follow-up questions.</p>
-  <div class="install" role="group" aria-label="Setup prompt URL">
-    <code id="install-cmd" translate="no">${setupPromptUrlEscaped}</code>
-    <button class="copy-btn" type="button" aria-label="Copy setup prompt URL" data-copy="${setupPromptUrlEscaped}">Copy</button>
+  <p>${setupPromptBlurbEscaped}</p>
+  <div class="install" role="group" aria-label="Setup prompt">
+    <code id="install-cmd" translate="no">${setupPromptTextEscaped}</code>
+    <button class="copy-btn" type="button" aria-label="Copy setup prompt" data-copy="${setupPromptTextEscaped}">Copy</button>
   </div>
 
   <h2>Fetch the Skill Directly</h2>


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Serve a per-page setup prompt on the skill site and fix the Deployments page to use a Deployments-specific prompt that points agents back to `/deployments`. Also escape prompt text, improve the copy box wrapping, and add tests.

- **Bug Fixes**
  - `/deployments` now shows a Deployments-specific setup prompt: “Read https://skill.hexclave.com/deployments …”, not the generic getting-started URL.
  - Non-browser clients still receive `text/markdown` with the Deployments skill.

- **Refactors**
  - Skill page shell takes a `setupPrompt` per page and escapes blurb/text.
  - Updated HTML/CSS: prompts wrap and long URLs break; copy button stays aligned.
  - Added `vitest` tests for prompt rendering, escaping, and per-page behavior.

<sup>Written for commit a98fb8c46a42bc136e550b773f9d2cbf8cfee415. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1805?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added skill-specific setup prompts with tailored instructions and copy-to-clipboard content.
  * Updated the setup section to display explanatory text and support longer, wrapping prompts.
  * Added deployment-specific setup guidance and markdown content.

* **Bug Fixes**
  * Improved escaping of setup prompt content to prevent unintended HTML rendering.

* **Tests**
  * Added coverage for setup prompt rendering, content escaping, deployment-specific copy text, and markdown responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->