### PR TITLE
fix(backend): skip replication wait for replica-routed reads

### DIFF
--- a/apps/backend/src/prisma-client.test.tsx
+++ b/apps/backend/src/prisma-client.test.tsx
@@ -1,0 +1,67 @@
+import { Client } from "pg";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { globalPrismaClient } from "@/prisma-client";
+
+const replicationStrategy = getEnvVariable("STACK_DATABASE_REPLICATION_WAIT_STRATEGY", "none");
+const replicaConnectionString = getEnvVariable("STACK_DATABASE_REPLICA_CONNECTION_STRING", "");
+const replicationWaitEnabled = replicationStrategy !== "none" && replicaConnectionString !== "";
+
+function queryText(query: unknown): string {
+  if (typeof query === "string") return query;
+  if (query !== null && typeof query === "object" && "text" in query && typeof query.text === "string") {
+    return query.text;
+  }
+  return "";
+}
+
+const hasReplicationTargetQuery = (calls: readonly (readonly unknown[])[]) =>
+  calls.some(([query]) => queryText(query).toLowerCase().includes("select pg_current_wal_lsn"));
+
+describe.skipIf(!replicationWaitEnabled)("replication wait behavior", () => {
+  let restoreQuerySpy: (() => void) | undefined;
+
+  afterEach(() => {
+    restoreQuerySpy?.();
+    restoreQuerySpy = undefined;
+  });
+
+  it("does not wait after a model read routed to the replica", async () => {
+    const querySpy = vi.spyOn(Client.prototype, "query");
+    restoreQuerySpy = () => querySpy.mockRestore();
+
+    await globalPrismaClient.team.findMany({
+      take: 1,
+      select: { teamId: true },
+    });
+
+    expect(hasReplicationTargetQuery(querySpy.mock.calls)).toBe(false);
+  });
+
+  it("waits after a write on the primary", async () => {
+    const querySpy = vi.spyOn(Client.prototype, "query");
+    restoreQuerySpy = () => querySpy.mockRestore();
+
+    await globalPrismaClient.team.updateMany({
+      where: { teamId: "00000000-0000-0000-0000-000000000000" },
+      data: { displayName: "replication wait test" },
+    });
+
+    expect(hasReplicationTargetQuery(querySpy.mock.calls)).toBe(true);
+  });
+
+  it("waits after a transaction commits", async () => {
+    const querySpy = vi.spyOn(Client.prototype, "query");
+    restoreQuerySpy = () => querySpy.mockRestore();
+
+    // eslint-disable-next-line no-restricted-syntax
+    await globalPrismaClient.$transaction(async (tx) => {
+      await tx.team.findMany({
+        take: 1,
+        select: { teamId: true },
+      });
+    });
+
+    expect(hasReplicationTargetQuery(querySpy.mock.calls)).toBe(true);
+  });
+});

--- a/apps/backend/src/prisma-client.tsx
+++ b/apps/backend/src/prisma-client.tsx
@@ -255,6 +255,21 @@ async function waitForReplication(replicas: PrismaClient[], target: string, time
   });
 }
 
+// Same list as @prisma/extension-read-replicas: operations it routes to the replica.
+// These never write to the primary, so they don't need a replication wait.
+const readOperations = [
+  "findFirst",
+  "findFirstOrThrow",
+  "findMany",
+  "findUnique",
+  "findUniqueOrThrow",
+  "groupBy",
+  "aggregate",
+  "count",
+  "findRaw",
+  "aggregateRaw",
+];
+
 /**
  * Extends a Prisma client to wait for replication after all operations.
  * This ensures read-after-write consistency when using a read replica.
@@ -319,8 +334,13 @@ function extendWithReplicationWait<T extends PrismaClient>(primary: T, replicaCl
       async $allOperations(params: { args: any, query: (args: any) => Promise<any>, operation: string, model?: string, __internalParams?: unknown }) {
         const { args, query, operation, model } = params;
 
-        // note that we intentionally trigger this after EVERY operation, including reads, as this is on the primary — reads aren't sent here in the first place
+        // Query extension callbacks run in the order they were applied, so this hook runs OUTSIDE the read-replicas
+        // extension and receives every operation, including reads that the read-replicas extension then routes to a
+        // replica. Reads never write to the primary, so they never need a replication wait.
         // (do note that $allOperations does not trigger for the transaction commit itself, so we do that separately above)
+        if (readOperations.includes(operation)) {
+          return await query(args);
+        }
 
         // __internalParams is an undocumented property, so let's validate that it fits our schema with yup first
         const internalParamsSchema = yupObject({

--- a/apps/backend/src/prisma-client.tsx
+++ b/apps/backend/src/prisma-client.tsx
@@ -255,21 +255,6 @@ async function waitForReplication(replicas: PrismaClient[], target: string, time
   });
 }
 
-// Same list as @prisma/extension-read-replicas: operations it routes to the replica.
-// These never write to the primary, so they don't need a replication wait.
-const readOperations = [
-  "findFirst",
-  "findFirstOrThrow",
-  "findMany",
-  "findUnique",
-  "findUniqueOrThrow",
-  "groupBy",
-  "aggregate",
-  "count",
-  "findRaw",
-  "aggregateRaw",
-];
-
 /**
  * Extends a Prisma client to wait for replication after all operations.
  * This ensures read-after-write consistency when using a read replica.
@@ -334,13 +319,11 @@ function extendWithReplicationWait<T extends PrismaClient>(primary: T, replicaCl
       async $allOperations(params: { args: any, query: (args: any) => Promise<any>, operation: string, model?: string, __internalParams?: unknown }) {
         const { args, query, operation, model } = params;
 
-        // Query extension callbacks run in the order they were applied, so this hook runs OUTSIDE the read-replicas
-        // extension and receives every operation, including reads that the read-replicas extension then routes to a
-        // replica. Reads never write to the primary, so they never need a replication wait.
+        // This extension must be applied AFTER (i.e. inside) the read-replicas extension: query extension callbacks
+        // run in the order they were applied, so the read-replicas hook runs first and dispatches read operations
+        // directly onto the replica client, which never reaches this hook. Everything that does arrive here executes
+        // on the primary and therefore needs a replication wait.
         // (do note that $allOperations does not trigger for the transaction commit itself, so we do that separately above)
-        if (readOperations.includes(operation)) {
-          return await query(args);
-        }
 
         // __internalParams is an undocumented property, so let's validate that it fits our schema with yup first
         const internalParamsSchema = yupObject({
@@ -365,12 +348,16 @@ function extendWithReadReplicas<T extends PrismaClient>(client: T, replicaConnec
   // Create a separate PrismaClient for the read replica
   const replicaClient = getPostgresPrismaClient(replicaConnectionString, "replica").client;
 
-  // First extend with replication wait (passing replica clients for direct querying), then with read replicas
-  const clientWithReplicationWait = extendWithReplicationWait(client, [replicaClient]);
-
-  return clientWithReplicationWait.$extends(readReplicas({
+  // Extend with read replicas FIRST so its query hook runs outermost: it routes read operations directly onto the
+  // replica client, so the replication-wait hook (applied second, i.e. inner) only ever sees operations that hit
+  // the primary. This is what makes replica-routed reads skip the replication wait.
+  const clientWithReadReplicas = client.$extends(readReplicas({
     replicas: [replicaClient],
-  })) as PrismaClientWithReplica<T>;
+  }));
+
+  // The $extends result doesn't structurally satisfy PrismaClient (e.g. it drops $on), but at runtime it supports
+  // everything extendWithReplicationWait uses ($extends, $transaction, $queryRaw), hence the cast.
+  return extendWithReplicationWait(clientWithReadReplicas as unknown as T, [replicaClient]) as unknown as PrismaClientWithReplica<T>;
 }
 
 function extendWithFakeReadReplica<T extends PrismaClient>(client: T): PrismaClientWithReplica<T> {


### PR DESCRIPTION
Prisma query-extension callbacks run in the order they were applied, so the replication-wait `$allOperations` hook wraps the read-replicas extension and receives every operation — including reads that get routed to the replica. Those reads then triggered `readTargetAndWaitForReplication()` (a primary `pg_current_wal_lsn()` query + a wait on all replicas) even though they never touched the primary.

Fix: skip the replication wait for the same read-operation list that `@prisma/extension-read-replicas` routes to replicas. Writes, `$queryRaw`/`$executeRaw`, and transactions still wait as before.

Verified locally against the dev primary+replica docker setup with SQL-level instrumentation: before, `team.findMany()` on the replica was followed by a primary LSN query and replication wait; after, it runs on the replica only, while primary write paths still wait.

Link to Devin session: https://app.devin.ai/sessions/2be081403d9d4be69ea0ee6b97964d2a
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip replication wait for replica-routed reads to cut latency and reduce primary load, while keeping read-after-write consistency for writes and transactions.

- **Bug Fixes**
  - Apply `@prisma/extension-read-replicas` before the replication-wait hook so replica reads never reach it; verified with Vitest.
  - Writes, `$queryRaw`/`$executeRaw`, and transactions still wait on the primary.

<sup>Written for commit d5973e9fcf3ad4e39f16b77ff8c6e19a6d0efc7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1806?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Improved routing for read-only operations so reads sent to replicas avoid unnecessary replication waiting.
  * Kept replication safeguards active for primary-path reads, writes, and transactional workflows.
* **Bug Fixes**
  * Corrected replication-wait interception behavior to ensure replica-routed queries don’t trigger wait logic.
* **Tests**
  * Added automated coverage validating replication-wait behavior by checking executed PostgreSQL statements.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->