### PR TITLE
feat(cli): add `hexclave team` commands and team selection in `project create`

### DIFF
--- a/apps/e2e/tests/js/team-memberships.test.ts
+++ b/apps/e2e/tests/js/team-memberships.test.ts
@@ -1,0 +1,74 @@
+import { KnownErrors } from "@hexclave/shared";
+import { it } from "../helpers";
+import { createApp } from "./js-helpers";
+
+it("allows a client team member with permission to remove another member", { timeout: 60_000 }, async ({ expect }) => {
+  const { clientApp, serverApp } = await createApp({ config: { clientTeamCreationEnabled: true } });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-owner@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  await clientApp.signInWithCredential({
+    email: "membership-owner@test.com",
+    password: "password",
+  });
+  const owner = await clientApp.getUser({ or: "throw" });
+  const team = await owner.createTeam({ displayName: "Membership Team" });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-member@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  const member = await clientApp.getUser({ or: "throw" });
+  const serverTeam = await serverApp.getTeam(team.id);
+  if (!serverTeam) throw new Error("Team not found on server");
+  await serverTeam.addUser(member.id);
+
+  await clientApp.signInWithCredential({
+    email: "membership-owner@test.com",
+    password: "password",
+  });
+  const ownerAgain = await clientApp.getUser({ or: "throw" });
+  const clientTeam = await ownerAgain.getTeam(team.id);
+  if (!clientTeam) throw new Error("Team not found for client user");
+
+  await clientTeam.removeUser(member.id);
+
+  const remainingMembers = await serverTeam.listUsers();
+  expect(remainingMembers.some((teamMember) => teamMember.id === member.id)).toBe(false);
+});
+
+it("rejects client team member removal without the remove-members permission", { timeout: 60_000 }, async ({ expect }) => {
+  const { clientApp, serverApp } = await createApp({ config: { clientTeamCreationEnabled: true } });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-owner-no-permission@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  await clientApp.signInWithCredential({
+    email: "membership-owner-no-permission@test.com",
+    password: "password",
+  });
+  const owner = await clientApp.getUser({ or: "throw" });
+  const team = await owner.createTeam({ displayName: "Permission Team" });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-member-no-permission@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  const member = await clientApp.getUser({ or: "throw" });
+  const serverTeam = await serverApp.getTeam(team.id);
+  if (!serverTeam) throw new Error("Team not found on server");
+  await serverTeam.addUser(member.id);
+
+  const memberTeam = await member.getTeam(team.id);
+  if (!memberTeam) throw new Error("Team not found for client member");
+  await expect(memberTeam.removeUser(owner.id)).rejects.toSatisfy((error: unknown) => (
+    KnownErrors.TeamPermissionRequired.isInstance(error)
+  ));
+});

--- a/apps/e2e/tests/js/team-memberships.test.ts
+++ b/apps/e2e/tests/js/team-memberships.test.ts
@@ -73,7 +73,7 @@ it("rejects client team member removal without the remove-members permission", {
   ));
 });
 
-it("refreshes the current user after leaving a team", { timeout: 60_000 }, async ({ expect }) => {
+it("refreshes the current user after removing themselves from a team", { timeout: 60_000 }, async ({ expect }) => {
   const { clientApp } = await createApp({ config: { clientTeamCreationEnabled: true } });
 
   await clientApp.signUpWithCredential({
@@ -83,13 +83,35 @@ it("refreshes the current user after leaving a team", { timeout: 60_000 }, async
   });
   const user = await clientApp.getUser({ or: "throw" });
   const team = await user.createTeam({ displayName: "Leave Team" });
+  const userWithTeam = await clientApp.getUser({ or: "throw" });
 
-  expect((await user.listTeams()).some((candidate) => candidate.id === team.id)).toBe(true);
-  expect(user.selectedTeam?.id).toBe(team.id);
+  expect((await userWithTeam.listTeams()).some((candidate) => candidate.id === team.id)).toBe(true);
+  expect(userWithTeam.selectedTeam?.id).toBe(team.id);
 
-  await user.leaveTeam(team);
+  const clientTeam = await userWithTeam.getTeam(team.id);
+  if (!clientTeam) throw new Error("Team not found for client user");
+  await clientTeam.removeUser(userWithTeam.id);
 
-  expect((await user.listTeams()).some((candidate) => candidate.id === team.id)).toBe(false);
+  expect((await userWithTeam.listTeams()).some((candidate) => candidate.id === team.id)).toBe(false);
+  const refreshedUser = await clientApp.getUser({ or: "throw" });
+  expect(refreshedUser.selectedTeam).toBeNull();
+});
+
+it("refreshes the current user after leaving a team", { timeout: 60_000 }, async ({ expect }) => {
+  const { clientApp } = await createApp({ config: { clientTeamCreationEnabled: true } });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-leave-team@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  const user = await clientApp.getUser({ or: "throw" });
+  const team = await user.createTeam({ displayName: "Leave Team" });
+  const userWithTeam = await clientApp.getUser({ or: "throw" });
+
+  await userWithTeam.leaveTeam(team);
+
+  expect((await userWithTeam.listTeams()).some((candidate) => candidate.id === team.id)).toBe(false);
   const refreshedUser = await clientApp.getUser({ or: "throw" });
   expect(refreshedUser.selectedTeam).toBeNull();
 });

--- a/apps/e2e/tests/js/team-memberships.test.ts
+++ b/apps/e2e/tests/js/team-memberships.test.ts
@@ -72,3 +72,24 @@ it("rejects client team member removal without the remove-members permission", {
     KnownErrors.TeamPermissionRequired.isInstance(error)
   ));
 });
+
+it("refreshes the current user after leaving a team", { timeout: 60_000 }, async ({ expect }) => {
+  const { clientApp } = await createApp({ config: { clientTeamCreationEnabled: true } });
+
+  await clientApp.signUpWithCredential({
+    email: "membership-leave@test.com",
+    password: "password",
+    verificationCallbackUrl: "http://localhost:3000",
+  });
+  const user = await clientApp.getUser({ or: "throw" });
+  const team = await user.createTeam({ displayName: "Leave Team" });
+
+  expect((await user.listTeams()).some((candidate) => candidate.id === team.id)).toBe(true);
+  expect(user.selectedTeam?.id).toBe(team.id);
+
+  await user.leaveTeam(team);
+
+  expect((await user.listTeams()).some((candidate) => candidate.id === team.id)).toBe(false);
+  const refreshedUser = await clientApp.getUser({ or: "throw" });
+  expect(refreshedUser.selectedTeam).toBeNull();
+});

--- a/packages/cli/src/commands/init.ts
+++ b/packages/cli/src/commands/init.ts
@@ -277,11 +277,9 @@ async function handleCreateCloud(_flags: Record<string, unknown>, opts: InitOpti
   const sessionAuth = await ensureLoggedInSession();
   const user = await withProgress("Loading account", async () => await getInternalUser(sessionAuth));
 
-  const { dashboardUrl } = resolveLoginConfig();
   const newProject = await createProjectInteractively(user, {
     displayName: opts.displayName,
     defaultDisplayName: path.basename(outputDir),
-    dashboardUrl,
   });
   console.log(`\nCreated project: ${newProject.displayName} (${newProject.id})\n`);
 
@@ -317,10 +315,8 @@ async function handleLinkFromCloud(_flags: Record<string, unknown>, opts: InitOp
       throw new CliError(`You don't own any projects. Create one at ${dashboardUrl} or re-run and choose to create one.`);
     }
 
-    const { dashboardUrl } = resolveLoginConfig();
     const newProject = await createProjectInteractively(user, {
       defaultDisplayName: path.basename(outputDir),
-      dashboardUrl,
     });
     console.log(`\nCreated project: ${newProject.displayName} (${newProject.id})\n`);
     projects = [newProject];

--- a/packages/cli/src/commands/project.ts
+++ b/packages/cli/src/commands/project.ts
@@ -1,6 +1,6 @@
 import { Command } from "commander";
 import { getInternalUser } from "../lib/app.js";
-import { resolveLoginConfig, resolveSessionAuth } from "../lib/auth.js";
+import { resolveSessionAuth } from "../lib/auth.js";
 import { createProjectInteractively } from "../lib/create-project.js";
 import { CliError } from "../lib/errors.js";
 import { withProgress } from "../lib/progress.js";
@@ -84,22 +84,21 @@ export function registerProjectCommand(program: Command) {
     .description("Create a new cloud project")
     .option("--cloud", "Confirm that this creates a cloud project")
     .option("--display-name <name>", "Project display name")
+    .option("--team-id <id>", "Team that owns the project")
     .action(async (opts) => {
       if (!opts.cloud) {
         throw new CliError("hexclave project create currently only creates cloud projects. Pass --cloud to confirm.");
       }
-      const [{ getInternalUser }, { resolveLoginConfig, resolveSessionAuth }, { createProjectInteractively }] = await Promise.all([
+      const [{ getInternalUser }, { resolveSessionAuth }, { createProjectInteractively }] = await Promise.all([
         import("../lib/app.js"),
         import("../lib/auth.js"),
         import("../lib/create-project.js"),
       ]);
       const auth = resolveSessionAuth();
       const user = await withProgress("Loading account", async () => await getInternalUser(auth));
-      const { dashboardUrl } = resolveLoginConfig();
-
       const newProject = await createProjectInteractively(user, {
         displayName: opts.displayName,
-        dashboardUrl,
+        teamId: opts.teamId,
       });
 
       if (program.opts().json) {

--- a/packages/cli/src/commands/team.command.test.ts
+++ b/packages/cli/src/commands/team.command.test.ts
@@ -86,7 +86,13 @@ describe("team command parsing", () => {
     ]);
 
     expect(team.removeUser).toHaveBeenCalledWith("user-2");
-    expect(logSpy).toHaveBeenCalledWith("Removed team member: user-2");
+    expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "Removed team member: user-2",
+        ],
+      ]
+    `);
   });
 
   it("parses the team id on invitations list", async () => {
@@ -107,6 +113,12 @@ describe("team command parsing", () => {
     ]);
 
     expect(team.listInvitations).toHaveBeenCalledTimes(1);
-    expect(logSpy).toHaveBeenCalledWith("No invitations found.");
+    expect(logSpy.mock.calls).toMatchInlineSnapshot(`
+      [
+        [
+          "No invitations found.",
+        ],
+      ]
+    `);
   });
 });

--- a/packages/cli/src/commands/team.command.test.ts
+++ b/packages/cli/src/commands/team.command.test.ts
@@ -1,0 +1,112 @@
+import { Command } from "commander";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { registerTeamCommand } from "./team.js";
+
+type TestTeam = {
+  id: string,
+  displayName: string,
+  listUsers: () => Promise<Array<{ id: string, teamProfile: { displayName: string | null } }>>,
+  listInvitations: () => Promise<Array<{
+    id: string,
+    recipientEmail: string | null,
+    expiresAt: Date,
+    revoke: () => Promise<void>,
+  }>>,
+  removeUser: (userId: string) => Promise<void>,
+  inviteUser: (options: { email: string }) => Promise<void>,
+  update: (options: { displayName?: string }) => Promise<void>,
+  delete: () => Promise<void>,
+};
+
+type TestUser = {
+  listTeams: () => Promise<TestTeam[]>,
+};
+
+const mockState = vi.hoisted(() => ({
+  user: null as TestUser | null,
+}));
+
+vi.mock("../lib/app.js", () => ({
+  getInternalUser: vi.fn(async () => {
+    if (mockState.user == null) {
+      throw new Error("Expected test user to be configured.");
+    }
+    return mockState.user;
+  }),
+}));
+
+vi.mock("../lib/auth.js", () => ({
+  resolveSessionAuth: vi.fn(() => ({})),
+}));
+
+function createTeam(id: string, displayName: string): TestTeam {
+  return {
+    id,
+    displayName,
+    listUsers: vi.fn(async () => [{ id: "user-2", teamProfile: { displayName: "Member" } }]),
+    listInvitations: vi.fn(async () => []),
+    removeUser: vi.fn(async () => {}),
+    inviteUser: vi.fn(async () => {}),
+    update: vi.fn(async () => {}),
+    delete: vi.fn(async () => {}),
+  };
+}
+
+function createProgram() {
+  const program = new Command();
+  program.exitOverride();
+  registerTeamCommand(program);
+  return program;
+}
+
+afterEach(() => {
+  mockState.user = null;
+  vi.restoreAllMocks();
+});
+
+describe("team command parsing", () => {
+  it("parses the team id on members remove", async () => {
+    const team = createTeam("team-1", "Acme");
+    mockState.user = {
+      listTeams: vi.fn(async () => [team]),
+    };
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await createProgram().parseAsync([
+      "node",
+      "hexclave",
+      "team",
+      "members",
+      "remove",
+      "--team-id",
+      "team-1",
+      "--user-id",
+      "user-2",
+      "--yes",
+    ]);
+
+    expect(team.removeUser).toHaveBeenCalledWith("user-2");
+    expect(logSpy).toHaveBeenCalledWith("Removed team member: user-2");
+  });
+
+  it("parses the team id on invitations list", async () => {
+    const team = createTeam("team-1", "Acme");
+    mockState.user = {
+      listTeams: vi.fn(async () => [team]),
+    };
+
+    const logSpy = vi.spyOn(console, "log").mockImplementation(() => {});
+    await createProgram().parseAsync([
+      "node",
+      "hexclave",
+      "team",
+      "invitations",
+      "list",
+      "--team-id",
+      "team-1",
+    ]);
+
+    expect(team.listInvitations).toHaveBeenCalledTimes(1);
+    expect(logSpy).toHaveBeenCalledWith("No invitations found.");
+  });
+});

--- a/packages/cli/src/commands/team.test.ts
+++ b/packages/cli/src/commands/team.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from "vitest";
+import { formatTeamList, formatTeamMembers } from "./team.js";
+
+describe("formatTeamList", () => {
+  it("formats teams as tab-separated rows", () => {
+    expect(formatTeamList([
+      { id: "team-1", displayName: "Acme" },
+      { id: "team-2", displayName: "Beta" },
+    ])).toBe("team-1\tAcme\nteam-2\tBeta");
+  });
+
+  it("returns an empty-list sentinel", () => {
+    expect(formatTeamList([])).toBe("No teams found.");
+  });
+});
+
+describe("formatTeamMembers", () => {
+  it("uses a placeholder for missing member display names", () => {
+    expect(formatTeamMembers([{ id: "user-1", displayName: null }])).toBe("user-1\t(none)");
+  });
+
+  it("returns an empty-list sentinel", () => {
+    expect(formatTeamMembers([])).toBe("No team members found.");
+  });
+});

--- a/packages/cli/src/commands/team.test.ts
+++ b/packages/cli/src/commands/team.test.ts
@@ -6,20 +6,20 @@ describe("formatTeamList", () => {
     expect(formatTeamList([
       { id: "team-1", displayName: "Acme" },
       { id: "team-2", displayName: "Beta" },
-    ])).toBe("team-1\tAcme\nteam-2\tBeta");
+    ])).toMatchInlineSnapshot(`"team-1\tAcme\nteam-2\tBeta"`);
   });
 
   it("returns an empty-list sentinel", () => {
-    expect(formatTeamList([])).toBe("No teams found.");
+    expect(formatTeamList([])).toMatchInlineSnapshot(`"No teams found."`);
   });
 });
 
 describe("formatTeamMembers", () => {
   it("uses a placeholder for missing member display names", () => {
-    expect(formatTeamMembers([{ id: "user-1", displayName: null }])).toBe("user-1\t(none)");
+    expect(formatTeamMembers([{ id: "user-1", displayName: null }])).toMatchInlineSnapshot(`"user-1\t(none)"`);
   });
 
   it("returns an empty-list sentinel", () => {
-    expect(formatTeamMembers([])).toBe("No team members found.");
+    expect(formatTeamMembers([])).toMatchInlineSnapshot(`"No team members found."`);
   });
 });

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -117,23 +117,26 @@ export function registerTeamCommand(program: Command) {
 
   const members = team
     .command("members")
-    .description("List members of a team")
-    .option("--team-id <id>", "Team ID");
+    .description("Manage team members");
 
-  members.action(async (options: TeamOptions) => {
-    const user = await getUser();
-    const selectedTeam = await getTeam(user, options);
-    const teamUsers = await withTeamPermissionError("list team members", () => selectedTeam.listUsers());
-    const result = teamUsers.map((member) => ({
-      id: member.id,
-      displayName: member.teamProfile.displayName,
-    }));
-    if (isJson(program)) {
-      console.log(JSON.stringify(result, null, 2));
-    } else {
-      console.log(formatTeamMembers(result));
-    }
-  });
+  members
+    .command("list")
+    .description("List members of a team")
+    .option("--team-id <id>", "Team ID")
+    .action(async (options: TeamOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      const teamUsers = await withTeamPermissionError("list team members", () => selectedTeam.listUsers());
+      const result = teamUsers.map((member) => ({
+        id: member.id,
+        displayName: member.teamProfile.displayName,
+      }));
+      if (isJson(program)) {
+        console.log(JSON.stringify(result, null, 2));
+      } else {
+        console.log(formatTeamMembers(result));
+      }
+    });
 
   members
     .command("remove")
@@ -181,26 +184,29 @@ export function registerTeamCommand(program: Command) {
 
   const invitations = team
     .command("invitations")
-    .description("Manage team invitations")
-    .option("--team-id <id>", "Team ID");
+    .description("Manage team invitations");
 
-  invitations.action(async (options: TeamOptions) => {
-    const user = await getUser();
-    const selectedTeam = await getTeam(user, options);
-    const sentInvitations = await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations());
-    const result = sentInvitations.map((invitation) => ({
-      id: invitation.id,
-      email: invitation.recipientEmail,
-      expiresAt: invitation.expiresAt.toISOString(),
-    }));
-    if (isJson(program)) {
-      console.log(JSON.stringify(result, null, 2));
-    } else if (result.length === 0) {
-      console.log("No invitations found.");
-    } else {
-      console.log(result.map((invitation) => `${invitation.id}\t${invitation.email ?? "(unknown)"}\t${invitation.expiresAt}`).join("\n"));
-    }
-  });
+  invitations
+    .command("list")
+    .description("List invitations sent by a team")
+    .option("--team-id <id>", "Team ID")
+    .action(async (options: TeamOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      const sentInvitations = await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations());
+      const result = sentInvitations.map((invitation) => ({
+        id: invitation.id,
+        email: invitation.recipientEmail,
+        expiresAt: invitation.expiresAt.toISOString(),
+      }));
+      if (isJson(program)) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.length === 0) {
+        console.log("No invitations found.");
+      } else {
+        console.log(result.map((invitation) => `${invitation.id}\t${invitation.email ?? "(unknown)"}\t${invitation.expiresAt}`).join("\n"));
+      }
+    });
 
   invitations
     .command("revoke")

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -17,7 +17,11 @@ type ConfirmationOptions = {
 };
 
 function isJson(program: Command): boolean {
-  return Boolean((program.opts() as { json?: boolean }).json);
+  return Boolean(program.opts<{ json?: boolean }>().json);
+}
+
+function printResult(program: Command, result: unknown, humanOutput: string): void {
+  console.log(isJson(program) ? JSON.stringify(result, null, 2) : humanOutput);
 }
 
 async function withTeamPermissionError<T>(operation: string, callback: () => Promise<T>): Promise<T> {
@@ -55,11 +59,7 @@ async function confirmDestructive(action: string, options: ConfirmationOptions):
 
 function printTeams(program: Command, teams: Team[]): void {
   const result = teams.map((team) => ({ id: team.id, displayName: team.displayName }));
-  if (isJson(program)) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(formatTeamList(result));
-  }
+  printResult(program, result, formatTeamList(result));
 }
 
 export function formatTeamList(teams: Array<{ id: string, displayName: string }>): string {
@@ -74,11 +74,120 @@ export function formatTeamMembers(members: Array<{ id: string, displayName: stri
 
 function printTeam(program: Command, team: Team, prefix: string): void {
   const result = { id: team.id, displayName: team.displayName };
-  if (isJson(program)) {
-    console.log(JSON.stringify(result, null, 2));
-  } else {
-    console.log(`${prefix}: ${result.id} (${result.displayName})`);
-  }
+  printResult(program, result, `${prefix}: ${result.id} (${result.displayName})`);
+}
+
+function registerTeamMembersCommand(team: Command, program: Command): void {
+  const members = team
+    .command("members")
+    .description("Manage team members");
+
+  members
+    .command("list")
+    .description("List members of a team")
+    .option("--team-id <id>", "Team ID")
+    .action(async (options: TeamOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      const teamUsers = await withTeamPermissionError("list team members", () => selectedTeam.listUsers());
+      const result = teamUsers.map((member) => ({
+        id: member.id,
+        displayName: member.teamProfile.displayName,
+      }));
+      printResult(program, result, formatTeamMembers(result));
+    });
+
+  members
+    .command("remove")
+    .description("Remove a member from a team")
+    .option("--team-id <id>", "Team ID")
+    .requiredOption("--user-id <id>", "User ID to remove")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & { userId: string } & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`remove user ${options.userId} from team ${selectedTeam.id}`, options);
+      await withTeamPermissionError("remove this team member", () => selectedTeam.removeUser(options.userId));
+      printResult(program, { teamId: selectedTeam.id, userId: options.userId }, `Removed team member: ${options.userId}`);
+    });
+}
+
+function registerTeamInvitationsCommand(team: Command, program: Command): void {
+  const invitations = team
+    .command("invitations")
+    .description("Manage team invitations");
+
+  invitations
+    .command("list")
+    .description("List invitations sent by a team")
+    .option("--team-id <id>", "Team ID")
+    .action(async (options: TeamOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      const sentInvitations = await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations());
+      const result = sentInvitations.map((invitation) => ({
+        id: invitation.id,
+        email: invitation.recipientEmail,
+        expiresAt: invitation.expiresAt.toISOString(),
+      }));
+      const humanOutput = result.length === 0
+        ? "No invitations found."
+        : result.map((invitation) => `${invitation.id}\t${invitation.email ?? "(unknown)"}\t${invitation.expiresAt}`).join("\n");
+      printResult(program, result, humanOutput);
+    });
+
+  invitations
+    .command("revoke")
+    .description("Revoke a team invitation")
+    .option("--team-id <id>", "Team ID")
+    .requiredOption("--invitation-id <id>", "Invitation ID")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & { invitationId: string } & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`revoke invitation ${options.invitationId}`, options);
+      const invitation = (await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations()))
+        .find((candidate) => candidate.id === options.invitationId);
+      if (invitation == null) {
+        throw new CliError(`Invitation '${options.invitationId}' was not found for team '${selectedTeam.id}'.`);
+      }
+      await withTeamPermissionError("revoke this invitation", () => invitation.revoke());
+      printResult(program, { teamId: selectedTeam.id, invitationId: options.invitationId }, `Invitation revoked: ${options.invitationId}`);
+    });
+
+  invitations
+    .command("received")
+    .description("List invitations received by the current user")
+    .action(async () => {
+      const user = await getUser();
+      const receivedInvitations = await user.listTeamInvitations();
+      const result = receivedInvitations.map((invitation) => ({
+        id: invitation.id,
+        teamId: invitation.teamId,
+        teamDisplayName: invitation.teamDisplayName,
+        email: invitation.recipientEmail,
+        expiresAt: invitation.expiresAt.toISOString(),
+      }));
+      const humanOutput = result.length === 0
+        ? "No received invitations found."
+        : result.map((invitation) => `${invitation.id}\t${invitation.teamId}\t${invitation.teamDisplayName}\t${invitation.expiresAt}`).join("\n");
+      printResult(program, result, humanOutput);
+    });
+
+  invitations
+    .command("accept")
+    .description("Accept an invitation received by the current user")
+    .requiredOption("--invitation-id <id>", "Invitation ID")
+    .action(async (options: { invitationId: string }) => {
+      const user = await getUser();
+      const invitation = (await user.listTeamInvitations())
+        .find((candidate) => candidate.id === options.invitationId);
+      if (invitation == null) {
+        throw new CliError(`Received invitation '${options.invitationId}' was not found.`);
+      }
+      await invitation.accept();
+      printResult(program, { invitationId: options.invitationId, teamId: invitation.teamId }, `Invitation accepted for team: ${invitation.teamId}`);
+    });
 }
 
 export function registerTeamCommand(program: Command) {
@@ -115,46 +224,7 @@ export function registerTeamCommand(program: Command) {
       printTeam(program, newTeam, "Team created");
     });
 
-  const members = team
-    .command("members")
-    .description("Manage team members");
-
-  members
-    .command("list")
-    .description("List members of a team")
-    .option("--team-id <id>", "Team ID")
-    .action(async (options: TeamOptions) => {
-      const user = await getUser();
-      const selectedTeam = await getTeam(user, options);
-      const teamUsers = await withTeamPermissionError("list team members", () => selectedTeam.listUsers());
-      const result = teamUsers.map((member) => ({
-        id: member.id,
-        displayName: member.teamProfile.displayName,
-      }));
-      if (isJson(program)) {
-        console.log(JSON.stringify(result, null, 2));
-      } else {
-        console.log(formatTeamMembers(result));
-      }
-    });
-
-  members
-    .command("remove")
-    .description("Remove a member from a team")
-    .option("--team-id <id>", "Team ID")
-    .requiredOption("--user-id <id>", "User ID to remove")
-    .option("-y, --yes", "Skip the confirmation prompt")
-    .action(async (options: TeamOptions & { userId: string } & ConfirmationOptions) => {
-      const user = await getUser();
-      const selectedTeam = await getTeam(user, options);
-      await confirmDestructive(`remove user ${options.userId} from team ${selectedTeam.id}`, options);
-      await withTeamPermissionError("remove this team member", () => selectedTeam.removeUser(options.userId));
-      if (isJson(program)) {
-        console.log(JSON.stringify({ teamId: selectedTeam.id, userId: options.userId }, null, 2));
-      } else {
-        console.log(`Removed team member: ${options.userId}`);
-      }
-    });
+  registerTeamMembersCommand(team, program);
 
   team
     .command("invite")
@@ -175,102 +245,10 @@ export function registerTeamCommand(program: Command) {
         })).trim();
       }
       await withTeamPermissionError("invite this user", () => selectedTeam.inviteUser({ email }));
-      if (isJson(program)) {
-        console.log(JSON.stringify({ teamId: selectedTeam.id, email }, null, 2));
-      } else {
-        console.log(`Invitation sent to ${email}.`);
-      }
+      printResult(program, { teamId: selectedTeam.id, email }, `Invitation sent to ${email}.`);
     });
 
-  const invitations = team
-    .command("invitations")
-    .description("Manage team invitations");
-
-  invitations
-    .command("list")
-    .description("List invitations sent by a team")
-    .option("--team-id <id>", "Team ID")
-    .action(async (options: TeamOptions) => {
-      const user = await getUser();
-      const selectedTeam = await getTeam(user, options);
-      const sentInvitations = await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations());
-      const result = sentInvitations.map((invitation) => ({
-        id: invitation.id,
-        email: invitation.recipientEmail,
-        expiresAt: invitation.expiresAt.toISOString(),
-      }));
-      if (isJson(program)) {
-        console.log(JSON.stringify(result, null, 2));
-      } else if (result.length === 0) {
-        console.log("No invitations found.");
-      } else {
-        console.log(result.map((invitation) => `${invitation.id}\t${invitation.email ?? "(unknown)"}\t${invitation.expiresAt}`).join("\n"));
-      }
-    });
-
-  invitations
-    .command("revoke")
-    .description("Revoke a team invitation")
-    .option("--team-id <id>", "Team ID")
-    .requiredOption("--invitation-id <id>", "Invitation ID")
-    .option("-y, --yes", "Skip the confirmation prompt")
-    .action(async (options: TeamOptions & { invitationId: string } & ConfirmationOptions) => {
-      const user = await getUser();
-      const selectedTeam = await getTeam(user, options);
-      await confirmDestructive(`revoke invitation ${options.invitationId}`, options);
-      const invitation = (await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations()))
-        .find((candidate) => candidate.id === options.invitationId);
-      if (invitation == null) {
-        throw new CliError(`Invitation '${options.invitationId}' was not found for team '${selectedTeam.id}'.`);
-      }
-      await withTeamPermissionError("revoke this invitation", () => invitation.revoke());
-      if (isJson(program)) {
-        console.log(JSON.stringify({ teamId: selectedTeam.id, invitationId: options.invitationId }, null, 2));
-      } else {
-        console.log(`Invitation revoked: ${options.invitationId}`);
-      }
-    });
-
-  invitations
-    .command("received")
-    .description("List invitations received by the current user")
-    .action(async () => {
-      const user = await getUser();
-      const receivedInvitations = await user.listTeamInvitations();
-      const result = receivedInvitations.map((invitation) => ({
-        id: invitation.id,
-        teamId: invitation.teamId,
-        teamDisplayName: invitation.teamDisplayName,
-        email: invitation.recipientEmail,
-        expiresAt: invitation.expiresAt.toISOString(),
-      }));
-      if (isJson(program)) {
-        console.log(JSON.stringify(result, null, 2));
-      } else if (result.length === 0) {
-        console.log("No received invitations found.");
-      } else {
-        console.log(result.map((invitation) => `${invitation.id}\t${invitation.teamId}\t${invitation.teamDisplayName}\t${invitation.expiresAt}`).join("\n"));
-      }
-    });
-
-  invitations
-    .command("accept")
-    .description("Accept an invitation received by the current user")
-    .requiredOption("--invitation-id <id>", "Invitation ID")
-    .action(async (options: { invitationId: string }) => {
-      const user = await getUser();
-      const invitation = (await user.listTeamInvitations())
-        .find((candidate) => candidate.id === options.invitationId);
-      if (invitation == null) {
-        throw new CliError(`Received invitation '${options.invitationId}' was not found.`);
-      }
-      await invitation.accept();
-      if (isJson(program)) {
-        console.log(JSON.stringify({ invitationId: options.invitationId, teamId: invitation.teamId }, null, 2));
-      } else {
-        console.log(`Invitation accepted for team: ${invitation.teamId}`);
-      }
-    });
+  registerTeamInvitationsCommand(team, program);
 
   team
     .command("leave")
@@ -282,11 +260,7 @@ export function registerTeamCommand(program: Command) {
       const selectedTeam = await getTeam(user, options);
       await confirmDestructive(`leave team ${selectedTeam.id}`, options);
       await user.leaveTeam(selectedTeam);
-      if (isJson(program)) {
-        console.log(JSON.stringify({ teamId: selectedTeam.id }, null, 2));
-      } else {
-        console.log(`Left team: ${selectedTeam.id}`);
-      }
+      printResult(program, { teamId: selectedTeam.id }, `Left team: ${selectedTeam.id}`);
     });
 
   team
@@ -309,11 +283,7 @@ export function registerTeamCommand(program: Command) {
         })).trim();
       }
       await withTeamPermissionError("update this team", () => selectedTeam.update({ displayName }));
-      if (isJson(program)) {
-        console.log(JSON.stringify({ id: selectedTeam.id, displayName }, null, 2));
-      } else {
-        console.log(`Team updated: ${selectedTeam.id} (${displayName})`);
-      }
+      printResult(program, { id: selectedTeam.id, displayName }, `Team updated: ${selectedTeam.id} (${displayName})`);
     });
 
   team
@@ -326,10 +296,6 @@ export function registerTeamCommand(program: Command) {
       const selectedTeam = await getTeam(user, options);
       await confirmDestructive(`delete team ${selectedTeam.id}`, options);
       await withTeamPermissionError("delete this team", () => selectedTeam.delete());
-      if (isJson(program)) {
-        console.log(JSON.stringify({ teamId: selectedTeam.id }, null, 2));
-      } else {
-        console.log(`Team deleted: ${selectedTeam.id}`);
-      }
+      printResult(program, { teamId: selectedTeam.id }, `Team deleted: ${selectedTeam.id}`);
     });
 }

--- a/packages/cli/src/commands/team.ts
+++ b/packages/cli/src/commands/team.ts
@@ -1,0 +1,329 @@
+import { confirm, input } from "@inquirer/prompts";
+import { KnownErrors } from "@hexclave/shared";
+import type { CurrentInternalUser, Team } from "@hexclave/js";
+import { Command } from "commander";
+import { getInternalUser } from "../lib/app.js";
+import { resolveSessionAuth } from "../lib/auth.js";
+import { CliError } from "../lib/errors.js";
+import { isNonInteractiveEnv } from "../lib/interactive.js";
+import { resolveTeam } from "../lib/resolve-team.js";
+
+type TeamOptions = {
+  teamId?: string,
+};
+
+type ConfirmationOptions = {
+  yes?: boolean,
+};
+
+function isJson(program: Command): boolean {
+  return Boolean((program.opts() as { json?: boolean }).json);
+}
+
+async function withTeamPermissionError<T>(operation: string, callback: () => Promise<T>): Promise<T> {
+  try {
+    return await callback();
+  } catch (error) {
+    if (KnownErrors.TeamPermissionRequired.isInstance(error)) {
+      throw new CliError(`Cannot ${operation}. You do not have the required permission for this team.`);
+    }
+    throw error;
+  }
+}
+
+async function getTeam(user: CurrentInternalUser, options: TeamOptions): Promise<Team> {
+  return await resolveTeam(await user.listTeams(), options);
+}
+
+async function getUser(): Promise<CurrentInternalUser> {
+  return await getInternalUser(resolveSessionAuth());
+}
+
+async function confirmDestructive(action: string, options: ConfirmationOptions): Promise<void> {
+  if (options.yes) return;
+  if (isNonInteractiveEnv()) {
+    throw new CliError(`--yes is required to ${action} in non-interactive environments (CI).`);
+  }
+  const shouldContinue = await confirm({
+    message: `Are you sure you want to ${action}?`,
+    default: false,
+  });
+  if (!shouldContinue) {
+    throw new CliError("Aborted.");
+  }
+}
+
+function printTeams(program: Command, teams: Team[]): void {
+  const result = teams.map((team) => ({ id: team.id, displayName: team.displayName }));
+  if (isJson(program)) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(formatTeamList(result));
+  }
+}
+
+export function formatTeamList(teams: Array<{ id: string, displayName: string }>): string {
+  if (teams.length === 0) return "No teams found.";
+  return teams.map((team) => `${team.id}\t${team.displayName}`).join("\n");
+}
+
+export function formatTeamMembers(members: Array<{ id: string, displayName: string | null }>): string {
+  if (members.length === 0) return "No team members found.";
+  return members.map((member) => `${member.id}\t${member.displayName ?? "(none)"}`).join("\n");
+}
+
+function printTeam(program: Command, team: Team, prefix: string): void {
+  const result = { id: team.id, displayName: team.displayName };
+  if (isJson(program)) {
+    console.log(JSON.stringify(result, null, 2));
+  } else {
+    console.log(`${prefix}: ${result.id} (${result.displayName})`);
+  }
+}
+
+export function registerTeamCommand(program: Command) {
+  const team = program
+    .command("team")
+    .description("Manage teams");
+
+  team
+    .command("list")
+    .description("List your teams")
+    .action(async () => {
+      const user = await getUser();
+      printTeams(program, await user.listTeams());
+    });
+
+  team
+    .command("create")
+    .description("Create a team")
+    .option("--display-name <name>", "Team display name")
+    .action(async (options: { displayName?: string }) => {
+      let displayName = options.displayName?.trim();
+      if (!displayName) {
+        if (isNonInteractiveEnv()) {
+          throw new CliError("--display-name is required in non-interactive environments (CI).");
+        }
+        displayName = (await input({
+          message: "Team display name:",
+          validate: (value) => value.trim().length > 0 || "Display name cannot be empty.",
+        })).trim();
+      }
+
+      const user = await getUser();
+      const newTeam = await user.createTeam({ displayName });
+      printTeam(program, newTeam, "Team created");
+    });
+
+  const members = team
+    .command("members")
+    .description("List members of a team")
+    .option("--team-id <id>", "Team ID");
+
+  members.action(async (options: TeamOptions) => {
+    const user = await getUser();
+    const selectedTeam = await getTeam(user, options);
+    const teamUsers = await withTeamPermissionError("list team members", () => selectedTeam.listUsers());
+    const result = teamUsers.map((member) => ({
+      id: member.id,
+      displayName: member.teamProfile.displayName,
+    }));
+    if (isJson(program)) {
+      console.log(JSON.stringify(result, null, 2));
+    } else {
+      console.log(formatTeamMembers(result));
+    }
+  });
+
+  members
+    .command("remove")
+    .description("Remove a member from a team")
+    .option("--team-id <id>", "Team ID")
+    .requiredOption("--user-id <id>", "User ID to remove")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & { userId: string } & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`remove user ${options.userId} from team ${selectedTeam.id}`, options);
+      await withTeamPermissionError("remove this team member", () => selectedTeam.removeUser(options.userId));
+      if (isJson(program)) {
+        console.log(JSON.stringify({ teamId: selectedTeam.id, userId: options.userId }, null, 2));
+      } else {
+        console.log(`Removed team member: ${options.userId}`);
+      }
+    });
+
+  team
+    .command("invite")
+    .description("Invite a user to a team")
+    .option("--team-id <id>", "Team ID")
+    .option("--email <email>", "Email address to invite")
+    .action(async (options: TeamOptions & { email?: string }) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      let email = options.email?.trim();
+      if (!email) {
+        if (isNonInteractiveEnv()) {
+          throw new CliError("--email is required in non-interactive environments (CI).");
+        }
+        email = (await input({
+          message: "Email address:",
+          validate: (value) => value.trim().length > 0 || "Email address cannot be empty.",
+        })).trim();
+      }
+      await withTeamPermissionError("invite this user", () => selectedTeam.inviteUser({ email }));
+      if (isJson(program)) {
+        console.log(JSON.stringify({ teamId: selectedTeam.id, email }, null, 2));
+      } else {
+        console.log(`Invitation sent to ${email}.`);
+      }
+    });
+
+  const invitations = team
+    .command("invitations")
+    .description("Manage team invitations")
+    .option("--team-id <id>", "Team ID");
+
+  invitations.action(async (options: TeamOptions) => {
+    const user = await getUser();
+    const selectedTeam = await getTeam(user, options);
+    const sentInvitations = await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations());
+    const result = sentInvitations.map((invitation) => ({
+      id: invitation.id,
+      email: invitation.recipientEmail,
+      expiresAt: invitation.expiresAt.toISOString(),
+    }));
+    if (isJson(program)) {
+      console.log(JSON.stringify(result, null, 2));
+    } else if (result.length === 0) {
+      console.log("No invitations found.");
+    } else {
+      console.log(result.map((invitation) => `${invitation.id}\t${invitation.email ?? "(unknown)"}\t${invitation.expiresAt}`).join("\n"));
+    }
+  });
+
+  invitations
+    .command("revoke")
+    .description("Revoke a team invitation")
+    .option("--team-id <id>", "Team ID")
+    .requiredOption("--invitation-id <id>", "Invitation ID")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & { invitationId: string } & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`revoke invitation ${options.invitationId}`, options);
+      const invitation = (await withTeamPermissionError("list team invitations", () => selectedTeam.listInvitations()))
+        .find((candidate) => candidate.id === options.invitationId);
+      if (invitation == null) {
+        throw new CliError(`Invitation '${options.invitationId}' was not found for team '${selectedTeam.id}'.`);
+      }
+      await withTeamPermissionError("revoke this invitation", () => invitation.revoke());
+      if (isJson(program)) {
+        console.log(JSON.stringify({ teamId: selectedTeam.id, invitationId: options.invitationId }, null, 2));
+      } else {
+        console.log(`Invitation revoked: ${options.invitationId}`);
+      }
+    });
+
+  invitations
+    .command("received")
+    .description("List invitations received by the current user")
+    .action(async () => {
+      const user = await getUser();
+      const receivedInvitations = await user.listTeamInvitations();
+      const result = receivedInvitations.map((invitation) => ({
+        id: invitation.id,
+        teamId: invitation.teamId,
+        teamDisplayName: invitation.teamDisplayName,
+        email: invitation.recipientEmail,
+        expiresAt: invitation.expiresAt.toISOString(),
+      }));
+      if (isJson(program)) {
+        console.log(JSON.stringify(result, null, 2));
+      } else if (result.length === 0) {
+        console.log("No received invitations found.");
+      } else {
+        console.log(result.map((invitation) => `${invitation.id}\t${invitation.teamId}\t${invitation.teamDisplayName}\t${invitation.expiresAt}`).join("\n"));
+      }
+    });
+
+  invitations
+    .command("accept")
+    .description("Accept an invitation received by the current user")
+    .requiredOption("--invitation-id <id>", "Invitation ID")
+    .action(async (options: { invitationId: string }) => {
+      const user = await getUser();
+      const invitation = (await user.listTeamInvitations())
+        .find((candidate) => candidate.id === options.invitationId);
+      if (invitation == null) {
+        throw new CliError(`Received invitation '${options.invitationId}' was not found.`);
+      }
+      await invitation.accept();
+      if (isJson(program)) {
+        console.log(JSON.stringify({ invitationId: options.invitationId, teamId: invitation.teamId }, null, 2));
+      } else {
+        console.log(`Invitation accepted for team: ${invitation.teamId}`);
+      }
+    });
+
+  team
+    .command("leave")
+    .description("Leave a team")
+    .option("--team-id <id>", "Team ID")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`leave team ${selectedTeam.id}`, options);
+      await user.leaveTeam(selectedTeam);
+      if (isJson(program)) {
+        console.log(JSON.stringify({ teamId: selectedTeam.id }, null, 2));
+      } else {
+        console.log(`Left team: ${selectedTeam.id}`);
+      }
+    });
+
+  team
+    .command("update")
+    .description("Update a team")
+    .option("--team-id <id>", "Team ID")
+    .option("--display-name <name>", "New team display name")
+    .action(async (options: TeamOptions & { displayName?: string }) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      let displayName = options.displayName?.trim();
+      if (!displayName) {
+        if (isNonInteractiveEnv()) {
+          throw new CliError("--display-name is required in non-interactive environments (CI).");
+        }
+        displayName = (await input({
+          message: "New team display name:",
+          default: selectedTeam.displayName,
+          validate: (value) => value.trim().length > 0 || "Display name cannot be empty.",
+        })).trim();
+      }
+      await withTeamPermissionError("update this team", () => selectedTeam.update({ displayName }));
+      if (isJson(program)) {
+        console.log(JSON.stringify({ id: selectedTeam.id, displayName }, null, 2));
+      } else {
+        console.log(`Team updated: ${selectedTeam.id} (${displayName})`);
+      }
+    });
+
+  team
+    .command("delete")
+    .description("Delete a team")
+    .option("--team-id <id>", "Team ID")
+    .option("-y, --yes", "Skip the confirmation prompt")
+    .action(async (options: TeamOptions & ConfirmationOptions) => {
+      const user = await getUser();
+      const selectedTeam = await getTeam(user, options);
+      await confirmDestructive(`delete team ${selectedTeam.id}`, options);
+      await withTeamPermissionError("delete this team", () => selectedTeam.delete());
+      if (isJson(program)) {
+        console.log(JSON.stringify({ teamId: selectedTeam.id }, null, 2));
+      } else {
+        console.log(`Team deleted: ${selectedTeam.id}`);
+      }
+    });
+}

--- a/packages/cli/src/index.ts
+++ b/packages/cli/src/index.ts
@@ -17,6 +17,7 @@ import { registerDevCommand } from "./commands/dev.js";
 import { registerFixCommand } from "./commands/fix.js";
 import { registerDoctorCommand } from "./commands/doctor.js";
 import { registerWhoamiCommand } from "./commands/whoami.js";
+import { registerTeamCommand } from "./commands/team.js";
 
 const program = new Command();
 
@@ -35,6 +36,7 @@ registerInitCommand(program);
 registerProjectCommand(program);
 registerDevCommand(program);
 registerWhoamiCommand(program);
+registerTeamCommand(program);
 registerFixCommand(program);
 registerDoctorCommand(program);
 

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -1,14 +1,14 @@
 import { input } from "@inquirer/prompts";
 import type { CurrentInternalUser } from "@hexclave/js";
-import { DEFAULT_DASHBOARD_URL } from "./auth.js";
 import { CliError } from "./errors.js";
 import { isNonInteractiveEnv } from "./interactive.js";
 import { withProgress } from "./progress.js";
+import { resolveTeam } from "./resolve-team.js";
 
 type CreateProjectOptions = {
   displayName?: string,
+  teamId?: string,
   defaultDisplayName?: string,
-  dashboardUrl?: string,
 };
 
 export async function createProjectInteractively(
@@ -27,16 +27,15 @@ export async function createProjectInteractively(
     })).trim();
   }
 
-  return await withProgress("Creating project", async () => {
-    const teams = await user.listTeams();
-    if (teams.length === 0) {
-      const dashboardUrl = opts.dashboardUrl ?? DEFAULT_DASHBOARD_URL;
-      throw new CliError(`No teams found on your account. Create a team at ${dashboardUrl} first.`);
-    }
-
-    return await user.createProject({
-      displayName,
-      teamId: teams[0].id,
-    });
+  const teams = await user.listTeams();
+  const team = await resolveTeam(teams, {
+    teamId: opts.teamId,
+    createIfNone: true,
+    createTeam: async (teamDisplayName) => await user.createTeam({ displayName: teamDisplayName }),
   });
+
+  return await withProgress("Creating project", async () => await user.createProject({
+    displayName,
+    teamId: team.id,
+  }));
 }

--- a/packages/cli/src/lib/create-project.ts
+++ b/packages/cli/src/lib/create-project.ts
@@ -30,7 +30,6 @@ export async function createProjectInteractively(
   const teams = await user.listTeams();
   const team = await resolveTeam(teams, {
     teamId: opts.teamId,
-    createIfNone: true,
     createTeam: async (teamDisplayName) => await user.createTeam({ displayName: teamDisplayName }),
   });
 

--- a/packages/cli/src/lib/resolve-team.test.ts
+++ b/packages/cli/src/lib/resolve-team.test.ts
@@ -1,0 +1,62 @@
+import { afterEach, describe, expect, it } from "vitest";
+import type { Team } from "@hexclave/js";
+import { CliError } from "./errors.js";
+import { resolveTeam } from "./resolve-team.js";
+
+function makeTeam(id: string, displayName: string): Team {
+  return {
+    id,
+    displayName,
+  } as Team;
+}
+
+const savedCi = process.env.CI;
+const savedGithubActions = process.env.GITHUB_ACTIONS;
+const savedNoninteractive = process.env.NONINTERACTIVE;
+
+afterEach(() => {
+  if (savedCi === undefined) delete process.env.CI;
+  else process.env.CI = savedCi;
+  if (savedGithubActions === undefined) delete process.env.GITHUB_ACTIONS;
+  else process.env.GITHUB_ACTIONS = savedGithubActions;
+  if (savedNoninteractive === undefined) delete process.env.NONINTERACTIVE;
+  else process.env.NONINTERACTIVE = savedNoninteractive;
+});
+
+describe("resolveTeam", () => {
+  it("returns the explicitly requested team id", async () => {
+    const teams = [makeTeam("team-1", "Acme"), makeTeam("team-2", "Beta")];
+
+    await expect(resolveTeam(teams, { teamId: "team-2" })).resolves.toBe(teams[1]);
+  });
+
+  it("throws when an explicit team id does not exist", async () => {
+    const teams = [makeTeam("team-1", "Acme")];
+
+    await expect(resolveTeam(teams, { teamId: "missing-team" })).rejects.toSatisfy((error: unknown) => (
+      error instanceof CliError && error.message === "Team 'missing-team' was not found on your account."
+    ));
+  });
+
+  it("auto-picks the only team without prompting", async () => {
+    const team = makeTeam("team-1", "Acme");
+
+    await expect(resolveTeam([team])).resolves.toBe(team);
+  });
+
+  it("rejects multi-team resolution in non-interactive environments", async () => {
+    process.env.CI = "1";
+
+    await expect(resolveTeam([makeTeam("team-1", "Acme"), makeTeam("team-2", "Beta")])).rejects.toSatisfy((error: unknown) => (
+      error instanceof CliError && error.message === "--team-id is required in non-interactive environments (CI)."
+    ));
+  });
+
+  it("rejects zero-team resolution in non-interactive environments", async () => {
+    process.env.CI = "1";
+
+    await expect(resolveTeam([], { createTeam: async () => makeTeam("team-1", "Acme") })).rejects.toSatisfy((error: unknown) => (
+      error instanceof CliError && error.message === "No teams found. Run `hexclave team create` first, or pass --team-id."
+    ));
+  });
+});

--- a/packages/cli/src/lib/resolve-team.test.ts
+++ b/packages/cli/src/lib/resolve-team.test.ts
@@ -1,13 +1,9 @@
 import { afterEach, describe, expect, it } from "vitest";
-import type { Team } from "@hexclave/js";
 import { CliError } from "./errors.js";
 import { resolveTeam } from "./resolve-team.js";
 
-function makeTeam(id: string, displayName: string): Team {
-  return {
-    id,
-    displayName,
-  } as Team;
+function makeTeam(id: string, displayName: string) {
+  return { id, displayName };
 }
 
 const savedCi = process.env.CI;

--- a/packages/cli/src/lib/resolve-team.ts
+++ b/packages/cli/src/lib/resolve-team.ts
@@ -1,14 +1,21 @@
 import { input, select } from "@inquirer/prompts";
-import type { Team } from "@hexclave/js";
 import { CliError } from "./errors.js";
 import { isNonInteractiveEnv } from "./interactive.js";
 
-export type ResolveTeamOptions = {
-  teamId?: string,
-  createTeam?: (displayName: string) => Promise<Team>,
+export type ResolveTeamItem = {
+  id: string,
+  displayName: string,
 };
 
-export async function resolveTeam(teams: Team[], options: ResolveTeamOptions = {}): Promise<Team> {
+export type ResolveTeamOptions<T extends ResolveTeamItem> = {
+  teamId?: string,
+  createTeam?: (displayName: string) => Promise<T>,
+};
+
+export async function resolveTeam<T extends ResolveTeamItem>(
+  teams: T[],
+  options: ResolveTeamOptions<T> = {},
+): Promise<T> {
   const teamId = options.teamId?.trim();
   if (teamId) {
     const team = teams.find((candidate) => candidate.id === teamId);

--- a/packages/cli/src/lib/resolve-team.ts
+++ b/packages/cli/src/lib/resolve-team.ts
@@ -1,0 +1,55 @@
+import { input, select } from "@inquirer/prompts";
+import type { Team } from "@hexclave/js";
+import { CliError } from "./errors.js";
+import { isNonInteractiveEnv } from "./interactive.js";
+
+export type ResolveTeamOptions = {
+  teamId?: string,
+  createTeam?: (displayName: string) => Promise<Team>,
+};
+
+export async function resolveTeam(teams: Team[], options: ResolveTeamOptions = {}): Promise<Team> {
+  const teamId = options.teamId?.trim();
+  if (teamId) {
+    const team = teams.find((candidate) => candidate.id === teamId);
+    if (team == null) {
+      throw new CliError(`Team '${teamId}' was not found on your account.`);
+    }
+    return team;
+  }
+
+  if (teams.length === 0) {
+    if (options.createTeam != null) {
+      if (isNonInteractiveEnv()) {
+        throw new CliError("No teams found. Run `hexclave team create` first, or pass --team-id.");
+      }
+      const displayName = (await input({
+        message: "Team display name:",
+        validate: (value) => value.trim().length > 0 || "Display name cannot be empty.",
+      })).trim();
+      return await options.createTeam(displayName);
+    }
+    throw new CliError("No teams found. Run `hexclave team create` first.");
+  }
+
+  if (teams.length === 1) {
+    return teams[0];
+  }
+
+  if (isNonInteractiveEnv()) {
+    throw new CliError("--team-id is required in non-interactive environments (CI).");
+  }
+
+  const selectedTeamId = await select({
+    message: "Choose a team:",
+    choices: teams.map((team) => ({
+      name: `${team.displayName || "(unnamed)"} (${team.id})`,
+      value: team.id,
+    })),
+  });
+  const selectedTeam = teams.find((team) => team.id === selectedTeamId);
+  if (selectedTeam == null) {
+    throw new CliError("The selected team was not found.");
+  }
+  return selectedTeam;
+}

--- a/packages/shared/src/interface/client-interface.ts
+++ b/packages/shared/src/interface/client-interface.ts
@@ -1726,6 +1726,24 @@ export class HexclaveClientInterface {
     );
   }
 
+  async removeUserFromTeam(
+    teamId: string,
+    userId: string,
+    session: InternalSession,
+  ) {
+    await this.sendClientRequest(
+      urlString`/team-memberships/${teamId}/${userId}`,
+      {
+        method: "DELETE",
+        headers: {
+          "content-type": "application/json",
+        },
+        body: JSON.stringify({}),
+      },
+      session,
+    );
+  }
+
   async updateTeamMemberProfile(
     options: {
       teamId: string,

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1826,6 +1826,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         const result = Result.orThrow(await app._teamMemberProfilesCache.getOrWait([session, crud.id], "write-only"));
         return result.map((crud) => app._clientTeamUserFromCrud(crud));
       },
+      async removeUser(userId: string) {
+        await app._interface.removeUserFromTeam(crud.id, userId, session);
+        await app._teamMemberProfilesCache.refresh([session, crud.id]);
+      },
       // IF_PLATFORM react-like
       useUsers() {
         const result = useAsyncCache(app._teamMemberProfilesCache, [session, crud.id] as const, "team.useUsers()");
@@ -2317,7 +2321,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       },
       async leaveTeam(team: Team) {
         await app._interface.leaveTeam(team.id, session);
-        // TODO: refresh cache
+        await app._currentUserTeamsCache.refresh([session]);
       },
       async listTeamInvitations() {
         const invitations = Result.orThrow(await app._currentUserTeamInvitationsCache.getOrWait([session], "write-only"));

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1829,6 +1829,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       async removeUser(userId: string) {
         await app._interface.removeUserFromTeam(crud.id, userId, session);
         await app._teamMemberProfilesCache.refresh([session, crud.id]);
+        await app._currentUserTeamsCache.refresh([session]);
+        await app._currentUserCache.refresh([session]);
       },
       // IF_PLATFORM react-like
       useUsers() {
@@ -2322,6 +2324,7 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       async leaveTeam(team: Team) {
         await app._interface.leaveTeam(team.id, session);
         await app._currentUserTeamsCache.refresh([session]);
+        await app._currentUserCache.refresh([session]);
       },
       async listTeamInvitations() {
         const invitations = Result.orThrow(await app._currentUserTeamInvitationsCache.getOrWait([session], "write-only"));

--- a/packages/template/src/lib/hexclave-app/teams/index.ts
+++ b/packages/template/src/lib/hexclave-app/teams/index.ts
@@ -74,6 +74,7 @@ export type Team = {
   clientReadOnlyMetadata: any,
   inviteUser(options: { email: string, callbackUrl?: string }): Promise<void>,
   listUsers(): Promise<TeamUser[]>,
+  removeUser(userId: string): Promise<void>,
   useUsers(): TeamUser[], // THIS_LINE_PLATFORM react-like
   listInvitations(): Promise<SentTeamInvitation[]>,
   useInvitations(): SentTeamInvitation[], // THIS_LINE_PLATFORM react-like

--- a/sdks/spec/src/types/teams/team.spec.md
+++ b/sdks/spec/src/types/teams/team.spec.md
@@ -76,6 +76,18 @@ See types/teams/team-member-profile.spec.md for TeamMemberProfile.
 Does not error.
 
 
+### removeUser(userId)
+
+userId: string
+
+DELETE /api/v1/team-memberships/{teamId}/{userId} [authenticated]
+
+Removes the specified user from the team. Requires the `$remove_members` team permission
+when removing another user; users may always remove themselves.
+
+Does not error.
+
+
 ### listInvitations()
 
 Returns: TeamInvitation[]


### PR DESCRIPTION
## Summary

The CLI had no way to create a team, yet a project must be owned by one — so `project create` dead-ended with "No teams found on your account. Create a team at <dashboard> first." and otherwise silently used `teams[0]`.

Adds a `hexclave team` command group and makes project creation resolve a team properly:

```
hexclave team list | create [--display-name]
hexclave team members [--team-id] | members remove --user-id [--yes]
hexclave team invite [--email] | invitations [revoke --invitation-id | received | accept --invitation-id]
hexclave team leave | update [--display-name] | delete   [--team-id] [--yes]
hexclave project create --cloud [--team-id]
```

Team resolution is shared by both surfaces (`lib/resolve-team.ts`): explicit `--team-id`, auto-pick when there's exactly one, `select` prompt when several, and — for `project create` only — prompt-and-create when there are none. Noninteractive (CI/non-TTY) always requires the flag, and destructive subcommands need confirmation or `--yes`.

Client SDK gained the missing member-removal call, so `team members remove` works for other members rather than only self:

```ts
// packages/template ... teams/index.ts
type Team = { ...,  removeUser(userId: string): Promise<void> }
// -> DELETE /team-memberships/{teamId}/{userId}, gated on `$remove_members`
```

`leaveTeam` also now refreshes the current-user teams cache (was a `// TODO: refresh cache`).

Caveat: `team invite` will fail with a permission error for internal-project teams, since the internal project's `team_admin` role doesn't include `$invite_members` (the dashboard invites via the server SDK, bypassing client permissions). Not changed here.


Link to Devin session: https://app.devin.ai/sessions/79e20c4450214fa3a2fe322aba269d5b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds `hexclave team` CLI commands and updates `hexclave project create` to pick, prompt, or create a team, removing the dashboard dependency and fixing the “no teams found” dead-end. Non-interactive runs now require `--team-id`. Addresses Linear 1784938812.

- **New Features**
  - Restructured `hexclave team` into clear groups: list/create/invite/leave/update/delete; members (list/remove); invitations (list/revoke/received/accept).
  - `hexclave project create --cloud` supports `--team-id`; auto-picks when one team exists, prompts when multiple, and creates a team when none.
  - Destructive actions (`members remove`, `invitations revoke`, `leave`, `delete`) prompt for confirmation or accept `--yes`.
  - Client SDK: added `Team.removeUser(userId)`; leaving or removing members now refreshes team and current-user caches; documented in `sdks/spec`.

<sup>Written for commit bccd78addb5ab149ed0bd5d594f55c646ae0611b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1811?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a full `team` command suite to the CLI (list/create/update/delete, members, invitations, and `leave`).
  * Added `--team-id` support to select an existing team during project creation.
  * Added team member removal in supported clients, including self-removal.
* **Bug Fixes**
  * Improved team resolution in non-interactive/CI environments with clearer, actionable errors.
  * Refreshes team/user state after leaving or removing team membership (including clearing the current selection where applicable).
* **Documentation**
  * Updated team API documentation to include `removeUser(userId)` with permission behavior and endpoint details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->