### PR TITLE
fix(sdk): show inline error when sign-up email is already used for auth

### DIFF
--- a/apps/e2e/tests/js/app.test.ts
+++ b/apps/e2e/tests/js/app.test.ts
@@ -1,4 +1,5 @@
 import { isUuid } from "@hexclave/shared/dist/utils/uuids";
+import { KnownErrors } from "@hexclave/shared";
 import { it } from "../helpers";
 import { createApp, scaffoldProject } from "./js-helpers";
 
@@ -60,6 +61,45 @@ it("should sign up without a verification callback when disabled", async ({ expe
     {
       "data": undefined,
       "status": "ok",
+    }
+  `);
+});
+
+it("should return a known error when signing up with an email used by another account", async ({ expect }) => {
+  const { clientApp } = await createApp();
+  const email = "already-used@test.com";
+
+  expect(await clientApp.signUpWithCredential({
+    email,
+    password: "password",
+    noVerificationCallback: true,
+  })).toMatchInlineSnapshot(`
+    {
+      "data": undefined,
+      "status": "ok",
+    }
+  `);
+
+  await clientApp.signOut();
+
+  const result = await clientApp.signUpWithCredential({
+    email,
+    password: "password",
+    noVerificationCallback: true,
+  });
+
+  expect(result.status).toBe("error");
+  if (result.status !== "error") {
+    throw new Error("Expected credential signup to return a known error");
+  }
+  expect(KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse.isInstance(result.error)).toBe(true);
+  expect({
+    status: result.status,
+    errorCode: result.error.errorCode,
+  }).toMatchInlineSnapshot(`
+    {
+      "errorCode": "CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE",
+      "status": "error",
     }
   `);
 });

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -1232,7 +1232,7 @@ export class HexclaveClientInterface {
     emailVerificationRedirectUrl: string | undefined,
     session: InternalSession,
     botChallenge?: BotChallengeInput,
-  ): Promise<Result<{ accessToken: string, refreshToken: string }, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors["PasswordRequirementsNotMet"] | KnownErrors["BotChallengeRequired"] | KnownErrors["BotChallengeFailed"]>> {
+  ): Promise<Result<{ accessToken: string, refreshToken: string }, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors["ContactChannelAlreadyUsedForAuthBySomeoneElse"] | KnownErrors["PasswordRequirementsNotMet"] | KnownErrors["BotChallengeRequired"] | KnownErrors["BotChallengeFailed"]>> {
     const res = await this.sendClientRequestAndCatchKnownError(
       "/auth/password/sign-up",
       {
@@ -1248,7 +1248,7 @@ export class HexclaveClientInterface {
         }),
       },
       session,
-      [KnownErrors.UserWithEmailAlreadyExists, KnownErrors.PasswordRequirementsNotMet, ...botChallengeKnownErrors]
+      [KnownErrors.UserWithEmailAlreadyExists, KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse, KnownErrors.PasswordRequirementsNotMet, ...botChallengeKnownErrors]
     );
 
     if (res.status === "error") {

--- a/packages/shared/src/interface/page-component-versions.ts
+++ b/packages/shared/src/interface/page-component-versions.ts
@@ -124,7 +124,7 @@ function createAuthPagePrompt(type: AuthPagePromptType): CustomPagePrompt {
 
   const credentialResultType = isSignIn
     ? "Promise<Result<undefined, KnownErrors[\"EmailPasswordMismatch\"] | KnownErrors[\"InvalidTotpCode\"]>>"
-    : "Promise<Result<undefined, KnownErrors[\"UserWithEmailAlreadyExists\"] | KnownErrors[\"PasswordRequirementsNotMet\"] | KnownErrors[\"BotChallengeFailed\"]>>";
+    : "Promise<Result<undefined, KnownErrors[\"UserWithEmailAlreadyExists\"] | KnownErrors[\"ContactChannelAlreadyUsedForAuthBySomeoneElse\"] | KnownErrors[\"PasswordRequirementsNotMet\"] | KnownErrors[\"BotChallengeFailed\"]>>";
 
   return createCustomPagePrompt({
     key: type,

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -3611,7 +3611,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     noRedirect?: boolean,
     noVerificationCallback?: boolean,
     verificationCallbackUrl?: string,
-  }): Promise<Result<undefined, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors['PasswordRequirementsNotMet'] | KnownErrors["BotChallengeFailed"]>> {
+  }): Promise<Result<undefined, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors["ContactChannelAlreadyUsedForAuthBySomeoneElse"] | KnownErrors['PasswordRequirementsNotMet'] | KnownErrors["BotChallengeFailed"]>> {
     if (options.noVerificationCallback && options.verificationCallbackUrl) {
       throw new HexclaveAssertionError("verificationCallbackUrl is not allowed when noVerificationCallback is true");
     }

--- a/packages/template/src/lib/hexclave-app/apps/interfaces/client-app.ts
+++ b/packages/template/src/lib/hexclave-app/apps/interfaces/client-app.ts
@@ -78,7 +78,7 @@ export type StackClientApp<HasTokenStore extends boolean = boolean, ProjectId ex
       email: string,
       password: string,
       noRedirect?: boolean,
-    } & ({ noVerificationCallback: true } | { noVerificationCallback?: false, verificationCallbackUrl?: string })): Promise<Result<undefined, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors["PasswordRequirementsNotMet"] | KnownErrors["BotChallengeFailed"]>>,
+    } & ({ noVerificationCallback: true } | { noVerificationCallback?: false, verificationCallbackUrl?: string })): Promise<Result<undefined, KnownErrors["UserWithEmailAlreadyExists"] | KnownErrors["ContactChannelAlreadyUsedForAuthBySomeoneElse"] | KnownErrors["PasswordRequirementsNotMet"] | KnownErrors["BotChallengeFailed"]>>,
     signInWithPasskey(): Promise<Result<undefined, KnownErrors["PasskeyAuthenticationFailed"] | KnownErrors["InvalidTotpCode"] | KnownErrors["PasskeyWebAuthnError"]>>,
     callOAuthCallback(): Promise<boolean>,
     promptCliLogin(options: { appUrl: string, expiresInMillis?: number, anonRefreshToken?: string, promptLink?: (url: string, loginCode: string) => void }): Promise<Result<string, KnownErrors["CliAuthError"] | KnownErrors["CliAuthExpiredError"] | KnownErrors["CliAuthUsedError"]>>,

--- a/sdks/implementations/swift/Sources/StackAuth/Errors.swift
+++ b/sdks/implementations/swift/Sources/StackAuth/Errors.swift
@@ -40,6 +40,17 @@ public struct UserWithEmailAlreadyExistsError: StackAuthErrorProtocol {
     public var description: String { "UserWithEmailAlreadyExistsError: \(message)" }
 }
 
+public struct ContactChannelAlreadyUsedForAuthBySomeoneElseError: StackAuthErrorProtocol {
+    public let code = "CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE"
+    public let message = "This email is already used for authentication by another account."
+    public let details: [String: Any]?
+    public var description: String { "ContactChannelAlreadyUsedForAuthBySomeoneElseError: \(message)" }
+
+    public init(details: [String: Any]? = nil) {
+        self.details = details
+    }
+}
+
 public struct PasswordRequirementsNotMetError: StackAuthErrorProtocol {
     public let code = "PASSWORD_REQUIREMENTS_NOT_MET"
     public let message = "The password does not meet the project's requirements."
@@ -150,6 +161,8 @@ extension StackAuthError {
             return EmailPasswordMismatchError()
         case "USER_EMAIL_ALREADY_EXISTS":
             return UserWithEmailAlreadyExistsError()
+        case "CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE":
+            return ContactChannelAlreadyUsedForAuthBySomeoneElseError(details: details)
         case "PASSWORD_REQUIREMENTS_NOT_MET":
             return PasswordRequirementsNotMetError()
         case "USER_NOT_FOUND":

--- a/sdks/spec/src/apps/client-app.spec.md
+++ b/sdks/spec/src/apps/client-app.spec.md
@@ -250,6 +250,10 @@ Errors:
   UserWithEmailAlreadyExists
     code: "user_email_already_exists"
     message: "A user with this email address already exists."
+
+  ContactChannelAlreadyUsedForAuthBySomeoneElse
+    code: "contact_channel_already_used_for_auth_by_someone_else"
+    message: "This email is already used for authentication by another account."
     
   PasswordRequirementsNotMet
     code: "password_requirements_not_met"


### PR DESCRIPTION
## Summary
The `/auth/password/sign-up` endpoint can return `KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse`, but the client interface's `signUpWithCredential` didn't include it in its caught known errors, so it was rethrown as an unexpected error and surfaced via `runAsynchronouslyWithAlert` (a browser alert) instead of the `<CredentialSignUp>` form's inline error text (`result.status === 'error'` path).

Adds `ContactChannelAlreadyUsedForAuthBySomeoneElse` to the caught-error list and the `Result` error unions of `signUpWithCredential` (client interface, client app impl/interface, SDK spec, page-component prompt), so the sign-up form now shows the error message inline.

Adds an e2e test asserting a second sign-up with the same email returns `status: "error"` with `CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE` instead of throwing.

Link to Devin session: https://app.devin.ai/sessions/fd228b2921394a4bab4b10ac3722a41b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show inline error on sign-up when the email is already used by another account. The client and Swift SDK now return a typed known error instead of throwing.

- **Bug Fixes**
  - Catch `KnownErrors.ContactChannelAlreadyUsedForAuthBySomeoneElse` from `/auth/password/sign-up` in `signUpWithCredential`, so `<CredentialSignUp>` shows the error inline instead of a browser alert.
  - Updated result unions in shared client interface, client app interface/impl, and page-component prompt; added the error code/message to the SDK spec.
  - Added an e2e test asserting a second sign-up with the same email returns `status: "error"` with `CONTACT_CHANNEL_ALREADY_USED_FOR_AUTH_BY_SOMEONE_ELSE`.

- **New Features**
  - Added a typed `ContactChannelAlreadyUsedForAuthBySomeoneElse` error to the Swift SDK and mapped it from the server error code.

<sup>Written for commit 4d74889bbc9e182aec8b2f0443eab531a9e6eaca. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1809?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Sign-up now clearly reports when an email or contact channel is already used for authentication by another account.
  - Swift SDK users can receive and inspect this specific error, including its code, message, and details.
- **Bug Fixes**
  - Duplicate-contact sign-up failures are returned as structured results instead of unexpected errors.
- **Documentation**
  - Added the new sign-up error case, code, and message to the client API documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->