### PR TITLE
Don't flash the auth page's Suspense fallback when the session changes

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -85,9 +85,13 @@ describe("StackClientApp sign-in cache warm-up", () => {
     });
 
     let onFirstPrefetchStarted!: () => void;
-    const firstPrefetchStarted = new Promise<void>((resolve) => { onFirstPrefetchStarted = resolve; });
+    const firstPrefetchStarted = new Promise<void>((resolve) => {
+      onFirstPrefetchStarted = resolve;
+    });
     let releaseFirstPrefetch!: () => void;
-    const firstPrefetchReleased = new Promise<void>((resolve) => { releaseFirstPrefetch = resolve; });
+    const firstPrefetchReleased = new Promise<void>((resolve) => {
+      releaseFirstPrefetch = resolve;
+    });
 
     const clientInterface = Reflect.get(clientApp, "_interface");
     let getClientUserByTokenCalls = 0;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -48,9 +48,9 @@ describe("StackClientApp sign-in cache warm-up", () => {
       return { id: "user-id", is_anonymous: false, is_restricted: false };
     });
 
-    // The token store is only updated once the user is cached, so `useUser()` hooks that re-render because of the new
-    // session read a warm cache instead of suspending and flashing their Suspense fallback.
-    const cachedUsersOnTokenStoreChange: unknown[] = [];
+    // The new session's user is cached before the token store update is published, so `useUser()` hooks that re-render
+    // because of the new session read a warm cache instead of suspending and flashing their Suspense fallback.
+    const cacheStatusesOnTokenStoreChange: string[] = [];
     const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
       clientApp,
       await Reflect.get(clientApp, "_createCookieHelper").call(clientApp),
@@ -58,7 +58,7 @@ describe("StackClientApp sign-in cache warm-up", () => {
     tokenStore.onChange(() => {
       const session = Reflect.get(clientApp, "_getSessionFromTokenStore").call(clientApp, tokenStore);
       const currentUserCache = Reflect.get(clientApp, "_currentUserCache");
-      cachedUsersOnTokenStoreChange.push(currentUserCache.getIfCached([session]));
+      cacheStatusesOnTokenStoreChange.push(currentUserCache.getIfCached([session]).status);
     });
 
     await Reflect.get(clientApp, "_signInToAccountWithTokens").call(clientApp, {
@@ -71,6 +71,6 @@ describe("StackClientApp sign-in cache warm-up", () => {
     expect(cachedUser.status).toBe("ok");
     expect(cachedUser.data.data).toMatchObject({ id: "user-id" });
     expect(getClientUserByTokenCalls).toBe(1);
-    expect(cachedUsersOnTokenStoreChange.length).toBeGreaterThan(0);
+    expect(cacheStatusesOnTokenStoreChange).toEqual(["ok"]);
   });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from "vitest";
+import { StackClientApp } from "../interfaces/client-app";
+
+function createAccessTokenString(refreshTokenId: string): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return [
+    encode({ alg: "none", typ: "JWT" }),
+    encode({
+      sub: "user-id",
+      exp: nowSeconds + 60,
+      iat: nowSeconds,
+      iss: "https://api.example.test",
+      aud: "project-id",
+      project_id: "project-id",
+      branch_id: "main",
+      refresh_token_id: refreshTokenId,
+      role: "authenticated",
+      name: null,
+      email: null,
+      email_verified: false,
+      selected_team_id: null,
+      signed_up_at: nowSeconds,
+      is_anonymous: false,
+      is_restricted: false,
+      restricted_reason: null,
+      requires_totp_mfa: false,
+    }),
+    "",
+  ].join(".");
+}
+
+describe("StackClientApp sign-in cache warm-up", () => {
+  it("has the new session's user cached by the time the token store change is published", async () => {
+    const clientApp = new StackClientApp({
+      baseUrl: "http://localhost:12345",
+      projectId: "00000000-0000-4000-8000-000000000000",
+      publishableClientKey: "stack-pk-test",
+      tokenStore: "memory",
+      redirectMethod: "none",
+      noAutomaticPrefetch: true,
+    });
+
+    const clientInterface = Reflect.get(clientApp, "_interface");
+    let getClientUserByTokenCalls = 0;
+    Reflect.set(clientInterface, "getClientUserByToken", async () => {
+      getClientUserByTokenCalls += 1;
+      return { id: "user-id", is_anonymous: false, is_restricted: false };
+    });
+
+    // The token store is only updated once the user is cached, so `useUser()` hooks that re-render because of the new
+    // session read a warm cache instead of suspending and flashing their Suspense fallback.
+    const cachedUsersOnTokenStoreChange: unknown[] = [];
+    const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
+      clientApp,
+      await Reflect.get(clientApp, "_createCookieHelper").call(clientApp),
+    );
+    tokenStore.onChange(() => {
+      const session = Reflect.get(clientApp, "_getSessionFromTokenStore").call(clientApp, tokenStore);
+      const currentUserCache = Reflect.get(clientApp, "_currentUserCache");
+      cachedUsersOnTokenStoreChange.push(currentUserCache.getIfCached([session]));
+    });
+
+    await Reflect.get(clientApp, "_signInToAccountWithTokens").call(clientApp, {
+      accessToken: createAccessTokenString("refresh-token-id"),
+      refreshToken: "refresh-token",
+    });
+
+    const session = await Reflect.get(clientApp, "_getSession").call(clientApp);
+    const cachedUser = Reflect.get(clientApp, "_currentUserCache").getIfCached([session]);
+    expect(cachedUser.status).toBe("ok");
+    expect(cachedUser.data.data).toMatchObject({ id: "user-id" });
+    expect(getClientUserByTokenCalls).toBe(1);
+    expect(cachedUsersOnTokenStoreChange.length).toBeGreaterThan(0);
+  });
+});

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -84,13 +84,20 @@ describe("StackClientApp sign-in cache warm-up", () => {
       noAutomaticPrefetch: true,
     });
 
+    let onFirstPrefetchStarted!: () => void;
+    const firstPrefetchStarted = new Promise<void>((resolve) => { onFirstPrefetchStarted = resolve; });
+    let releaseFirstPrefetch!: () => void;
+    const firstPrefetchReleased = new Promise<void>((resolve) => { releaseFirstPrefetch = resolve; });
+
     const clientInterface = Reflect.get(clientApp, "_interface");
     let getClientUserByTokenCalls = 0;
     Reflect.set(clientInterface, "getClientUserByToken", async () => {
       getClientUserByTokenCalls += 1;
-      // Only the first sign-in's pre-fetch is slow, so the second one gets to publish while the first is still waiting.
+      // The first sign-in's pre-fetch only finishes once we let it, so the second one deterministically gets to publish
+      // while the first one is still waiting.
       if (getClientUserByTokenCalls === 1) {
-        await new Promise((resolve) => setTimeout(resolve, 50));
+        onFirstPrefetchStarted();
+        await firstPrefetchReleased;
       }
       return { id: "user-id", is_anonymous: false, is_restricted: false };
     });
@@ -101,9 +108,11 @@ describe("StackClientApp sign-in cache warm-up", () => {
     });
 
     const slowSignIn = signIn("old-refresh-token", "old-refresh-token-id");
-    await new Promise((resolve) => setTimeout(resolve, 10));
+    await firstPrefetchStarted;
     await signIn("new-refresh-token", "new-refresh-token-id");
+    releaseFirstPrefetch();
     await slowSignIn;
+    expect(getClientUserByTokenCalls).toBe(2);
 
     const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
       clientApp,

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -73,4 +73,42 @@ describe("StackClientApp sign-in cache warm-up", () => {
     expect(getClientUserByTokenCalls).toBe(1);
     expect(cacheStatusesOnTokenStoreChange).toEqual(["ok"]);
   });
+
+  it("doesn't let a slow sign-in publish its tokens on top of a sign-in that started later", async () => {
+    const clientApp = new StackClientApp({
+      baseUrl: "http://localhost:12345",
+      projectId: "00000000-0000-4000-8000-000000000000",
+      publishableClientKey: "stack-pk-test",
+      tokenStore: "memory",
+      redirectMethod: "none",
+      noAutomaticPrefetch: true,
+    });
+
+    const clientInterface = Reflect.get(clientApp, "_interface");
+    let getClientUserByTokenCalls = 0;
+    Reflect.set(clientInterface, "getClientUserByToken", async () => {
+      getClientUserByTokenCalls += 1;
+      // Only the first sign-in's pre-fetch is slow, so the second one gets to publish while the first is still waiting.
+      if (getClientUserByTokenCalls === 1) {
+        await new Promise((resolve) => setTimeout(resolve, 50));
+      }
+      return { id: "user-id", is_anonymous: false, is_restricted: false };
+    });
+
+    const signIn = (refreshToken: string, refreshTokenId: string) => Reflect.get(clientApp, "_signInToAccountWithTokens").call(clientApp, {
+      accessToken: createAccessTokenString(refreshTokenId),
+      refreshToken,
+    });
+
+    const slowSignIn = signIn("old-refresh-token", "old-refresh-token-id");
+    await new Promise((resolve) => setTimeout(resolve, 10));
+    await signIn("new-refresh-token", "new-refresh-token-id");
+    await slowSignIn;
+
+    const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
+      clientApp,
+      await Reflect.get(clientApp, "_createCookieHelper").call(clientApp),
+    );
+    expect(tokenStore.get().refreshToken).toBe("new-refresh-token");
+  });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.sign-in-cache-warmup.test.ts
@@ -6,122 +6,85 @@ function createAccessTokenString(refreshTokenId: string): string {
   const nowSeconds = Math.floor(Date.now() / 1000);
   return [
     encode({ alg: "none", typ: "JWT" }),
-    encode({
-      sub: "user-id",
-      exp: nowSeconds + 60,
-      iat: nowSeconds,
-      iss: "https://api.example.test",
-      aud: "project-id",
-      project_id: "project-id",
-      branch_id: "main",
-      refresh_token_id: refreshTokenId,
-      role: "authenticated",
-      name: null,
-      email: null,
-      email_verified: false,
-      selected_team_id: null,
-      signed_up_at: nowSeconds,
-      is_anonymous: false,
-      is_restricted: false,
-      restricted_reason: null,
-      requires_totp_mfa: false,
-    }),
+    encode({ sub: "user-id", exp: nowSeconds + 60, iat: nowSeconds, refresh_token_id: refreshTokenId }),
     "",
   ].join(".");
 }
 
+function createTestSetup(getUser: () => Promise<unknown>) {
+  const clientApp = new StackClientApp({
+    baseUrl: "http://localhost:12345",
+    projectId: "00000000-0000-4000-8000-000000000000",
+    publishableClientKey: "stack-pk-test",
+    tokenStore: "memory",
+    redirectMethod: "none",
+    noAutomaticPrefetch: true,
+  });
+  Reflect.set(Reflect.get(clientApp, "_interface"), "getClientUserByToken", getUser);
+  const privateMethod = (name: string) => (...args: unknown[]) => Reflect.get(clientApp, name).apply(clientApp, args);
+  return {
+    currentUserCache: Reflect.get(clientApp, "_currentUserCache"),
+    signIn: (refreshToken: string) => privateMethod("_signInToAccountWithTokens")({
+      accessToken: createAccessTokenString(`${refreshToken}-id`),
+      refreshToken,
+    }),
+    getSessionFromTokenStore: privateMethod("_getSessionFromTokenStore"),
+    getTokenStore: async () => privateMethod("_getOrCreateTokenStore")(await privateMethod("_createCookieHelper")()),
+  };
+}
+
 describe("StackClientApp sign-in cache warm-up", () => {
   it("has the new session's user cached by the time the token store change is published", async () => {
-    const clientApp = new StackClientApp({
-      baseUrl: "http://localhost:12345",
-      projectId: "00000000-0000-4000-8000-000000000000",
-      publishableClientKey: "stack-pk-test",
-      tokenStore: "memory",
-      redirectMethod: "none",
-      noAutomaticPrefetch: true,
-    });
-
-    const clientInterface = Reflect.get(clientApp, "_interface");
-    let getClientUserByTokenCalls = 0;
-    Reflect.set(clientInterface, "getClientUserByToken", async () => {
-      getClientUserByTokenCalls += 1;
+    let getUserCalls = 0;
+    const setup = createTestSetup(async () => {
+      getUserCalls += 1;
       return { id: "user-id", is_anonymous: false, is_restricted: false };
     });
 
-    // The new session's user is cached before the token store update is published, so `useUser()` hooks that re-render
-    // because of the new session read a warm cache instead of suspending and flashing their Suspense fallback.
+    // `useUser()` hooks re-read the cache when the session changes, so if the cache were still cold here, they'd
+    // suspend and flash their Suspense fallback over the UI that's already on the screen.
     const cacheStatusesOnTokenStoreChange: string[] = [];
-    const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
-      clientApp,
-      await Reflect.get(clientApp, "_createCookieHelper").call(clientApp),
-    );
+    const tokenStore = await setup.getTokenStore();
     tokenStore.onChange(() => {
-      const session = Reflect.get(clientApp, "_getSessionFromTokenStore").call(clientApp, tokenStore);
-      const currentUserCache = Reflect.get(clientApp, "_currentUserCache");
-      cacheStatusesOnTokenStoreChange.push(currentUserCache.getIfCached([session]).status);
+      const session = setup.getSessionFromTokenStore(tokenStore);
+      cacheStatusesOnTokenStoreChange.push(setup.currentUserCache.getIfCached([session]).status);
     });
 
-    await Reflect.get(clientApp, "_signInToAccountWithTokens").call(clientApp, {
-      accessToken: createAccessTokenString("refresh-token-id"),
-      refreshToken: "refresh-token",
-    });
+    await setup.signIn("refresh-token");
 
-    const session = await Reflect.get(clientApp, "_getSession").call(clientApp);
-    const cachedUser = Reflect.get(clientApp, "_currentUserCache").getIfCached([session]);
-    expect(cachedUser.status).toBe("ok");
-    expect(cachedUser.data.data).toMatchObject({ id: "user-id" });
-    expect(getClientUserByTokenCalls).toBe(1);
     expect(cacheStatusesOnTokenStoreChange).toEqual(["ok"]);
+    const cachedUser = setup.currentUserCache.getIfCached([setup.getSessionFromTokenStore(tokenStore)]);
+    expect(cachedUser.data.data).toMatchObject({ id: "user-id" });
+    expect(getUserCalls).toBe(1);
   });
 
   it("doesn't let a slow sign-in publish its tokens on top of a sign-in that started later", async () => {
-    const clientApp = new StackClientApp({
-      baseUrl: "http://localhost:12345",
-      projectId: "00000000-0000-4000-8000-000000000000",
-      publishableClientKey: "stack-pk-test",
-      tokenStore: "memory",
-      redirectMethod: "none",
-      noAutomaticPrefetch: true,
+    let onFirstFetchStarted!: () => void;
+    let releaseFirstFetch!: () => void;
+    const firstFetchStarted = new Promise<void>((resolve) => {
+      onFirstFetchStarted = resolve;
+    });
+    const firstFetchReleased = new Promise<void>((resolve) => {
+      releaseFirstFetch = resolve;
     });
 
-    let onFirstPrefetchStarted!: () => void;
-    const firstPrefetchStarted = new Promise<void>((resolve) => {
-      onFirstPrefetchStarted = resolve;
-    });
-    let releaseFirstPrefetch!: () => void;
-    const firstPrefetchReleased = new Promise<void>((resolve) => {
-      releaseFirstPrefetch = resolve;
-    });
-
-    const clientInterface = Reflect.get(clientApp, "_interface");
-    let getClientUserByTokenCalls = 0;
-    Reflect.set(clientInterface, "getClientUserByToken", async () => {
-      getClientUserByTokenCalls += 1;
-      // The first sign-in's pre-fetch only finishes once we let it, so the second one deterministically gets to publish
-      // while the first one is still waiting.
-      if (getClientUserByTokenCalls === 1) {
-        onFirstPrefetchStarted();
-        await firstPrefetchReleased;
+    let getUserCalls = 0;
+    const setup = createTestSetup(async () => {
+      // Only the first sign-in's fetch blocks, so the second one deterministically gets to publish while it waits.
+      if (++getUserCalls === 1) {
+        onFirstFetchStarted();
+        await firstFetchReleased;
       }
       return { id: "user-id", is_anonymous: false, is_restricted: false };
     });
 
-    const signIn = (refreshToken: string, refreshTokenId: string) => Reflect.get(clientApp, "_signInToAccountWithTokens").call(clientApp, {
-      accessToken: createAccessTokenString(refreshTokenId),
-      refreshToken,
-    });
-
-    const slowSignIn = signIn("old-refresh-token", "old-refresh-token-id");
-    await firstPrefetchStarted;
-    await signIn("new-refresh-token", "new-refresh-token-id");
-    releaseFirstPrefetch();
+    const slowSignIn = setup.signIn("old-refresh-token");
+    await firstFetchStarted;
+    await setup.signIn("new-refresh-token");
+    releaseFirstFetch();
     await slowSignIn;
-    expect(getClientUserByTokenCalls).toBe(2);
 
-    const tokenStore = Reflect.get(clientApp, "_getOrCreateTokenStore").call(
-      clientApp,
-      await Reflect.get(clientApp, "_createCookieHelper").call(clientApp),
-    );
-    expect(tokenStore.get().refreshToken).toBe("new-refresh-token");
+    expect(getUserCalls).toBe(2);
+    expect((await setup.getTokenStore()).get().refreshToken).toBe("new-refresh-token");
   });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1578,6 +1578,12 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
    */
   private _sessionsByTokenStoreAndSessionKey = new WeakMap<Store<TokenObject>, Map<string, InternalSession>>();
   /**
+   * Monotonic IDs for `_signInToAccountWithTokens` calls, so that a sign-in which awaits longer than a sign-in that
+   * started after it doesn't publish its (by then outdated) tokens on top of the newer ones.
+   */
+  private _signInAttemptCounter = 0;
+  private _lastPublishedSignInAttemptId = 0;
+  /**
    * @param overrideTokenObj The tokens to build the session for, if they haven't been written to the token store yet.
    *                         Used to create (and hence warm the caches of) the session of a sign-in before the token
    *                         store update makes it observable to the rest of the app.
@@ -1642,6 +1648,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     if (!("accessToken" in tokens) || !("refreshToken" in tokens)) {
       throw new HexclaveAssertionError("Invalid tokens object; can't sign in with this", { tokens });
     }
+    const signInAttemptId = ++this._signInAttemptCounter;
+
     // Fetch the user of the incoming tokens before publishing them, so the new session's cache is already warm when
     // the token store update below notifies its subscribers. Mounted `useUser()` hooks re-read the cache when the
     // session changes, so an empty cache entry for the new session makes them suspend — flashing their Suspense
@@ -1650,6 +1658,14 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     const prefetchedUser = await this._prefetchCurrentUserForFreshTokens(tokens);
 
     const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper());
+
+    // We awaited above, so a sign-in that started after ours may have already taken effect (eg. the analytics anonymous
+    // sign-up racing against a real sign-in on the same page). Publishing our older tokens now would roll the app back
+    // to the session it just left, so drop this sign-in instead.
+    if (this._lastPublishedSignInAttemptId > signInAttemptId) {
+      return;
+    }
+    this._lastPublishedSignInAttemptId = signInAttemptId;
 
     // If these tokens resolve to a session we already have (eg. the RDE dashboard re-installing a freshly minted
     // access token for the same access-only session), push the new token into it in place; constructing a new

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1658,10 +1658,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     // Note that we create the session (and seed its cache) from the tokens directly, before writing them to the token
     // store; that way, the session is already fully warm by the time the token store notifies its subscribers.
     const session = this._getSessionFromTokenStore(tokenStore, tokens);
-    session.updateAccessToken(tokens);
     if (prefetchedUser !== null) {
       this._currentUserCache.forceSetCachedValue([session], prefetchedUser);
     }
+    session.updateAccessToken(tokens);
 
     tokenStore.set(tokens);
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1637,6 +1637,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     if (!("accessToken" in tokens) || !("refreshToken" in tokens)) {
       throw new HexclaveAssertionError("Invalid tokens object; can't sign in with this", { tokens });
     }
+    // Fetch the user of the incoming tokens before publishing them, so we can seed the current-user cache in the same
+    // tick as the token store update below. Mounted `useUser()` hooks re-read the cache synchronously when the token
+    // store changes, so an empty cache entry for the new session makes them suspend — flashing their Suspense fallback
+    // over UI that was already on the screen. That is most visible on the sign-in/sign-up pages, which sit there
+    // signed out until the analytics anonymous sign-up swaps in a session a few seconds after the page loaded.
+    const prefetchedUser = await this._prefetchCurrentUserForFreshTokens(tokens);
+
     const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper());
     tokenStore.set(tokens);
 
@@ -1646,8 +1653,31 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     const session = this._getSessionFromTokenStore(tokenStore);
     session.updateAccessToken(tokens);
 
-    // Pre-fetch the current user so the cache is warm when useUser() re-renders (write-only, so it never suspends).
-    runAsynchronously(this._currentUserCache.getOrWait([session], "write-only"));
+    if (prefetchedUser === null) {
+      // We have nothing to seed the cache with (no access token to pre-fetch with, or the pre-fetch failed), so warm
+      // it in the background instead; that may lose the race against the re-render, but it's the best we can do.
+      runAsynchronously(this._currentUserCache.getOrWait([session], "write-only"));
+    } else {
+      this._currentUserCache.forceSetCachedValue([session], prefetchedUser);
+    }
+  }
+
+  /**
+   * Fetches the current user for a token pair that has not been written to the token store yet, without touching the
+   * app-level session (token stores created from an explicit token pair are in-memory only).
+   *
+   * Returns `null` if the user could not be fetched, in which case callers should fall back to a background refresh.
+   */
+  private async _prefetchCurrentUserForFreshTokens(
+    tokens: { accessToken: string | null, refreshToken: string },
+  ): Promise<Result<CurrentUserCrud['Client']['Read'] | null> | null> {
+    const freshTokenStoreInit = this._getTokenStoreInitForFreshTokens(tokens);
+    if (freshTokenStoreInit === undefined) {
+      return null;
+    }
+    const prefetchSession = await this._getSession(freshTokenStoreInit);
+    const result = await this._currentUserCache.getOrWait([prefetchSession], "write-only");
+    return result.status === "ok" ? result : null;
   }
 
   protected _getTokenStoreInitForFreshTokens(tokens: { accessToken: string | null, refreshToken: string }): TokenStoreInit | undefined {

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1577,8 +1577,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
    * - So different token stores are separated and don't leak information between each other, eg. if the same user sends two requests to the same server they should get a different session object
    */
   private _sessionsByTokenStoreAndSessionKey = new WeakMap<Store<TokenObject>, Map<string, InternalSession>>();
-  protected _getSessionFromTokenStore(tokenStore: Store<TokenObject>): InternalSession {
-    const tokenObj = tokenStore.get();
+  /**
+   * @param overrideTokenObj The tokens to build the session for, if they haven't been written to the token store yet.
+   *                         Used to create (and hence warm the caches of) the session of a sign-in before the token
+   *                         store update makes it observable to the rest of the app.
+   */
+  protected _getSessionFromTokenStore(tokenStore: Store<TokenObject>, overrideTokenObj?: TokenObject): InternalSession {
+    const tokenObj = overrideTokenObj ?? tokenStore.get();
     const sessionKey = InternalSession.calculateSessionKey(tokenObj);
     const existing = sessionKey ? this._sessionsByTokenStoreAndSessionKey.get(tokenStore)?.get(sessionKey) : null;
     if (existing) return existing;
@@ -1637,28 +1642,33 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     if (!("accessToken" in tokens) || !("refreshToken" in tokens)) {
       throw new HexclaveAssertionError("Invalid tokens object; can't sign in with this", { tokens });
     }
-    // Fetch the user of the incoming tokens before publishing them, so we can seed the current-user cache in the same
-    // tick as the token store update below. Mounted `useUser()` hooks re-read the cache synchronously when the token
-    // store changes, so an empty cache entry for the new session makes them suspend — flashing their Suspense fallback
-    // over UI that was already on the screen. That is most visible on the sign-in/sign-up pages, which sit there
-    // signed out until the analytics anonymous sign-up swaps in a session a few seconds after the page loaded.
+    // Fetch the user of the incoming tokens before publishing them, so the new session's cache is already warm when
+    // the token store update below notifies its subscribers. Mounted `useUser()` hooks re-read the cache when the
+    // session changes, so an empty cache entry for the new session makes them suspend — flashing their Suspense
+    // fallback over UI that was already on the screen. That is most visible on the sign-in/sign-up pages, which sit
+    // there signed out until the analytics anonymous sign-up swaps in a session a few seconds after the page loaded.
     const prefetchedUser = await this._prefetchCurrentUserForFreshTokens(tokens);
 
     const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper());
-    tokenStore.set(tokens);
 
     // If these tokens resolve to a session we already have (eg. the RDE dashboard re-installing a freshly minted
     // access token for the same access-only session), push the new token into it in place; constructing a new
     // session here would cold-invalidate every session-scoped cache and suspend the UI on each refresh.
-    const session = this._getSessionFromTokenStore(tokenStore);
+    //
+    // Note that we create the session (and seed its cache) from the tokens directly, before writing them to the token
+    // store; that way, the session is already fully warm by the time the token store notifies its subscribers.
+    const session = this._getSessionFromTokenStore(tokenStore, tokens);
     session.updateAccessToken(tokens);
+    if (prefetchedUser !== null) {
+      this._currentUserCache.forceSetCachedValue([session], prefetchedUser);
+    }
+
+    tokenStore.set(tokens);
 
     if (prefetchedUser === null) {
-      // We have nothing to seed the cache with (no access token to pre-fetch with, or the pre-fetch failed), so warm
-      // it in the background instead; that may lose the race against the re-render, but it's the best we can do.
+      // We had nothing to seed the cache with (no access token to pre-fetch with, or the pre-fetch failed), so warm it
+      // in the background instead; that may lose the race against the re-render, but it's the best we can do.
       runAsynchronously(this._currentUserCache.getOrWait([session], "write-only"));
-    } else {
-      this._currentUserCache.forceSetCachedValue([session], prefetchedUser);
     }
   }
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1578,15 +1578,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
    */
   private _sessionsByTokenStoreAndSessionKey = new WeakMap<Store<TokenObject>, Map<string, InternalSession>>();
   /**
-   * Monotonic IDs for `_signInToAccountWithTokens` calls, so that a sign-in which awaits longer than a sign-in that
-   * started after it doesn't publish its (by then outdated) tokens on top of the newer ones.
-   */
-  private _signInAttemptCounter = 0;
-  private _lastPublishedSignInAttemptId = 0;
-  /**
-   * @param overrideTokenObj The tokens to build the session for, if they haven't been written to the token store yet.
-   *                         Used to create (and hence warm the caches of) the session of a sign-in before the token
-   *                         store update makes it observable to the rest of the app.
+   * @param overrideTokenObj The tokens to build the session for, if they haven't been written to the token store yet
+   *                         (so we can warm a sign-in's session before the token store publishes it).
    */
   protected _getSessionFromTokenStore(tokenStore: Store<TokenObject>, overrideTokenObj?: TokenObject): InternalSession {
     const tokenObj = overrideTokenObj ?? tokenStore.get();
@@ -1644,66 +1637,33 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   }
   // END_PLATFORM
 
+  private _signInAttemptCounter = 0;
   protected async _signInToAccountWithTokens(tokens: { accessToken: string | null, refreshToken: string }) {
     if (!("accessToken" in tokens) || !("refreshToken" in tokens)) {
       throw new HexclaveAssertionError("Invalid tokens object; can't sign in with this", { tokens });
     }
-    const signInAttemptId = ++this._signInAttemptCounter;
-
-    // Fetch the user of the incoming tokens before publishing them, so the new session's cache is already warm when
-    // the token store update below notifies its subscribers. Mounted `useUser()` hooks re-read the cache when the
-    // session changes, so an empty cache entry for the new session makes them suspend — flashing their Suspense
-    // fallback over UI that was already on the screen. That is most visible on the sign-in/sign-up pages, which sit
-    // there signed out until the analytics anonymous sign-up swaps in a session a few seconds after the page loaded.
-    const prefetchedUser = await this._prefetchCurrentUserForFreshTokens(tokens);
-
+    const attemptId = ++this._signInAttemptCounter;
     const tokenStore = this._getOrCreateTokenStore(await this._createCookieHelper());
-
-    // We awaited above, so a sign-in that started after ours may have already taken effect (eg. the analytics anonymous
-    // sign-up racing against a real sign-in on the same page). Publishing our older tokens now would roll the app back
-    // to the session it just left, so drop this sign-in instead.
-    if (this._lastPublishedSignInAttemptId > signInAttemptId) {
-      return;
-    }
-    this._lastPublishedSignInAttemptId = signInAttemptId;
 
     // If these tokens resolve to a session we already have (eg. the RDE dashboard re-installing a freshly minted
     // access token for the same access-only session), push the new token into it in place; constructing a new
     // session here would cold-invalidate every session-scoped cache and suspend the UI on each refresh.
     //
-    // Note that we create the session (and seed its cache) from the tokens directly, before writing them to the token
-    // store; that way, the session is already fully warm by the time the token store notifies its subscribers.
+    // We build the session from the tokens instead of the token store, so that we can fetch its user before the token
+    // store publishes it below: mounted `useUser()` hooks re-read the cache when the session changes, so a cold cache
+    // entry at that point makes them suspend, flashing their Suspense fallback over UI that's already on the screen.
+    // That's most visible on the auth pages, which sit there signed out until the analytics anonymous sign-up swaps in
+    // a session a few seconds after the page loaded.
     const session = this._getSessionFromTokenStore(tokenStore, tokens);
-    if (prefetchedUser !== null) {
-      this._currentUserCache.forceSetCachedValue([session], prefetchedUser);
-    }
     session.updateAccessToken(tokens);
+    // If the fetch fails, we still publish the session (dropping a successful sign-in over a failed /users/me would be
+    // much worse than a flicker); the cache stays dirty, so `useUser()` retries and surfaces the error itself.
+    await Result.fromPromise(this._currentUserCache.getOrWait([session], "write-only"));
 
+    // A sign-in that started after ours may have raced past us while we were fetching, in which case publishing our
+    // (by now outdated) tokens would roll the app back to the session it just left.
+    if (attemptId !== this._signInAttemptCounter) return;
     tokenStore.set(tokens);
-
-    if (prefetchedUser === null) {
-      // We had nothing to seed the cache with (no access token to pre-fetch with, or the pre-fetch failed), so warm it
-      // in the background instead; that may lose the race against the re-render, but it's the best we can do.
-      runAsynchronously(this._currentUserCache.getOrWait([session], "write-only"));
-    }
-  }
-
-  /**
-   * Fetches the current user for a token pair that has not been written to the token store yet, without touching the
-   * app-level session (token stores created from an explicit token pair are in-memory only).
-   *
-   * Returns `null` if the user could not be fetched, in which case callers should fall back to a background refresh.
-   */
-  private async _prefetchCurrentUserForFreshTokens(
-    tokens: { accessToken: string | null, refreshToken: string },
-  ): Promise<Result<CurrentUserCrud['Client']['Read'] | null> | null> {
-    const freshTokenStoreInit = this._getTokenStoreInitForFreshTokens(tokens);
-    if (freshTokenStoreInit === undefined) {
-      return null;
-    }
-    const prefetchSession = await this._getSession(freshTokenStoreInit);
-    const result = await this._currentUserCache.getOrWait([prefetchSession], "write-only");
-    return result.status === "ok" ? result : null;
   }
 
   protected _getTokenStoreInitForFreshTokens(tokens: { accessToken: string | null, refreshToken: string }): TokenStoreInit | undefined {


### PR DESCRIPTION
## Summary

Auth pages flashed their Suspense fallback over an already-rendered form: analytics needs a session, so a few seconds after the page loads the SDK signs the visitor up anonymously, and `_signInToAccountWithTokens` published the new tokens before anything had fetched that session's user. The token store notifies synchronously, so the mounted `useUser()` re-rendered against a cold cache entry and suspended until `/users/me` came back.

Fix is to warm the new session's cache before publishing it:

```diff
-  tokenStore.set(tokens);
-  const session = this._getSessionFromTokenStore(tokenStore);
+  const session = this._getSessionFromTokenStore(tokenStore, tokens);  // build from the tokens, they're not published yet
   session.updateAccessToken(tokens);
-  runAsynchronously(this._currentUserCache.getOrWait([session], "write-only"));
+  await Result.fromPromise(this._currentUserCache.getOrWait([session], "write-only"));
+  if (attemptId !== this._signInAttemptCounter) return;  // a later sign-in raced past us while we were fetching
+  tokenStore.set(tokens);
```

Sessions are memoized per token store + session key, so the store-derived read after publication returns the same session object, hence the same warm cache entry.

Tradeoffs:
- `_signInToAccountWithTokens` now resolves one round trip later (same number of requests; the post-sign-in page no longer has to wait for `/users/me` itself).
- If the pre-fetch fails we still publish, since dropping a successful sign-in over a failed `/users/me` is worse than a flicker — the cache stays dirty and `useUser()` retries.
- The added await introduces a race (a slow anonymous sign-up publishing over a real sign-in that started later), hence the monotonic attempt counter.

Measured on a fresh browser context, dashboard `/handler/sign-up` (ms since navigation): before `2387 form → 3085 skeleton → 4228 form`, after `2441 form` and no later skeleton; same for `/handler/sign-in` and hosted components.

Tests: `client-app-impl.sign-in-cache-warmup.test.ts` asserts the cache status observed inside the `tokenStore.onChange` callback is `"ok"` (fails on either of the old orderings), and that a deliberately blocked older sign-in doesn't publish over a newer one.


Link to Devin session: https://app.devin.ai/sessions/6b3c9a2eb28e4fef88ab4f3de4747684
Requested by: @N2D4