### PR TITLE
feat(dashboard): add robots.txt route

### DIFF
--- a/apps/dashboard/src/app/robots.ts
+++ b/apps/dashboard/src/app/robots.ts
@@ -19,6 +19,7 @@ export default function robots(): MetadataRoute.Robots {
           '/playground',
           '/purchase/',
           '/integrations/',
+          '/health',
           '/rde-debug',
           '/development-environment',
         ],

--- a/apps/dashboard/src/app/robots.ts
+++ b/apps/dashboard/src/app/robots.ts
@@ -1,0 +1,28 @@
+import type { MetadataRoute } from 'next';
+
+/**
+ * Permissive robots policy: all crawlers, including AI/LLM crawlers, may fetch the
+ * dashboard's public surface (landing redirect, llms.txt). Authenticated app routes
+ * and API endpoints are excluded since they never render useful content for crawlers.
+ */
+export default function robots(): MetadataRoute.Robots {
+  return {
+    rules: [
+      {
+        userAgent: '*',
+        allow: '/',
+        disallow: [
+          '/api/',
+          '/handler/',
+          '/projects/',
+          '/new-project',
+          '/playground',
+          '/purchase/',
+          '/integrations/',
+          '/rde-debug',
+          '/development-environment',
+        ],
+      },
+    ],
+  };
+}


### PR DESCRIPTION
## Summary

The dashboard served no `robots.txt`. Adds `apps/dashboard/src/app/robots.ts`: `User-Agent: *`, `Allow: /`, with no per-bot blocks so AI/LLM crawlers can reach `/llms.txt` and `/llms-full.txt`. Authenticated app routes and API endpoints (`/api/`, `/handler/`, `/projects/`, `/new-project`, `/playground`, `/purchase/`, `/integrations/`, `/rde-debug`, `/development-environment`) are disallowed since they never render crawlable content.

Docs already opt into full indexing via `docs-mintlify/docs.json` (`"seo": { "indexing": "all" }`), so no change needed there.


Link to Devin session: https://app.devin.ai/sessions/305045cb2a1e480fbaf589a581525068
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Add `robots.txt` to the dashboard using `next` `MetadataRoute`. Allows crawling of public pages (including `/llms.txt` and `/llms-full.txt`) and blocks authenticated app, API, and operational routes from indexing.

Disallowed: `/api/`, `/handler/`, `/projects/`, `/new-project`, `/playground`, `/purchase/`, `/integrations/`, `/rde-debug`, `/development-environment`, `/health`.

<sup>Written for commit 21a86cb07bf2d20a49e549ed5458d739b0bfa75e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1813?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added crawler access rules for the dashboard via an updated robots configuration. Search engines can index only the site root (`/`), while crawler traffic is blocked for non-public areas such as dashboard subpages, API/handler routes, project creation/listing, playground, purchase flows, integrations, and health/debug/development-related endpoints.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->