### PR TITLE
Trust deployed domains for redirect URL validation

### DIFF
--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -50,7 +50,8 @@ describe('validateRedirectUrl', () => {
     }
   };
 
-  const createMockTenancy = (config: Partial<Tenancy['config']>): Tenancy => {
+  const createMockTenancy = (config: Partial<Tenancy['config']>) => {
+    const deployedDomains: string[] = [];
     return {
       config: {
         domains: {
@@ -58,13 +59,12 @@ describe('validateRedirectUrl', () => {
           trustedDomains: {},
           ...config.domains,
         },
-        ...config,
       },
-      deployedDomains: [],
+      deployedDomains,
       project: {
         id: "12345678-1234-4234-8234-123456789abc",
       },
-    } as unknown as Tenancy;
+    };
   };
 
   describe('deployment domains', () => {

--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -60,11 +60,43 @@ describe('validateRedirectUrl', () => {
         },
         ...config,
       },
+      deployedDomains: [],
       project: {
         id: "12345678-1234-4234-8234-123456789abc",
       },
-    } as Tenancy;
+    } as unknown as Tenancy;
   };
+
+  describe('deployment domains', () => {
+    it('trusts verified deployment domains', () => {
+      const tenancy = createMockTenancy({});
+      tenancy.deployedDomains = ['app.example.com'];
+
+      expect(validateRedirectUrl('https://app.example.com/sign-in', tenancy)).toBe(true);
+    });
+
+    it('does not trust an origin absent from the verified deployment origins', () => {
+      const tenancy = createMockTenancy({});
+
+      expect(validateRedirectUrl('https://pending.example.com/sign-in', tenancy)).toBe(false);
+    });
+
+    it('trusts the latest deployment URL', () => {
+      const tenancy = createMockTenancy({});
+      tenancy.deployedDomains = ['https://deployment-abc.vercel.app'];
+
+      expect(validateRedirectUrl('https://deployment-abc.vercel.app/sign-in', tenancy)).toBe(true);
+    });
+
+    it('includes deployed origins in OAuth redirect URIs', () => {
+      const tenancy = createMockTenancy({});
+      tenancy.deployedDomains = ['deployment-abc.vercel.app'];
+
+      expect(getOAuthRedirectUrisForTenancy(tenancy)).toContain(
+        'https://deployment-abc.vercel.app/handler/oauth-callback',
+      );
+    });
+  });
 
   describe('exact domain matching', () => {
     it('should implicitly validate hosted handler domains for the project', () => {

--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -96,6 +96,16 @@ describe('validateRedirectUrl', () => {
         'https://deployment-abc.vercel.app/handler/oauth-callback',
       );
     });
+
+    it('does not trust deployment values with unsupported schemes', () => {
+      const tenancy = createMockTenancy({});
+      tenancy.deployedDomains = ['file:///tmp/deployment'];
+
+      expect(validateRedirectUrl('https://tmp/deployment', tenancy)).toBe(false);
+      expect(getOAuthRedirectUrisForTenancy(tenancy)).not.toContain(
+        'https:///handler/oauth-callback',
+      );
+    });
   });
 
   describe('exact domain matching', () => {

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -1,9 +1,15 @@
 import { getEnvVariable, getProcessEnv } from "@hexclave/shared/dist/utils/env";
 import { getHostedHandlerTrustedDomain as getHostedHandlerTrustedDomainFromConfig, isAcceptedNativeAppUrl, validateRedirectUrl as validateRedirectUrlAgainstTrustedDomains } from "@hexclave/shared/dist/utils/redirect-urls";
+import { createUrlIfValid } from "@hexclave/shared/dist/utils/urls";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { Tenancy } from "./tenancies";
 
 export { isAcceptedNativeAppUrl };
+
+type RedirectTenancy = Pick<Tenancy, "deployedDomains"> & {
+  config: Pick<Tenancy["config"], "domains">,
+  project: Pick<Tenancy["project"], "id">,
+};
 
 export function getHostedHandlerTrustedDomain(projectId: string): string {
   return getHostedHandlerTrustedDomainFromConfig({
@@ -14,7 +20,7 @@ export function getHostedHandlerTrustedDomain(projectId: string): string {
   });
 }
 
-export function getTrustedDomainsForTenancy(tenancy: Tenancy): string[] {
+export function getTrustedDomainsForTenancy(tenancy: RedirectTenancy): string[] {
   return [
     ...Object.values(tenancy.config.domains.trustedDomains)
       .map(domain => domain.baseUrl)
@@ -24,7 +30,7 @@ export function getTrustedDomainsForTenancy(tenancy: Tenancy): string[] {
   ];
 }
 
-export function getOAuthRedirectUrisForTenancy(tenancy: Tenancy): string[] {
+export function getOAuthRedirectUrisForTenancy(tenancy: RedirectTenancy): string[] {
   return [
     ...Object.values(tenancy.config.domains.trustedDomains)
       .filter((domain) => domain.baseUrl)
@@ -34,28 +40,26 @@ export function getOAuthRedirectUrisForTenancy(tenancy: Tenancy): string[] {
   ];
 }
 
-function getDeployedOrigins(tenancy: Tenancy): string[] {
+function getDeployedOrigins(tenancy: RedirectTenancy): string[] {
   return tenancy.deployedDomains
     .map((domain) => {
-      try {
-        // Deployment URLs are public HTTPS origins even when Vercel returns a
-        // bare host or a stored value includes a scheme/path.
-        const url = new URL(domain.includes("://") ? domain : `https://${domain}`);
-        return `https://${url.host}`;
-      } catch (error) {
+      // Deployment URLs are public HTTPS origins even when Vercel returns a
+      // bare host or a stored value includes a scheme/path.
+      const url = createUrlIfValid(domain.includes("://") ? domain : `https://${domain}`);
+      if (url == null) {
         captureError("invalid-deployment-domain", new HexclaveAssertionError("A deployment domain could not be normalized for redirect validation.", {
           domain,
-          cause: error,
         }));
         return null;
       }
+      return `https://${url.host}`;
     })
     .filter((origin): origin is string => origin != null);
 }
 
 export function validateRedirectUrl(
   urlOrString: string | URL,
-  tenancy: Tenancy,
+  tenancy: RedirectTenancy,
 ): boolean {
   return validateRedirectUrlAgainstTrustedDomains(urlOrString, {
     allowLocalhost: tenancy.config.domains.allowLocalhost,
@@ -63,7 +67,7 @@ export function validateRedirectUrl(
   });
 }
 
-export function validateRedirectHostname(hostname: string, tenancy: Tenancy): boolean {
+export function validateRedirectHostname(hostname: string, tenancy: RedirectTenancy): boolean {
   return validateRedirectUrlAgainstTrustedDomains(`https://${hostname}`, {
     allowLocalhost: tenancy.config.domains.allowLocalhost,
     trustedDomains: getTrustedDomainsForTenancy(tenancy),

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -46,7 +46,7 @@ function getDeployedOrigins(tenancy: RedirectTenancy): string[] {
       // Deployment URLs are public HTTPS origins even when Vercel returns a
       // bare host or a stored value includes a scheme/path.
       const url = createUrlIfValid(domain.includes("://") ? domain : `https://${domain}`);
-      if (url == null) {
+      if (url == null || !["http:", "https:"].includes(url.protocol) || url.hostname === "") {
         captureError("invalid-deployment-domain", new HexclaveAssertionError("A deployment domain could not be normalized for redirect validation.", {
           domain,
         }));

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -1,5 +1,6 @@
 import { getEnvVariable, getProcessEnv } from "@hexclave/shared/dist/utils/env";
 import { getHostedHandlerTrustedDomain as getHostedHandlerTrustedDomainFromConfig, isAcceptedNativeAppUrl, validateRedirectUrl as validateRedirectUrlAgainstTrustedDomains } from "@hexclave/shared/dist/utils/redirect-urls";
+import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { Tenancy } from "./tenancies";
 
 export { isAcceptedNativeAppUrl };
@@ -18,6 +19,7 @@ export function getTrustedDomainsForTenancy(tenancy: Tenancy): string[] {
     ...Object.values(tenancy.config.domains.trustedDomains)
       .map(domain => domain.baseUrl)
       .filter((baseUrl): baseUrl is string => baseUrl != null),
+    ...getDeployedOrigins(tenancy),
     getHostedHandlerTrustedDomain(tenancy.project.id),
   ];
 }
@@ -27,8 +29,28 @@ export function getOAuthRedirectUrisForTenancy(tenancy: Tenancy): string[] {
     ...Object.values(tenancy.config.domains.trustedDomains)
       .filter((domain) => domain.baseUrl)
       .map((domain) => new URL(domain.handlerPath, domain.baseUrl).toString()),
+    ...getDeployedOrigins(tenancy).map((origin) => new URL("/handler/oauth-callback", origin).toString()),
     new URL("/handler/oauth-callback", getHostedHandlerTrustedDomain(tenancy.project.id)).toString(),
   ];
+}
+
+function getDeployedOrigins(tenancy: Tenancy): string[] {
+  return tenancy.deployedDomains
+    .map((domain) => {
+      try {
+        // Deployment URLs are public HTTPS origins even when Vercel returns a
+        // bare host or a stored value includes a scheme/path.
+        const url = new URL(domain.includes("://") ? domain : `https://${domain}`);
+        return `https://${url.host}`;
+      } catch (error) {
+        captureError("invalid-deployment-domain", new HexclaveAssertionError("A deployment domain could not be normalized for redirect validation.", {
+          domain,
+          cause: error,
+        }));
+        return null;
+      }
+    })
+    .filter((origin): origin is string => origin != null);
 }
 
 export function validateRedirectUrl(

--- a/apps/backend/src/lib/tenancies.tsx
+++ b/apps/backend/src/lib/tenancies.tsx
@@ -32,15 +32,19 @@ async function tenancyPrismaToCrudUnused(prisma: Prisma.TenancyGetPayload<{}>) {
 
   const projectCrud = await getProject(prisma.projectId) ?? throwErr("Project in tenancy not found");
 
-  const config = await rawQuery(globalPrismaClient, getRenderedOrganizationConfigQuery({
-    projectId: projectCrud.id,
-    branchId: prisma.branchId,
-    organizationId: prisma.organizationId,
-  }));
+  const [config, deployedDomains] = await Promise.all([
+    rawQuery(globalPrismaClient, getRenderedOrganizationConfigQuery({
+      projectId: projectCrud.id,
+      branchId: prisma.branchId,
+      organizationId: prisma.organizationId,
+    })),
+    rawQuery(globalPrismaClient, getDeployedDomainsQuery(Prisma.sql`"tenancyId" = ${prisma.id}::uuid`)),
+  ]);
 
   return {
     id: prisma.id,
     config,
+    deployedDomains,
     branchId: prisma.branchId,
     organization: prisma.organizationId === null ? null : {
       // TODO actual organization type
@@ -77,6 +81,47 @@ export async function getSoleTenancyFromProjectBranch(projectOrId: Omit<Projects
  */
 export function getSoleTenancyFromProjectBranchQuery(project: Omit<ProjectsCrud["Admin"]["Read"], "config"> | string, branchId: string, returnNullIfNotFound: true): RawQuery<Promise<Tenancy | null>> {
   return getTenancyFromProjectQuery(typeof project === 'string' ? project : project.id, branchId, null);
+}
+
+type DeployedDomainQueryRow = {
+  origin: unknown;
+};
+
+function getDeployedDomainsQuery(tenancySelector: Prisma.Sql): RawQuery<string[]> {
+  return {
+    supportedPrismaClients: ["global"],
+    readOnlyQuery: true,
+    sql: Prisma.sql`
+      WITH latest_runs AS (
+        SELECT DISTINCT ON ("deploymentServiceId")
+          "vercelDeploymentUrl",
+          "createdAt"
+        FROM "DeploymentRun"
+        WHERE ${tenancySelector}
+          AND "status" = 'READY'
+          AND "vercelDeploymentUrl" IS NOT NULL
+        ORDER BY "deploymentServiceId", "createdAt" DESC
+      )
+      -- Pending custom domains are not trusted until Vercel confirms ownership
+      -- and DNS, otherwise adding an unclaimed hostname would widen redirects.
+      SELECT "hostname" AS "origin"
+      FROM "DeploymentServiceDomain"
+      WHERE ${tenancySelector}
+        AND "verified" = TRUE
+      UNION
+      -- Only the latest successful run's URL is exposed by the deployments
+      -- service URL, so older deployment aliases must not remain trusted.
+      SELECT "vercelDeploymentUrl" AS "origin"
+      FROM latest_runs
+      ORDER BY "origin"
+    `,
+    postProcess: (rows: DeployedDomainQueryRow[]) => rows.map((row) => {
+      if (typeof row.origin !== "string") {
+        throwErr("Expected deployment-domain query to return string origins.");
+      }
+      return row.origin;
+    }),
+  };
 }
 
 export async function getTenancy(tenancyId: string) {
@@ -130,8 +175,21 @@ function getTenancyFromProjectQuery(projectId: string, branchId: string, organiz
         branchId,
         organizationId,
       }),
+      getDeployedDomainsQuery(Prisma.sql`
+        "tenancyId" IN (
+          SELECT "id"
+          FROM "Tenancy"
+          WHERE "projectId" = ${projectId}
+            AND "branchId" = ${branchId}
+            AND ${
+              organizationId === null
+                ? Prisma.sql`"hasNoOrganization" = 'TRUE'`
+                : Prisma.sql`"organizationId" = ${organizationId}`
+            }
+        )
+      `),
     ] as const),
-    async ([tenancyResultPromise, projectResultPromise, configPromise]) => {
+    async ([tenancyResultPromise, projectResultPromise, configPromise, deployedDomains]) => {
       const tenancyResult = await tenancyResultPromise;
 
       if (!tenancyResult) return null;
@@ -162,6 +220,7 @@ function getTenancyFromProjectQuery(projectId: string, branchId: string, organiz
       return {
         id: tenancyResult.id,
         config,
+        deployedDomains,
         branchId: tenancyResult.branchId,
         organization: tenancyResult.organizationId === null ? null : {
           // TODO actual organization type

--- a/apps/backend/src/lib/tenancies.tsx
+++ b/apps/backend/src/lib/tenancies.tsx
@@ -100,7 +100,7 @@ function getDeployedDomainsQuery(tenancySelector: Prisma.Sql): RawQuery<string[]
         WHERE ${tenancySelector}
           AND "status" = 'READY'
           AND "vercelDeploymentUrl" IS NOT NULL
-        ORDER BY "deploymentServiceId", "createdAt" DESC
+        ORDER BY "deploymentServiceId", "createdAt" DESC, "id" DESC
       )
       -- Pending custom domains are not trusted until Vercel confirms ownership
       -- and DNS, otherwise adding an unclaimed hostname would widen redirects.


### PR DESCRIPTION
## Summary

Domains a project deploys through the Deployments app are now trusted for redirect validation automatically, so users no longer have to re-add them on the Domains page.

Deployment domains live in Prisma (`DeploymentServiceDomain`, `DeploymentRun`), not in the config, so they're loaded alongside the tenancy instead of inside validation — `validateRedirectUrl` and friends stay synchronous and DB-free:

```ts
type Tenancy = { ..., deployedDomains: string[] }

getTrustedDomainsForTenancy(tenancy) = [
  ...config.domains.trustedDomains,
  ...deployedOrigins(tenancy),   // normalized to https://<host>
  hostedHandlerDomain,
]
```

The same origins are added to `getOAuthRedirectUrisForTenancy` with `/handler/oauth-callback`.

What counts as deployed:
- custom domains with `verified = TRUE` only — a pending hostname isn't proven to belong to the project yet
- the newest `READY` run URL per service (not simply the newest run, so a later failed deploy doesn't drop the still-live URL)

The query orders its results because `getTenancyFromProject` compares the RawQuery result against the legacy loader with an order-sensitive `deepPlainEquals` in dev.

Coverage gap: the verified-only / latest-READY filtering lives in SQL and isn't covered by a test — there's no existing tenancy fixture, and a DB-backed test would need a full project + tenancy + service + run history setup.


Link to Devin session: https://app.devin.ai/sessions/0449b71b2fd445d4bae8f40cb1a30037
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Automatically trusts verified deployment domains and the latest READY run URLs for redirect validation and OAuth callbacks. Invalid or non-HTTP(S) deployment values are rejected, reported, and skipped.

- **New Features**
  - Load deployed domains via `tenancy.deployedDomains` to keep `validateRedirectUrl` synchronous and DB-free.
  - Normalize deployment domains to HTTPS origins in `getTrustedDomainsForTenancy` and `getOAuthRedirectUrisForTenancy`.

- **Bug Fixes**
  - Stabilized selection of the latest READY run per service by ordering with `createdAt` and `id`, and ordering results for deterministic comparisons.
  - Explicitly reject non-HTTP(S) schemes and empty hosts in deployment values; capture and report invalid entries.

<sup>Written for commit eb918aa393827baa2958ff827e5ce46328875965. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1817?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Redirect URL trust now also considers verified custom domains and the latest deployed domains for a tenancy.
  - OAuth callback URLs now include handler routes for supported deployed origins.
- **Bug Fixes**
  - Redirect validation no longer trusts unverified, malformed, or currently-unavailable deployed domains.
  - The latest deployed domain values are used when deciding whether a redirect is allowed.
- **Tests**
  - Added tests covering deployed-domain redirect validation and generated OAuth callback handlers.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->