### PR TITLE
Require an unrestricted user to complete CLI authorization

### DIFF
--- a/apps/backend/src/app/api/latest/auth/cli/complete/route.tsx
+++ b/apps/backend/src/app/api/latest/auth/cli/complete/route.tsx
@@ -7,7 +7,7 @@ import { getPrismaClientForTenancy, getPrismaSchemaForTenancy, globalPrismaClien
 import { createSmartRouteHandler } from "@/route-handlers/smart-route-handler";
 import { KnownErrors } from "@hexclave/shared";
 import { adaptSchema, clientOrHigherAuthTypeSchema, yupBoolean, yupNumber, yupObject, yupString, yupUnion } from "@hexclave/shared/dist/schema-fields";
-import { StatusError } from "@hexclave/shared/dist/utils/errors";
+import { HexclaveAssertionError, StatusError } from "@hexclave/shared/dist/utils/errors";
 import type { InferType } from "yup";
 
 type CliSessionState = "anonymous" | "none";
@@ -261,6 +261,27 @@ export const POST = createSmartRouteHandler<PostCliAuthCompleteRequest, PostCliA
     const browserRefreshTokenSession = await getRefreshTokenSession(tenancy.id, refresh_token);
     if (!browserRefreshTokenSession) {
       throw new StatusError(400, "Invalid refresh token");
+    }
+
+    let browserUser;
+    try {
+      browserUser = await usersCrudHandlers.adminRead({
+        tenancy,
+        user_id: browserRefreshTokenSession.projectUserId,
+        allowedErrorTypes: [KnownErrors.UserNotFound],
+      });
+    } catch (error) {
+      if (KnownErrors.UserNotFound.isInstance(error)) {
+        throw new HexclaveAssertionError("Refresh token session references a missing user", { cause: error });
+      }
+      throw error;
+    }
+
+    if (browserUser.is_restricted) {
+      if (browserUser.restricted_reason === null) {
+        throw new HexclaveAssertionError("Restricted user is missing a restricted reason");
+      }
+      throw new KnownErrors.RestrictedUserNotAllowed(browserUser.restricted_reason);
     }
 
     // Atomically claim the pending CLI auth attempt. Any anonymous session

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/cli/complete.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/cli/complete.test.ts
@@ -1,5 +1,5 @@
 import { it } from "../../../../../../helpers";
-import { Auth, Team, niceBackendFetch } from "../../../../../backend-helpers";
+import { Auth, ContactChannels, Project, Team, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should set the refresh token for a CLI auth attempt and return success when polling", async ({ expect }) => {
   const createResponse = await niceBackendFetch("/api/latest/auth/cli", {
@@ -74,6 +74,89 @@ it("should set the refresh token for a CLI auth attempt and return success when 
       "headers": Headers { <some fields may have been hidden> },
     }
   `);
+});
+
+it("should reject a restricted user's refresh token", async ({ expect }) => {
+  await Project.createAndSwitch({
+    config: {
+      credential_enabled: true,
+    },
+  });
+  await Project.updateConfig({
+    "onboarding.requireEmailVerification": true,
+  });
+
+  const restrictedUser = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
+  const restrictedUserAuth = backendContext.value.userAuth;
+  const createResponse = await niceBackendFetch("/api/latest/auth/cli", {
+    method: "POST",
+    accessType: "server",
+    body: {},
+  });
+
+  backendContext.set({ userAuth: null });
+  const completeResponse = await niceBackendFetch("/api/latest/auth/cli/complete", {
+    method: "POST",
+    accessType: "server",
+    body: {
+      login_code: createResponse.body.login_code,
+      mode: "complete",
+      refresh_token: restrictedUser.signUpResponse.body.refresh_token,
+    },
+  });
+
+  expect(completeResponse).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 403,
+      "body": {
+        "code": "RESTRICTED_USER_NOT_ALLOWED",
+        "details": { "restricted_reason": { "type": "email_not_verified" } },
+        "error": "The user in the access token is in restricted state. Reason: email_not_verified. Please pass the X-Stack-Allow-Restricted-User header if this is intended.",
+      },
+      "headers": Headers {
+        "x-stack-known-error": "RESTRICTED_USER_NOT_ALLOWED",
+        <some fields may have been hidden>,
+      },
+    }
+  `);
+
+  backendContext.set({ userAuth: restrictedUserAuth });
+  await ContactChannels.verify();
+
+  backendContext.set({ userAuth: null });
+  const completedResponse = await niceBackendFetch("/api/latest/auth/cli/complete", {
+    method: "POST",
+    accessType: "server",
+    body: {
+      login_code: createResponse.body.login_code,
+      mode: "complete",
+      refresh_token: restrictedUser.signUpResponse.body.refresh_token,
+    },
+  });
+  expect(completedResponse).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 200,
+      "body": { "success": true },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+
+  const pollResponse = await niceBackendFetch("/api/latest/auth/cli/poll", {
+    method: "POST",
+    accessType: "server",
+    body: { polling_code: createResponse.body.polling_code },
+  });
+  expect(pollResponse).toMatchInlineSnapshot(`
+    NiceResponse {
+      "status": 201,
+      "body": {
+        "refresh_token": <stripped field 'refresh_token'>,
+        "status": "success",
+      },
+      "headers": Headers { <some fields may have been hidden> },
+    }
+  `);
+  expect(pollResponse.body.refresh_token).toBe(restrictedUser.signUpResponse.body.refresh_token);
 });
 
 it("should return anonymous CLI session details when the CLI started from an anonymous user", async ({ expect }) => {

--- a/packages/template/src/components-page/cli-auth-confirm.test.tsx
+++ b/packages/template/src/components-page/cli-auth-confirm.test.tsx
@@ -24,11 +24,13 @@ function createAppTestDouble(options: {
   signInWithTokens?: (tokens: { accessToken: string, refreshToken: string }) => Promise<void>,
   redirectToSignIn?: (options: { replace: true }) => Promise<void>,
   redirectToSignUp?: (options: { replace: true }) => Promise<void>,
+  redirectToOnboarding?: (options: { replace: true }) => Promise<void>,
 }) {
   const app = {
     useUser: () => options.user,
     redirectToSignIn: options.redirectToSignIn ?? vi.fn(async () => {}),
     redirectToSignUp: options.redirectToSignUp ?? vi.fn(async () => {}),
+    redirectToOnboarding: options.redirectToOnboarding ?? vi.fn(async () => {}),
     [hexclaveAppInternalsSymbol]: {
       sendRequest: options.sendRequest,
       signInWithTokens: options.signInWithTokens ?? vi.fn(async () => {}),
@@ -98,6 +100,7 @@ describe("useCliAuthConfirmation", () => {
     root = null;
     container = null;
     vi.restoreAllMocks();
+    sessionStorage.clear();
     window.history.replaceState({}, "", "/");
     Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousActEnvironment);
   });
@@ -126,6 +129,58 @@ describe("useCliAuthConfirmation", () => {
         "refresh_token": "refresh-token",
       }
     `);
+  });
+
+  it("redirects restricted users to onboarding without completing CLI auth", async () => {
+    window.history.replaceState({}, "", "/handler/cli-auth-confirm?login_code=login-code");
+    const redirectToOnboarding = vi.fn(async (_options: { replace: true }) => {});
+    const sendRequest = vi.fn(async (_path: string, _requestOptions: RequestInit) => new Response(null, { status: 200 }));
+    const app = createAppTestDouble({
+      user: {
+        isRestricted: true,
+        isAnonymous: false,
+        currentSession: {
+          getTokens: vi.fn(async () => ({ refreshToken: "restricted-refresh-token" })),
+        },
+      },
+      sendRequest,
+      redirectToOnboarding,
+    });
+
+    await renderWithApp(app);
+    await act(async () => {
+      getButton("authorize").click();
+    });
+
+    expect(redirectToOnboarding).toHaveBeenCalledWith({ replace: true });
+    expect(sessionStorage.getItem("hexclave-cli-auth-confirmed")).toBe("login-code");
+    expect(sendRequest).not.toHaveBeenCalled();
+  });
+
+  it("redirects anonymous users to sign-up without completing CLI auth", async () => {
+    window.history.replaceState({}, "", "/handler/cli-auth-confirm?login_code=login-code");
+    const redirectToSignUp = vi.fn(async (_options: { replace: true }) => {});
+    const sendRequest = vi.fn(async (_path: string, _requestOptions: RequestInit) => new Response(null, { status: 200 }));
+    const app = createAppTestDouble({
+      user: {
+        isRestricted: true,
+        isAnonymous: true,
+        currentSession: {
+          getTokens: vi.fn(async () => ({ refreshToken: "anonymous-refresh-token" })),
+        },
+      },
+      sendRequest,
+      redirectToSignUp,
+    });
+
+    await renderWithApp(app);
+    await act(async () => {
+      getButton("authorize").click();
+    });
+
+    expect(redirectToSignUp).toHaveBeenCalledWith({ replace: true });
+    expect(sessionStorage.getItem("hexclave-cli-auth-confirmed")).toBe("login-code");
+    expect(sendRequest).not.toHaveBeenCalled();
   });
 
   it("ignores duplicate authorize clicks before React re-renders", async () => {

--- a/packages/template/src/components-page/cli-auth-confirm.tsx
+++ b/packages/template/src/components-page/cli-auth-confirm.tsx
@@ -106,7 +106,7 @@ export function useCliAuthConfirmation(): CliAuthConfirmationState {
   }, [app, loginCode, user]);
 
   useEffect(() => {
-    if (!confirmed || !user || autoCompleteRef.current) {
+    if (!confirmed || !user || user.isRestricted || autoCompleteRef.current) {
       return;
     }
     autoCompleteRef.current = true;
@@ -139,6 +139,16 @@ export function useCliAuthConfirmation(): CliAuthConfirmationState {
       setError(null);
       setStatus("authorizing");
       if (user) {
+        if (user.isRestricted) {
+          markConfirmed(loginCode);
+          setStatus("redirecting");
+          await (
+            user.isAnonymous
+              ? app.redirectToSignUp({ replace: true })
+              : app.redirectToOnboarding({ replace: true })
+          );
+          return;
+        }
         await completeWithCurrentUser();
         clearConfirmed();
         setStatus("success");


### PR DESCRIPTION
CLI authorization handed the CLI a refresh token for a restricted user. Repro: with `onboarding.requireEmailVerification` on, sign up a new email/password account inside the CLI auth flow — the flow reports success and the CLI receives a token for an unverified (restricted) account.

Two changes:

- `useCliAuthConfirmation` loads the user with `includeRestricted: true`, so a restricted user reached `completeWithCurrentUser()`. Restricted users are now marked and redirected instead of completing: anonymous users to sign-up (as the existing anonymous CLI path does), other restricted users to onboarding. `onboarding` is redirect-back-aware, so `after_auth_return_to` carries the `cli-auth-confirm?login_code=...` URL and the stored login-code marker resumes completion once the user is unrestricted. The auto-complete effect also refuses to fire while the user is restricted.
- `/auth/cli/complete` (`mode: "complete"`) previously only checked that the submitted refresh token existed, belonged to the tenancy, and wasn't expired — never who it belonged to. It now resolves the token's user and rejects restricted ones with `RestrictedUserNotAllowed`, so a custom client can't bypass the browser-side check. `check` and `claim-anon-session` are unchanged.

Tests: e2e coverage that a restricted (email-unverified) user's refresh token is rejected and that completion + polling succeed once the email is verified; component tests that restricted and anonymous users are redirected without any completion request. Verified the e2e test fails against the endpoint without the new check.


Link to Devin session: https://app.devin.ai/sessions/8a989859e8b7458b88aab33bc5d37bb2
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Require an unrestricted user to complete CLI authorization. Fixes a bug that let the CLI receive a refresh token for a restricted (e.g., email-unverified) account.

- **Bug Fixes**
  - Backend: `/auth/cli/complete` now resolves the token’s user and rejects restricted users with `RESTRICTED_USER_NOT_ALLOWED`; assertion added for missing user/reason. `check` and `claim-anon-session` unchanged.
  - Frontend: `useCliAuthConfirmation` redirects restricted users instead of completing (anonymous → sign-up, others → onboarding). Auto-complete is disabled while restricted, and the login code is stored to resume after verification.
  - Tests: Added e2e to verify rejection until email is verified and success afterward; component tests for redirects and no completion request while restricted.

<sup>Written for commit 117047475e340ccc3e1eabe89295d0f457216401. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1812?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Restricted users are now prevented from completing CLI authentication directly.
  * Restricted authenticated users are redirected to onboarding, while anonymous users are redirected to sign-up.
  * CLI authentication resumes successfully after required user verification is completed.

* **Bug Fixes**
  * Improved handling of missing or restricted accounts during CLI authentication.
  * Prevented restricted users from triggering standard authentication completion flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->