### PR TITLE
fix(cli): friendly error instead of internal crash when the CLI user is restricted

### DIFF
--- a/packages/cli/src/lib/app.test.ts
+++ b/packages/cli/src/lib/app.test.ts
@@ -47,4 +47,14 @@ describe("getInternalUser", () => {
       "Finish setting up your account at https://app.hexclave.com/onboarding before using the CLI.",
     );
   });
+
+  it("keeps the onboarding auth error friendly when the dashboard URL is malformed", async () => {
+    getUser.mockResolvedValue({ isRestricted: true });
+
+    const result = getInternalUser({ ...auth, dashboardUrl: "not-a-url" });
+    await expect(result).rejects.toBeInstanceOf(AuthError);
+    await expect(result).rejects.toThrow(
+      "Finish setting up your account at not-a-url/onboarding before using the CLI.",
+    );
+  });
 });

--- a/packages/cli/src/lib/app.test.ts
+++ b/packages/cli/src/lib/app.test.ts
@@ -1,0 +1,50 @@
+import { beforeEach, describe, expect, it, vi } from "vitest";
+import { AuthError } from "./errors.js";
+
+const { getUser } = vi.hoisted(() => ({
+  getUser: vi.fn(),
+}));
+
+vi.mock("@hexclave/js", () => ({
+  StackClientApp: class {
+    getUser = getUser;
+  },
+}));
+
+import { getInternalUser } from "./app.js";
+
+const auth = {
+  apiUrl: "https://api.hexclave.com",
+  dashboardUrl: "https://app.hexclave.com",
+  publishableClientKey: "pck_test",
+  refreshToken: "refresh-token",
+};
+
+describe("getInternalUser", () => {
+  beforeEach(() => {
+    getUser.mockReset();
+  });
+
+  it("throws a friendly auth error when there is no signed-in user", async () => {
+    getUser.mockResolvedValue(null);
+
+    const result = getInternalUser(auth);
+    await expect(result).rejects.toBeInstanceOf(AuthError);
+    await expect(result).rejects.toMatchObject({
+      name: "AuthError",
+      message: "Your session is invalid or expired. Run `hexclave login` again.",
+    });
+    await expect(result).rejects.not.toThrow("User is not signed in but getUser was called with");
+    expect(getUser).toHaveBeenCalledWith({ includeRestricted: true });
+  });
+
+  it("throws a friendly onboarding error for restricted users", async () => {
+    getUser.mockResolvedValue({ isRestricted: true });
+
+    const result = getInternalUser(auth);
+    await expect(result).rejects.toBeInstanceOf(AuthError);
+    await expect(result).rejects.toThrow(
+      "Finish setting up your account at https://app.hexclave.com/onboarding before using the CLI.",
+    );
+  });
+});

--- a/packages/cli/src/lib/app.test.ts
+++ b/packages/cli/src/lib/app.test.ts
@@ -30,10 +30,9 @@ describe("getInternalUser", () => {
 
     const result = getInternalUser(auth);
     await expect(result).rejects.toBeInstanceOf(AuthError);
-    await expect(result).rejects.toMatchObject({
-      name: "AuthError",
-      message: "Your session is invalid or expired. Run `hexclave login` again.",
-    });
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AuthError: Your session is invalid or expired. Run \`hexclave login\` again.]`,
+    );
     await expect(result).rejects.not.toThrow("User is not signed in but getUser was called with");
     expect(getUser).toHaveBeenCalledWith({ includeRestricted: true });
   });
@@ -43,18 +42,27 @@ describe("getInternalUser", () => {
 
     const result = getInternalUser(auth);
     await expect(result).rejects.toBeInstanceOf(AuthError);
-    await expect(result).rejects.toThrow(
-      "Finish setting up your account at https://app.hexclave.com/onboarding before using the CLI.",
+    await expect(result).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AuthError: Finish setting up your account at https://app.hexclave.com/onboarding before using the CLI.]`,
     );
   });
 
-  it("keeps the onboarding auth error friendly when the dashboard URL is malformed", async () => {
+  it("keeps the onboarding auth error friendly for malformed and nested dashboard URLs", async () => {
     getUser.mockResolvedValue({ isRestricted: true });
 
-    const result = getInternalUser({ ...auth, dashboardUrl: "not-a-url" });
-    await expect(result).rejects.toBeInstanceOf(AuthError);
-    await expect(result).rejects.toThrow(
-      "Finish setting up your account at not-a-url/onboarding before using the CLI.",
+    const malformedResult = getInternalUser({ ...auth, dashboardUrl: "not-a-url" });
+    await expect(malformedResult).rejects.toBeInstanceOf(AuthError);
+    await expect(malformedResult).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AuthError: Finish setting up your account at not-a-url/onboarding before using the CLI.]`,
+    );
+
+    const nestedResult = getInternalUser({
+      ...auth,
+      dashboardUrl: "https://app.hexclave.com/console?tenant=one#settings",
+    });
+    await expect(nestedResult).rejects.toBeInstanceOf(AuthError);
+    await expect(nestedResult).rejects.toThrowErrorMatchingInlineSnapshot(
+      `[AuthError: Finish setting up your account at https://app.hexclave.com/console/onboarding before using the CLI.]`,
     );
   });
 });

--- a/packages/cli/src/lib/app.ts
+++ b/packages/cli/src/lib/app.ts
@@ -1,5 +1,6 @@
 import { StackClientApp } from "@hexclave/js";
 import type { CurrentInternalUser, AdminOwnedProject } from "@hexclave/js";
+import { createUrlIfValid } from "@hexclave/shared/dist/utils/urls";
 import { AuthError } from "./errors.js";
 import type { SessionAuth, ProjectAuthWithRefreshToken } from "./auth.js";
 
@@ -25,7 +26,15 @@ export async function getInternalUser(auth: SessionAuth): Promise<CurrentInterna
     throw new AuthError("Your session is invalid or expired. Run `hexclave login` again.");
   }
   if (user.isRestricted) {
-    const onboardingUrl = `${auth.dashboardUrl.replace(/\/+$/, "")}/onboarding`;
+    const dashboardUrl = createUrlIfValid(auth.dashboardUrl);
+    const onboardingUrl = dashboardUrl == null
+      ? `${auth.dashboardUrl.replace(/\/+$/, "")}/onboarding`
+      : (() => {
+        dashboardUrl.pathname = `${dashboardUrl.pathname.replace(/\/+$/, "")}/onboarding`;
+        dashboardUrl.search = "";
+        dashboardUrl.hash = "";
+        return dashboardUrl.toString();
+      })();
     throw new AuthError(`Finish setting up your account at ${onboardingUrl} before using the CLI.`);
   }
   return user as CurrentInternalUser;

--- a/packages/cli/src/lib/app.ts
+++ b/packages/cli/src/lib/app.ts
@@ -25,7 +25,7 @@ export async function getInternalUser(auth: SessionAuth): Promise<CurrentInterna
     throw new AuthError("Your session is invalid or expired. Run `hexclave login` again.");
   }
   if (user.isRestricted) {
-    const onboardingUrl = new URL("/onboarding", auth.dashboardUrl).toString();
+    const onboardingUrl = `${auth.dashboardUrl.replace(/\/+$/, "")}/onboarding`;
     throw new AuthError(`Finish setting up your account at ${onboardingUrl} before using the CLI.`);
   }
   return user as CurrentInternalUser;

--- a/packages/cli/src/lib/app.ts
+++ b/packages/cli/src/lib/app.ts
@@ -18,7 +18,16 @@ export function getInternalApp(auth: SessionAuth): StackClientApp<true, "interna
 
 export async function getInternalUser(auth: SessionAuth): Promise<CurrentInternalUser> {
   const app = getInternalApp(auth);
-  const user = await app.getUser({ or: "throw" });
+  // Avoid `or: "throw"` here: its internal error message leaked to CLI users
+  // and was reported as a fatal Sentry event instead of a normal auth error.
+  const user = await app.getUser({ includeRestricted: true });
+  if (user == null) {
+    throw new AuthError("Your session is invalid or expired. Run `hexclave login` again.");
+  }
+  if (user.isRestricted) {
+    const onboardingUrl = new URL("/onboarding", auth.dashboardUrl).toString();
+    throw new AuthError(`Finish setting up your account at ${onboardingUrl} before using the CLI.`);
+  }
   return user as CurrentInternalUser;
 }
 

--- a/packages/cli/src/lib/app.ts
+++ b/packages/cli/src/lib/app.ts
@@ -4,6 +4,18 @@ import { createUrlIfValid } from "@hexclave/shared/dist/utils/urls";
 import { AuthError } from "./errors.js";
 import type { SessionAuth, ProjectAuthWithRefreshToken } from "./auth.js";
 
+function onboardingUrlFor(dashboardUrl: string): string {
+  const parsedDashboardUrl = createUrlIfValid(dashboardUrl);
+  if (parsedDashboardUrl == null) {
+    // Configured dashboard URLs are unvalidated, so this fallback must not throw.
+    return `${dashboardUrl.replace(/\/+$/, "")}/onboarding`;
+  }
+  parsedDashboardUrl.pathname = `${parsedDashboardUrl.pathname.replace(/\/+$/, "")}/onboarding`;
+  parsedDashboardUrl.search = "";
+  parsedDashboardUrl.hash = "";
+  return parsedDashboardUrl.toString();
+}
+
 export function getInternalApp(auth: SessionAuth): StackClientApp<true, "internal"> {
   return new StackClientApp({
     projectId: "internal",
@@ -26,16 +38,7 @@ export async function getInternalUser(auth: SessionAuth): Promise<CurrentInterna
     throw new AuthError("Your session is invalid or expired. Run `hexclave login` again.");
   }
   if (user.isRestricted) {
-    const dashboardUrl = createUrlIfValid(auth.dashboardUrl);
-    const onboardingUrl = dashboardUrl == null
-      ? `${auth.dashboardUrl.replace(/\/+$/, "")}/onboarding`
-      : (() => {
-        dashboardUrl.pathname = `${dashboardUrl.pathname.replace(/\/+$/, "")}/onboarding`;
-        dashboardUrl.search = "";
-        dashboardUrl.hash = "";
-        return dashboardUrl.toString();
-      })();
-    throw new AuthError(`Finish setting up your account at ${onboardingUrl} before using the CLI.`);
+    throw new AuthError(`Finish setting up your account at ${onboardingUrlFor(auth.dashboardUrl)} before using the CLI.`);
   }
   return user as CurrentInternalUser;
 }


### PR DESCRIPTION
## Summary

`getInternalUser` used `app.getUser({ or: "throw" })`, whose error is an internal-sounding `User is not signed in but getUser was called with { or: 'throw' }`. Since `getUser` returns `null` for restricted (not-yet-onboarded) accounts, any CLI command (`whoami`, `init`, `project`, ...) run by a restricted user printed that raw stack trace and reported a `stack-cli-fatal` Sentry event.

Now the two cases are distinguished:

```ts
const user = await app.getUser({ includeRestricted: true });
if (user == null) throw new AuthError("Your session is invalid or expired. Run `hexclave login` again.");
if (user.isRestricted) throw new AuthError(`Finish setting up your account at ${dashboardUrl}/onboarding ...`);
```

`AuthError` is already handled in `main()` as a clean `Auth error: <message>` with exit code 1 and no Sentry report. Adds unit tests for both branches.


Link to Devin session: https://app.devin.ai/sessions/80cfb0982a064cf984218b5a1173e2f0
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show friendly auth errors in the CLI for expired sessions and restricted accounts. Robustly build the onboarding URL to avoid stack traces and Sentry fatals.

- **Bug Fixes**
  - Use `getUser({ includeRestricted: true })`; throw `AuthError` for null or restricted users with clear guidance.
  - Exit with "Auth error: ..." and code 1 without Sentry.
  - Tests cover no user, restricted user, and URL edge cases.

- **Refactors**
  - Extract `onboardingUrlFor()` using `createUrlIfValid` from `@hexclave/shared` to strip query/hash, trim trailing slashes, append `/onboarding`, and safely fall back for invalid URLs.

<sup>Written for commit c5ba0b2143277577d9191c5a4da12e93349a126b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1808?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved CLI authentication error handling for invalid or expired sessions, with clearer guidance to rerun `hexclave login`.
  * Restricted accounts now receive a setup/onboarding prompt using a correctly constructed dashboard URL.
  * Enhanced onboarding error behavior for malformed or nested dashboard URLs, preserving actionable messaging.
* **Tests**
  * Added Vitest coverage for invalid sessions, restricted-account onboarding errors, and dashboard URL edge cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->