### PR TITLE
fix(dashboard): don't leave /new-project blank after dismissing the dialog

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.test.tsx
@@ -7,6 +7,7 @@ import { cleanup, fireEvent, render, screen } from "@testing-library/react";
 const mockPush = vi.hoisted(() => vi.fn());
 const mockReplace = vi.hoisted(() => vi.fn());
 const mockOwnedProjects = vi.hoisted(() => ({ current: [] as Array<{ id: string }> }));
+const mockCreateProject = vi.hoisted(() => vi.fn(async () => ({ id: "created-project-id" })));
 
 vi.mock("@/components/design-components/button", () => ({
   DesignButton: ({ children, type, loading: _loading, variant: _variant, ...props }: ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean, variant?: string }) => (
@@ -70,7 +71,7 @@ vi.mock("@/lib/dashboard-user", () => ({
     selectedTeam: null,
     useTeams: () => [{ id: "team-id", displayName: "Team" }],
     useOwnedProjects: () => mockOwnedProjects.current,
-    createProject: vi.fn(),
+    createProject: mockCreateProject,
     createTeam: vi.fn(),
     setSelectedTeam: vi.fn(),
   }),
@@ -97,11 +98,21 @@ afterEach(() => {
   mockPush.mockClear();
   mockReplace.mockClear();
   mockOwnedProjects.current = [];
+  mockCreateProject.mockReset();
+  mockCreateProject.mockResolvedValue({ id: "created-project-id" });
 });
 
 // The page renders both the create-project and the create-team dialog, in that order.
 function dismissCreateProjectDialog() {
   fireEvent.click(screen.getAllByText("dismiss dialog")[0]);
+}
+
+function throwMissingInput(): never {
+  throw new Error("The project name input was not rendered.");
+}
+
+function throwMissingForm(): never {
+  throw new Error("The project creation form was not rendered.");
 }
 
 describe("new project page", () => {
@@ -116,6 +127,20 @@ describe("new project page", () => {
     expect(screen.getByText("Create a new project")).not.toBeNull();
     expect(mockPush).not.toHaveBeenCalled();
     expect(screen.queryByText("Cancel")).toBeNull();
+  });
+
+  it("ignores dismissals while a project is being created", () => {
+    mockOwnedProjects.current = [{ id: "project-id" }];
+    mockCreateProject.mockReturnValue(new Promise(() => {}));
+    const { container } = render(<PageClient />);
+
+    fireEvent.change(container.querySelector("#project-name") ?? throwMissingInput(), { target: { value: "My Project" } });
+    fireEvent.submit(container.querySelector("form") ?? throwMissingForm());
+
+    dismissCreateProjectDialog();
+
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(screen.getByText("Create a new project")).not.toBeNull();
   });
 
   it("returns users with projects to the projects page when they dismiss the dialog", () => {

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.test.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.test.tsx
@@ -1,0 +1,130 @@
+// @vitest-environment jsdom
+
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from "react";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { cleanup, fireEvent, render, screen } from "@testing-library/react";
+
+const mockPush = vi.hoisted(() => vi.fn());
+const mockReplace = vi.hoisted(() => vi.fn());
+const mockOwnedProjects = vi.hoisted(() => ({ current: [] as Array<{ id: string }> }));
+
+vi.mock("@/components/design-components/button", () => ({
+  DesignButton: ({ children, type, loading: _loading, variant: _variant, ...props }: ButtonHTMLAttributes<HTMLButtonElement> & { loading?: boolean, variant?: string }) => (
+    <button type={type ?? "button"} {...props}>{children}</button>
+  ),
+}));
+
+vi.mock("@/components/design-components/input", () => ({
+  DesignInput: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />,
+}));
+
+vi.mock("@/components/design-components/select", () => ({
+  DesignSelectorDropdown: ({ value, onValueChange, options }: {
+    value: string,
+    onValueChange: (value: string) => void,
+    options: Array<{ value: string, label: string }>,
+  }) => (
+    <select aria-label="team" value={value} onChange={(event) => onValueChange(event.target.value)}>
+      {options.map((option) => <option key={option.value} value={option.value}>{option.label}</option>)}
+    </select>
+  ),
+}));
+
+vi.mock("@/components/router", () => ({
+  useRouter: () => ({ push: mockPush, replace: mockReplace }),
+}));
+
+// The dialog primitive is replaced by a minimal stand-in that renders its children only while
+// open and exposes a button to trigger the same `onOpenChange(false)` that clicking the overlay
+// (or pressing escape) would.
+vi.mock("@/components/ui", () => {
+  const passthrough = ({ children }: { children?: ReactNode }) => <div>{children}</div>;
+  return {
+    Button: ({ children, type, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+      <button type={type ?? "button"} {...props}>{children}</button>
+    ),
+    Card: passthrough,
+    CardContent: passthrough,
+    CardDescription: passthrough,
+    CardHeader: passthrough,
+    CardTitle: passthrough,
+    Dialog: ({ open, onOpenChange, children }: { open: boolean, onOpenChange?: (open: boolean) => void, children: ReactNode }) => (
+      <div>
+        <button type="button" onClick={() => onOpenChange?.(false)}>dismiss dialog</button>
+        {open ? children : null}
+      </div>
+    ),
+    DialogContent: passthrough,
+    DialogDescription: passthrough,
+    DialogFooter: passthrough,
+    DialogHeader: passthrough,
+    DialogTitle: ({ children }: { children?: ReactNode }) => <h2>{children}</h2>,
+    Label: ({ children }: { children?: ReactNode }) => <label>{children}</label>,
+    Spinner: () => <div>Loading</div>,
+    Typography: passthrough,
+  };
+});
+
+vi.mock("@/lib/dashboard-user", () => ({
+  useDashboardInternalUser: () => ({
+    selectedTeam: null,
+    useTeams: () => [{ id: "team-id", displayName: "Team" }],
+    useOwnedProjects: () => mockOwnedProjects.current,
+    createProject: vi.fn(),
+    createTeam: vi.fn(),
+    setSelectedTeam: vi.fn(),
+  }),
+}));
+
+vi.mock("@/lib/env", () => ({
+  getPublicEnvVar: () => "false",
+}));
+
+vi.mock("@hexclave/next", () => ({}));
+
+vi.mock("next/navigation", () => ({
+  useSearchParams: () => new URLSearchParams(),
+}));
+
+vi.mock("./project-onboarding-wizard", () => ({
+  ProjectOnboardingWizard: () => <div>Onboarding wizard</div>,
+}));
+
+import PageClient from "./content";
+
+afterEach(() => {
+  cleanup();
+  mockPush.mockClear();
+  mockReplace.mockClear();
+  mockOwnedProjects.current = [];
+});
+
+// The page renders both the create-project and the create-team dialog, in that order.
+function dismissCreateProjectDialog() {
+  fireEvent.click(screen.getAllByText("dismiss dialog")[0]);
+}
+
+describe("new project page", () => {
+  it("keeps the creation dialog open when a user without projects dismisses it", () => {
+    render(<PageClient />);
+    expect(screen.getByText("Create a new project")).not.toBeNull();
+
+    dismissCreateProjectDialog();
+
+    // Leaving would bounce the user right back here from the projects page, which previously
+    // left the page blank because the dialog stayed closed across the round trip.
+    expect(screen.getByText("Create a new project")).not.toBeNull();
+    expect(mockPush).not.toHaveBeenCalled();
+    expect(screen.queryByText("Cancel")).toBeNull();
+  });
+
+  it("returns users with projects to the projects page when they dismiss the dialog", () => {
+    mockOwnedProjects.current = [{ id: "project-id" }];
+    render(<PageClient />);
+
+    dismissCreateProjectDialog();
+
+    expect(mockPush).toHaveBeenCalledWith("/projects");
+    expect(screen.getByText("Cancel")).not.toBeNull();
+  });
+});

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
@@ -348,7 +348,8 @@ function PageClientInner() {
         <Dialog
           open
           onOpenChange={(open) => {
-            if (open || !canLeaveProjectCreation) {
+            // Navigating away mid-creation would hide the result (or error) of the request.
+            if (open || creatingProjectRef.current || !canLeaveProjectCreation) {
               return;
             }
             router.push("/projects");

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/new-project/page-client-parts/content.tsx
@@ -76,11 +76,13 @@ function PageClientInner() {
   const [selectedTeamId, setSelectedTeamId] = useState<string | null>(null);
   const [creatingTeam, setCreatingTeam] = useState(false);
   const [creatingProject, setCreatingProject] = useState(false);
-  const [isCreateProjectOpen, setIsCreateProjectOpen] = useState(true);
   const [isCreateTeamOpen, setIsCreateTeamOpen] = useState(false);
   const [newTeamName, setNewTeamName] = useState("");
   const creatingTeamRef = useRef(false);
   const creatingProjectRef = useRef(false);
+  // Users without a project have nowhere to go: the projects page immediately sends them back
+  // here, so dismissing the creation dialog must be a no-op for them.
+  const canLeaveProjectCreation = projects.length > 0;
 
   useEffect(() => {
     if (selectedTeamId != null) {
@@ -336,13 +338,20 @@ function PageClientInner() {
   if (selectedProject == null) {
     return (
       <div className="flex w-full flex-grow items-center justify-center">
+        {/*
+          The dialog is the entire page, so its open state is derived from the route rather than
+          from component state: dismissing it navigates away instead of closing it in place. Keeping
+          a local `open` state here used to leave the page blank, because the projects page bounces
+          users without projects straight back to /new-project without remounting this component,
+          so the closed state survived the round trip.
+        */}
         <Dialog
-          open={isCreateProjectOpen}
+          open
           onOpenChange={(open) => {
-            setIsCreateProjectOpen(open);
-            if (!open) {
-              router.push("/projects");
+            if (open || !canLeaveProjectCreation) {
+              return;
             }
+            router.push("/projects");
           }}
         >
           <DialogContent
@@ -397,9 +406,11 @@ function PageClientInner() {
               </div>
 
               <DialogFooter className="border-t border-black/[0.08] px-6 py-4 dark:border-white/[0.08] sm:justify-end sm:space-x-2">
-                <DesignButton type="button" variant="outline" className="rounded-xl" onClick={() => router.push("/projects")} disabled={creatingProject}>
-                  Cancel
-                </DesignButton>
+                {canLeaveProjectCreation && (
+                  <DesignButton type="button" variant="outline" className="rounded-xl" onClick={() => router.push("/projects")} disabled={creatingProject}>
+                    Cancel
+                  </DesignButton>
+                )}
                 <DesignButton
                   type="submit"
                   className="rounded-xl"

--- a/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/(outside-dashboard)/projects/page-client.tsx
@@ -276,7 +276,8 @@ function ProjectsListPage() {
 
   useEffect(() => {
     if (rawProjects.length === 0 && !isRemoteDevelopmentEnvironment) {
-      router.push('/new-project');
+      // Replace instead of push, so that the back button doesn't bounce between the two pages.
+      router.replace('/new-project');
     }
   }, [isRemoteDevelopmentEnvironment, router, rawProjects]);
 


### PR DESCRIPTION
## Summary

Clicking outside the create-project dialog on `/new-project` left the page permanently blank, including after navigating back to it.

The dialog is the entire page, but its open state lived in component state:

```diff
-<Dialog open={isCreateProjectOpen} onOpenChange={(open) => { setIsCreateProjectOpen(open); if (!open) router.push("/projects"); }}>
+<Dialog open onOpenChange={(open) => { if (!open && canLeaveProjectCreation) router.push("/projects"); }}>
```

For a user with no projects, `/projects` immediately sends them back to `/new-project`, and that round trip does not remount the page component — so `isCreateProjectOpen: false` survived and the page rendered nothing at all.

Now the open state is derived from the route (`open` is always true; dismissing navigates instead of closing), and dismissal is a no-op for users with no projects, since they'd just be bounced straight back. `Cancel` is hidden in that case for the same reason. The `/projects` → `/new-project` redirect also uses `replace` instead of `push`, so the back button can't get stuck between the two pages.

Regression test in `content.test.tsx` covers both dismissal paths (stays open with no projects; navigates to `/projects` otherwise).


Link to Devin session: https://app.devin.ai/sessions/112079330b8047b396d21acea92f620e
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes a blank screen on `/new-project` after dismissing the create-project dialog. Dialog state now follows the route; dismissals during creation are ignored, so the page never renders empty and back navigation works.

- **Bug Fixes**
  - Dialog is always open; dismiss navigates to `/projects` only if the user has projects, and is ignored while a project is being created.
  - For users with no projects, dismiss is a no-op and the "Cancel" button is hidden.
  - `/projects` → `/new-project` now uses `router.replace` to prevent back-button loops.
  - Added regression tests in `content.test.tsx` covering dismissal paths and in-progress creation.

<sup>Written for commit f3597a61909e0aebfd51b0a272864f0004a31d5b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1810?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Project creation remains open for users without existing projects, preventing accidental dismissal.
  * Added conditional navigation and Cancel-button behavior based on whether the user can leave project creation.

* **Bug Fixes**
  * Improved navigation for users without projects so the browser Back button no longer returns them to an unnecessary intermediate page.
  * Added automated coverage for dialog dismissal and navigation behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->