### PR TITLE
Show a helpful message when no auth methods are enabled

### DIFF
--- a/apps/dashboard/src/components/hosted-auth-preview.test.tsx
+++ b/apps/dashboard/src/components/hosted-auth-preview.test.tsx
@@ -45,4 +45,57 @@ describe("HostedAuthMethodPreview", () => {
     screen.getByLabelText("Password");
     expect(screen.getByRole("tab", { name: "Email & Password" }).getAttribute("data-state")).toBe("active");
   });
+
+  it("explains how to fix the project instead of rendering a form when no auth method is enabled", () => {
+    render(<HostedAuthMethodPreview project={{
+      displayName: "Preview App",
+      config: {
+        signUpEnabled: true,
+        credentialEnabled: false,
+        passkeyEnabled: false,
+        magicLinkEnabled: false,
+        oauthProviders: [],
+      },
+    }} />);
+
+    expect(screen.queryByLabelText("Password")).toBeNull();
+    expect(screen.queryByLabelText("Email")).toBeNull();
+    screen.getByText("Sign-in is not available");
+    screen.getByText("hexclave.config.ts");
+  });
+
+  it("keeps rendering the sign-in form when only some auth methods are disabled", () => {
+    render(<HostedAuthMethodPreview project={{
+      displayName: "Preview App",
+      config: {
+        signUpEnabled: true,
+        credentialEnabled: true,
+        passkeyEnabled: false,
+        magicLinkEnabled: false,
+        oauthProviders: [],
+      },
+    }} />);
+
+    screen.getByLabelText("Password");
+    expect(screen.queryByText("Sign-in is not available")).toBeNull();
+  });
+
+  it("tells passkey-only projects to sign in instead of signing up, without claiming a misconfiguration", () => {
+    render(<HostedAuthMethodPreview
+      type="sign-up"
+      project={{
+        displayName: "Preview App",
+        config: {
+          signUpEnabled: true,
+          credentialEnabled: false,
+          passkeyEnabled: true,
+          magicLinkEnabled: false,
+          oauthProviders: [],
+        },
+      }}
+    />);
+
+    expect(screen.queryByText("Sign-in is not available")).toBeNull();
+    screen.getByText("New accounts can't be created with the sign-in methods enabled for this app. Sign in instead.");
+  });
 });

--- a/apps/dashboard/src/components/hosted-auth-preview.tsx
+++ b/apps/dashboard/src/components/hosted-auth-preview.tsx
@@ -412,6 +412,39 @@ function HostedCredentialPreviewForm(props: {
   );
 }
 
+/**
+ * Mirrors the `HostedNoAuthMethods` component of the hosted components app, so that the dashboard preview
+ * shows developers exactly what their end users would see when no auth method is enabled.
+ */
+function NoAuthMethodsPreview(props: {
+  projectDisplayName?: string,
+}) {
+  return (
+    <>
+      <div className="flex flex-col items-center text-center">
+        <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl border border-black/[0.08] bg-zinc-100/70 dark:border-white/[0.10] dark:bg-zinc-900/45">
+          <KeyIcon className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <Typography type="h2" className="mb-1 text-xl font-semibold tracking-tight">Sign-in is not available</Typography>
+        <Typography className="text-sm text-muted-foreground">
+          {props.projectDisplayName == null
+            ? "This app has no authentication methods enabled, so nobody can sign in yet."
+            : <>
+              <span className="font-medium text-foreground">{props.projectDisplayName}</span> has no authentication methods enabled, so nobody can sign in yet.
+            </>}
+        </Typography>
+      </div>
+
+      <div className="mt-6 rounded-xl border border-black/[0.08] bg-zinc-100/50 p-4 text-left dark:border-white/[0.10] dark:bg-zinc-900/45">
+        <p className="text-sm font-semibold">Are you the developer?</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enable at least one sign-in method in your <code className="rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.10]">hexclave.config.ts</code>, or right here in the dashboard.
+        </p>
+      </div>
+    </>
+  );
+}
+
 export function HostedAuthMethodPreview(props: {
   project: HostedAuthPreviewProject,
   type?: HostedAuthType,
@@ -432,6 +465,15 @@ export function HostedAuthMethodPreview(props: {
   const hasPasskey = props.project.config.passkeyEnabled === true && type === "sign-in";
   const hasEmailMethods = props.project.config.credentialEnabled || props.project.config.magicLinkEnabled;
   const enableSeparator = hasEmailMethods && (hasOAuthProviders || hasPasskey);
+  const hasAnyAuthMethod = hasOAuthProviders || props.project.config.passkeyEnabled === true || hasEmailMethods;
+
+  if (!hasAnyAuthMethod) {
+    return (
+      <PreviewFrame className={props.className}>
+        <NoAuthMethodsPreview projectDisplayName={props.project.displayName} />
+      </PreviewFrame>
+    );
+  }
 
   return (
     <PreviewFrame className={props.className}>
@@ -476,7 +518,9 @@ export function HostedAuthMethodPreview(props: {
       ) : props.project.config.magicLinkEnabled ? (
         <HostedMagicLinkPreviewForm />
       ) : !(hasOAuthProviders || hasPasskey) ? (
-        <p className="py-4 text-center text-sm text-destructive">No authentication method enabled.</p>
+        <p className="py-2 text-center text-sm text-muted-foreground">
+          New accounts can&apos;t be created with the sign-in methods enabled for this app. Sign in instead.
+        </p>
       ) : null}
 
       {(type === "sign-up" || props.project.config.signUpEnabled) && (

--- a/apps/hosted-components/src/hosted-components/auth/auth-page.tsx
+++ b/apps/hosted-components/src/hosted-components/auth/auth-page.tsx
@@ -23,6 +23,7 @@ import {
   authFooterClassName,
   authFooterLinkClassName,
 } from "./supporting/layout";
+import { HostedNoAuthMethods } from "./supporting/no-auth-methods";
 import { OAuthButtonGroup } from "./supporting/oauth-button";
 import { PasskeyButton } from "./supporting/passkey-button";
 import type { AuthProject, AuthType } from "./supporting/types";
@@ -138,6 +139,23 @@ function HostedAuthPageInner(props: {
   const hasEmailMethods = project.config.credentialEnabled || project.config.magicLinkEnabled;
   const enableSeparator = hasEmailMethods && (hasOAuthProviders || hasPasskey);
 
+  // Note that we check passkeys regardless of `props.type` here (unlike `hasPasskey`); a project with only
+  // passkeys enabled can't sign up with them, but it is configured correctly, so the sign-up page should
+  // keep pointing at the sign-in page instead of claiming that the project is misconfigured.
+  const hasAnyAuthMethod = hasOAuthProviders
+    || project.config.passkeyEnabled === true
+    || hasEmailMethods;
+
+  if (!hasAnyAuthMethod) {
+    return (
+      <HostedNoAuthMethods
+        fullPage={props.fullPage}
+        projectId={app.projectId}
+        projectDisplayName={project.displayName}
+      />
+    );
+  }
+
   return (
     <HostedAuthShell fullPage={props.fullPage} paddedFullPage={false}>
       <HostedAuthHeading title={props.type === "sign-in" ? "Sign in" : "Create account"}>
@@ -181,7 +199,11 @@ function HostedAuthPageInner(props: {
       ) : project.config.magicLinkEnabled ? (
         <MagicLinkSignIn email={email} onEmailChange={setEmail} />
       ) : !(hasOAuthProviders || hasPasskey) ? (
-        <p className="py-4 text-center text-sm text-destructive">No authentication method enabled.</p>
+        // Only reachable on the sign-up page of a passkey-only project: the project is configured
+        // correctly, there is just no way to create an account with a passkey alone.
+        <p className="py-2 text-center text-sm text-muted-foreground">
+          New accounts can't be created with the sign-in methods enabled for this app. Sign in instead.
+        </p>
       ) : null}
 
       <div className={authFooterClassName}>

--- a/apps/hosted-components/src/hosted-components/auth/supporting/no-auth-methods.tsx
+++ b/apps/hosted-components/src/hosted-components/auth/supporting/no-auth-methods.tsx
@@ -1,0 +1,65 @@
+import { KeyRound } from "lucide-react";
+
+import { Typography } from "~/components/ui";
+
+import { HostedAuthShell } from "./layout";
+
+// The hosted components are only ever served by Hexclave Cloud (<projectId>.built-with-hexclave.com),
+// so we can hardcode the cloud dashboard here; self-hosters use the SDK components instead.
+const HOSTED_DASHBOARD_URL = "https://app.hexclave.com";
+
+const configSnippet = `auth: {
+  password: { allowSignIn: true },
+  otp: { allowSignIn: true },
+}`;
+
+/**
+ * Shown instead of the sign-in/sign-up form when a project has no auth methods at all (no password,
+ * no OTP, no passkey, no OAuth provider). Without this, the page would look broken: there is nothing
+ * the end user can do, and the developer gets no hint about what went wrong.
+ */
+export function HostedNoAuthMethods(props: {
+  fullPage?: boolean,
+  projectId: string,
+  projectDisplayName?: string,
+}) {
+  const authMethodsUrl = `${HOSTED_DASHBOARD_URL}/projects/${encodeURIComponent(props.projectId)}/auth-methods`;
+
+  return (
+    <HostedAuthShell fullPage={props.fullPage} paddedFullPage={false}>
+      <div className="flex flex-col items-center text-center">
+        <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl border border-black/[0.08] bg-zinc-100/70 dark:border-white/[0.10] dark:bg-zinc-900/45">
+          <KeyRound className="h-5 w-5 text-muted-foreground" />
+        </div>
+        <Typography type="h2" className="mb-1 text-xl font-semibold tracking-tight">Sign-in is not available</Typography>
+        <Typography className="text-sm text-muted-foreground">
+          {props.projectDisplayName == null
+            ? "This app has no authentication methods enabled, so nobody can sign in yet."
+            : <>
+              <span className="font-medium text-foreground">{props.projectDisplayName}</span> has no authentication methods enabled, so nobody can sign in yet.
+            </>}
+        </Typography>
+      </div>
+
+      <div className="mt-6 rounded-xl border border-black/[0.08] bg-zinc-100/50 p-4 text-left dark:border-white/[0.10] dark:bg-zinc-900/45">
+        <p className="text-sm font-semibold">Are you the developer?</p>
+        <p className="mt-1 text-sm text-muted-foreground">
+          Enable at least one sign-in method in your <code className="rounded bg-black/[0.06] px-1 py-0.5 font-mono text-xs dark:bg-white/[0.10]">hexclave.config.ts</code>:
+        </p>
+        <pre className="mt-2 overflow-x-auto rounded-lg border border-black/[0.06] bg-white/60 p-3 font-mono text-xs leading-relaxed dark:border-white/[0.08] dark:bg-zinc-950/50">{configSnippet}</pre>
+        <p className="mt-3 text-sm text-muted-foreground">
+          Or turn one on in the{" "}
+          <a
+            href={authMethodsUrl}
+            target="_blank"
+            rel="noopener noreferrer"
+            className="font-medium text-foreground underline underline-offset-4 transition-colors hover:transition-none hover:text-foreground/80"
+          >
+            Hexclave dashboard
+          </a>
+          {" "}under Auth Methods.
+        </p>
+      </div>
+    </HostedAuthShell>
+  );
+}

--- a/packages/template/src/components-page/auth-page.tsx
+++ b/packages/template/src/components-page/auth-page.tsx
@@ -14,6 +14,7 @@ import { SeparatorWithText } from '../components/elements/separator-with-text';
 import { StyledLink } from '../components/link';
 import { KnownErrorMessageCard } from '../components/message-cards/known-error-message-card';
 import { MessageCard } from '../components/message-cards/message-card';
+import { NoAuthMethodsMessageCard } from '../components/message-cards/no-auth-methods-message-card';
 import { MagicLinkSignIn } from '../components/magic-link-sign-in';
 import { PredefinedMessageCard } from '../components/message-cards/predefined-message-card';
 import { OAuthButtonGroup } from '../components/oauth-button-group';
@@ -132,6 +133,18 @@ function Inner(props: Props) {
   const hasPasskey = (project.config.passkeyEnabled === true && props.type === "sign-in");
   const enableSeparator = (project.config.credentialEnabled || project.config.magicLinkEnabled) && (hasOAuthProviders || hasPasskey);
 
+  // Note that we check passkeys regardless of `props.type` here (unlike `hasPasskey`); a project with only
+  // passkeys enabled can't sign up with them, but it is configured correctly, so the sign-up page should
+  // keep pointing at the sign-in page instead of claiming that the project is misconfigured.
+  const hasAnyAuthMethod = hasOAuthProviders
+    || project.config.passkeyEnabled === true
+    || project.config.credentialEnabled
+    || project.config.magicLinkEnabled;
+
+  if (!hasAnyAuthMethod) {
+    return <NoAuthMethodsMessageCard fullPage={props.fullPage} projectDisplayName={'displayName' in project ? project.displayName : undefined} />;
+  }
+
   return (
     <MaybeFullPage fullPage={!!props.fullPage}>
       <div className='stack-scope flex flex-col items-stretch' style={{ maxWidth: '380px', flexBasis: '380px', padding: props.fullPage ? '1rem' : 0 }}>
@@ -186,7 +199,11 @@ function Inner(props: Props) {
           props.type === 'sign-up' ? <CredentialSignUp noPasswordRepeat={props.noPasswordRepeat} /> : <CredentialSignIn />
         ) : project.config.magicLinkEnabled ? (
           <MagicLinkSignIn />
-        ) : !(hasOAuthProviders || hasPasskey) ? <Typography variant={"destructive"} className="text-center">{t("No authentication method enabled.")}</Typography> : null}
+        ) : !(hasOAuthProviders || hasPasskey) ? (
+          // Only reachable on the sign-up page of a passkey-only project: the project is configured
+          // correctly, there is just no way to create an account with a passkey alone.
+          <Typography variant="secondary" className="text-center">{t("New accounts can't be created with the sign-in methods enabled for this app. Sign in instead.")}</Typography>
+        ) : null}
         {props.extraInfo && (
           <div className={cn('flex flex-col items-center text-center text-sm text-gray-500', {
             'mt-2': project.config.credentialEnabled || project.config.magicLinkEnabled,

--- a/packages/template/src/components/message-cards/no-auth-methods-message-card.tsx
+++ b/packages/template/src/components/message-cards/no-auth-methods-message-card.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { Typography } from "@hexclave/ui";
+import { KeyRound } from "lucide-react";
+import { useTranslation } from "../../lib/translations";
+import { MaybeFullPage } from "../elements/maybe-full-page";
+
+const configSnippet = `auth: {
+  password: { allowSignIn: true },
+  otp: { allowSignIn: true },
+}`;
+
+/**
+ * Shown instead of the sign-in/sign-up form when a project has no auth methods at all (no password, no
+ * OTP, no passkey, no OAuth provider). Without this, the page would look broken: there is nothing the end
+ * user can do, and the developer gets no hint about what went wrong or how to fix it.
+ */
+export function NoAuthMethodsMessageCard(props: {
+  fullPage?: boolean,
+  projectDisplayName?: string,
+}) {
+  const { t } = useTranslation();
+
+  return (
+    <MaybeFullPage fullPage={!!props.fullPage}>
+      <div className='stack-scope flex flex-col items-stretch' style={{ maxWidth: '380px', flexBasis: '380px', padding: props.fullPage ? '1rem' : 0 }}>
+        <div className="flex flex-col items-center text-center">
+          <div className="mb-4 flex h-11 w-11 items-center justify-center rounded-2xl border border-black/[0.08] dark:border-white/[0.10]">
+            <KeyRound className="h-5 w-5 text-gray-500" />
+          </div>
+          <Typography type='h2'>{t("Sign-in is not available")}</Typography>
+          <Typography type='label' variant='secondary'>
+            {props.projectDisplayName == null
+              ? t("This app has no authentication methods enabled, so nobody can sign in yet.")
+              : t("{projectDisplayName} has no authentication methods enabled, so nobody can sign in yet.", { projectDisplayName: props.projectDisplayName })}
+          </Typography>
+        </div>
+
+        <div className="mt-6 rounded-xl border border-black/[0.08] p-4 text-left dark:border-white/[0.10]">
+          <Typography type='label'>{t("Are you the developer?")}</Typography>
+          <Typography type='label' variant='secondary'>
+            {t("Enable at least one sign-in method in your hexclave.config.ts:")}
+          </Typography>
+          <pre className="mt-2 overflow-x-auto rounded-lg border border-black/[0.06] p-3 font-mono text-xs leading-relaxed dark:border-white/[0.08]">{configSnippet}</pre>
+          <Typography type='label' variant='secondary'>
+            {t("Or turn one on in the Hexclave dashboard, under Auth Methods.")}
+          </Typography>
+        </div>
+      </div>
+    </MaybeFullPage>
+  );
+}


### PR DESCRIPTION
When a project has no auth method enabled (no password, OTP, passkey, or OAuth provider), the auth pages replaced the form with a terse red `No authentication method enabled.` line, which looks like a broken page and gives the developer no hint about how to fix it.

Sign-in and sign-up now render a dedicated card instead: what's wrong, plus how to fix it in `hexclave.config.ts` or in the dashboard (hosted components deep-link to the project's Auth Methods page).

- `apps/hosted-components/.../auth/supporting/no-auth-methods.tsx` (new) + `auth-page.tsx`
- `packages/template/.../message-cards/no-auth-methods-message-card.tsx` (new) + `components-page/auth-page.tsx`
- `apps/dashboard/.../hosted-auth-preview.tsx` mirrors it so the preview matches what end users see

The "any auth method" check ignores `props.type`, unlike the existing `hasPasskey`: a passkey-only project is configured correctly, so its sign-up page now says accounts can't be created with the enabled methods (sign in instead) rather than claiming a misconfiguration.

Tests: `apps/dashboard/src/components/hosted-auth-preview.test.tsx` covers no methods, partial methods, and passkey-only sign-up.


Link to Devin session: https://app.devin.ai/sessions/93b3999b15124d789d37857b8e5ec440
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show a clear, actionable message when a project has no authentication methods enabled, and align the hosted auth pages with the dashboard preview. Also improves copy for passkey‑only projects on sign-up.

- **New Features**
  - Replace the terse error with a message card that explains the issue and how to enable methods in `hexclave.config.ts` or via the dashboard (hosted deep-link to the project’s Auth Methods).
  - Add `HostedNoAuthMethods` in `apps/hosted-components` and `NoAuthMethodsMessageCard` in `packages/template`; `apps/dashboard` uses `NoAuthMethodsPreview` so the preview matches the hosted UI, including project name and a config snippet.
  - Use an “any auth method” check (ignores `type`) so passkey‑only projects show sign-up guidance (“Sign in instead.”) rather than a misconfiguration error.
  - Add tests in `apps/dashboard/src/components/hosted-auth-preview.test.tsx` for no methods, partial methods, and passkey‑only sign‑up.

<sup>Written for commit ddbeb2f31f3ddd5cd44e6e8be55b4d85dcaa4a19. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1814?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added clear sign-in unavailable screens when no authentication methods are enabled.
  - Added guidance for enabling password or OTP sign-in through project configuration or the dashboard.
  - Improved messaging for passkey-only and partially configured sign-in methods.
  - Added contextual project naming and configuration examples to empty states.

- **Bug Fixes**
  - Prevented misleading authentication error messages when valid sign-in methods remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->