### PR TITLE
Migrate hosted components to built-with-hexclave.com

### DIFF
--- a/apps/backend/src/lib/redirect-urls.test.tsx
+++ b/apps/backend/src/lib/redirect-urls.test.tsx
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { getOAuthRedirectUrisForTenancy, validateRedirectHostname, isAcceptedNativeAppUrl, validateRedirectUrl } from './redirect-urls';
+import { getHostedHandlerTrustedDomains, getOAuthRedirectUrisForTenancy, validateRedirectHostname, isAcceptedNativeAppUrl, validateRedirectUrl } from './redirect-urls';
 import { Tenancy } from './tenancies';
 
 describe('validateRedirectUrl', () => {
@@ -81,6 +81,8 @@ describe('validateRedirectUrl', () => {
 
         expect(validateRedirectUrl('http://12345678-1234-4234-8234-123456789abc.localhost:9209/anything', tenancy)).toBe(true);
         expect(validateRedirectUrl('http://other-project.localhost:9209/anything', tenancy)).toBe(false);
+        expect(validateRedirectUrl('https://12345678-1234-4234-8234-123456789abc.built-with-hexclave.com/anything', tenancy)).toBe(false);
+        expect(validateRedirectUrl('https://12345678-1234-4234-8234-123456789abc.built-with-stack-auth.com/anything', tenancy)).toBe(false);
       });
     });
 
@@ -118,13 +120,14 @@ describe('validateRedirectUrl', () => {
         expect(getOAuthRedirectUrisForTenancy(tenancy)).toMatchInlineSnapshot(`
           [
             "https://example.com/handler",
+            "https://12345678-1234-4234-8234-123456789abc.built-with-hexclave.com/handler/oauth-callback",
             "https://12345678-1234-4234-8234-123456789abc.built-with-stack-auth.com/handler/oauth-callback",
           ]
         `);
       });
     });
 
-    it('should validate Turnstile hostnames through the same trusted domains', () => {
+    it('should trust both current and legacy cloud hosted handler domains', () => {
       withHostedHandlerEnv({}, () => {
         const tenancy = createMockTenancy({
           domains: {
@@ -136,8 +139,22 @@ describe('validateRedirectUrl', () => {
         });
 
         expect(validateRedirectHostname('app.example.com', tenancy)).toBe(true);
+        expect(validateRedirectHostname('12345678-1234-4234-8234-123456789abc.built-with-hexclave.com', tenancy)).toBe(true);
         expect(validateRedirectHostname('12345678-1234-4234-8234-123456789abc.built-with-stack-auth.com', tenancy)).toBe(true);
+        expect(validateRedirectHostname('other-project.built-with-hexclave.com', tenancy)).toBe(false);
+        expect(validateRedirectHostname('other-project.built-with-stack-auth.com', tenancy)).toBe(false);
         expect(validateRedirectHostname('evil.example.test', tenancy)).toBe(false);
+      });
+    });
+
+    it('should trust both cloud domains while the legacy domain is still configured as canonical', () => {
+      withHostedHandlerEnv({
+        hostedHandlerDomainSuffix: ".built-with-stack-auth.com",
+      }, () => {
+        expect(getHostedHandlerTrustedDomains("12345678-1234-4234-8234-123456789abc")).toEqual([
+          "https://12345678-1234-4234-8234-123456789abc.built-with-stack-auth.com",
+          "https://12345678-1234-4234-8234-123456789abc.built-with-hexclave.com",
+        ]);
       });
     });
 

--- a/apps/backend/src/lib/redirect-urls.tsx
+++ b/apps/backend/src/lib/redirect-urls.tsx
@@ -4,13 +4,37 @@ import { Tenancy } from "./tenancies";
 
 export { isAcceptedNativeAppUrl };
 
+const currentCloudHostedHandlerDomainSuffix = ".built-with-hexclave.com";
+const legacyCloudHostedHandlerDomainSuffix = ".built-with-stack-auth.com";
+
 export function getHostedHandlerTrustedDomain(projectId: string): string {
   return getHostedHandlerTrustedDomainFromConfig({
     projectId,
-    hostedHandlerDomainSuffix: getProcessEnv("NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX"),
-    hostedHandlerUrlTemplate: getProcessEnv("NEXT_PUBLIC_STACK_HOSTED_HANDLER_URL_TEMPLATE"),
+    hostedHandlerDomainSuffix: getProcessEnv("NEXT_PUBLIC_HEXCLAVE_HOSTED_HANDLER_DOMAIN_SUFFIX"),
+    hostedHandlerUrlTemplate: getProcessEnv("NEXT_PUBLIC_HEXCLAVE_HOSTED_HANDLER_URL_TEMPLATE"),
     hexclavePortPrefix: getEnvVariable("NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX", "81"),
   });
+}
+
+export function getHostedHandlerTrustedDomains(projectId: string): string[] {
+  const configuredOrigin = getHostedHandlerTrustedDomain(projectId);
+  const currentCloudOrigin = getHostedHandlerTrustedDomainFromConfig({
+    projectId,
+    hostedHandlerDomainSuffix: currentCloudHostedHandlerDomainSuffix,
+  });
+  const legacyCloudOrigin = getHostedHandlerTrustedDomainFromConfig({
+    projectId,
+    hostedHandlerDomainSuffix: legacyCloudHostedHandlerDomainSuffix,
+  });
+
+  // Old SDKs have the Stack Auth hostname compiled into their default hosted
+  // URLs. Trust both cloud origins during the domain migration, regardless of
+  // which one is configured as canonical, but do not add cloud origins to a
+  // custom/self-hosted handler configuration.
+  if (configuredOrigin === currentCloudOrigin || configuredOrigin === legacyCloudOrigin) {
+    return [...new Set([configuredOrigin, currentCloudOrigin, legacyCloudOrigin])];
+  }
+  return [configuredOrigin];
 }
 
 export function getTrustedDomainsForTenancy(tenancy: Tenancy): string[] {
@@ -18,7 +42,7 @@ export function getTrustedDomainsForTenancy(tenancy: Tenancy): string[] {
     ...Object.values(tenancy.config.domains.trustedDomains)
       .map(domain => domain.baseUrl)
       .filter((baseUrl): baseUrl is string => baseUrl != null),
-    getHostedHandlerTrustedDomain(tenancy.project.id),
+    ...getHostedHandlerTrustedDomains(tenancy.project.id),
   ];
 }
 
@@ -27,7 +51,8 @@ export function getOAuthRedirectUrisForTenancy(tenancy: Tenancy): string[] {
     ...Object.values(tenancy.config.domains.trustedDomains)
       .filter((domain) => domain.baseUrl)
       .map((domain) => new URL(domain.handlerPath, domain.baseUrl).toString()),
-    new URL("/handler/oauth-callback", getHostedHandlerTrustedDomain(tenancy.project.id)).toString(),
+    ...getHostedHandlerTrustedDomains(tenancy.project.id)
+      .map((domain) => new URL("/handler/oauth-callback", domain).toString()),
   ];
 }
 

--- a/apps/hosted-components/src/hosted-components/auth/supporting/no-auth-methods.tsx
+++ b/apps/hosted-components/src/hosted-components/auth/supporting/no-auth-methods.tsx
@@ -4,8 +4,8 @@ import { Typography } from "~/components/ui";
 
 import { HostedAuthShell } from "./layout";
 
-// The hosted components are only ever served by Hexclave Cloud (<projectId>.built-with-hexclave.com),
-// so we can hardcode the cloud dashboard here; self-hosters use the SDK components instead.
+// The hosted components are only ever served by Hexclave Cloud (on the current or legacy hosted
+// subdomain), so we can hardcode the cloud dashboard here; self-hosters use the SDK components instead.
 const HOSTED_DASHBOARD_URL = "https://app.hexclave.com";
 
 const configSnippet = `auth: {

--- a/apps/hosted-components/src/routes/__root.tsx
+++ b/apps/hosted-components/src/routes/__root.tsx
@@ -19,7 +19,8 @@ import '../styles.css';
 
 
 export function getProjectId(): string | null {
-  // Extract from subdomain: <projectId>.built-with-hexclave.com
+  // Extract from either cloud subdomain:
+  // <projectId>.built-with-hexclave.com or the legacy <projectId>.built-with-stack-auth.com.
   // Also works with <projectId>.localhost for local dev
   const hostname = window.location.hostname;
   const parts = hostname.split('.');

--- a/docs-mintlify/migration.mdx
+++ b/docs-mintlify/migration.mdx
@@ -47,7 +47,7 @@ All legacy names keep working — rename only if you want your code to match the
 - **Environment variables**: `STACK_*` → `HEXCLAVE_*`.
 - **Bearer prefix**: `stackauth_*` tokens remain valid.
 - **CLI binary**: both `stack` and `hexclave` ship with `@hexclave/cli`.
-- **Hosted-handler subdomain**: `.built-with-stack-auth.com` still works.
+- **Hosted-handler subdomain**: current SDKs use `.built-with-hexclave.com`. The legacy `.built-with-stack-auth.com` domain remains available for SDK versions that already generated those URLs. Passkeys are scoped to the domain where they were registered and are not transferred between the two domains.
 
 ## Other
 

--- a/packages/shared/src/utils/redirect-urls.tsx
+++ b/packages/shared/src/utils/redirect-urls.tsx
@@ -6,7 +6,7 @@ type TrustedDomainConfig = {
   trustedDomains: readonly (string | null | undefined)[],
 };
 
-const defaultHostedHandlerDomainSuffix = ".built-with-stack-auth.com";
+const defaultHostedHandlerDomainSuffix = ".built-with-hexclave.com";
 const hostedHandlerProjectIdPlaceholder = "{projectId}";
 const hostedHandlerPathPlaceholder = "{hostedPath}";
 const defaultPorts = new Map<string, string>([['https:', '443'], ['http:', '80']]);
@@ -30,7 +30,7 @@ function assertHostedHandlerTemplateHasProjectOrigin(template: string): void {
   if (projectUrlA.origin === projectUrlB.origin || !projectUrlA.hostname.includes(hostedHandlerTemplateProjectIdA)) {
     throw new HexclaveAssertionError("The hosted handler URL template must put {projectId} in the hostname.", {
       hostedHandlerUrlTemplate: template,
-      hint: "Use a project-specific origin like 'https://{projectId}.built-with-stack-auth.com/{hostedPath}', not a shared-origin path like 'https://example.com/{projectId}/{hostedPath}'.",
+      hint: "Use a project-specific origin like 'https://{projectId}.built-with-hexclave.com/{hostedPath}', not a shared-origin path like 'https://example.com/{projectId}/{hostedPath}'.",
     });
   }
 }
@@ -61,7 +61,7 @@ export function getHostedHandlerUrlFromConfig(options: {
       if (!domainSuffix.startsWith(".")) {
         throw new HexclaveAssertionError("The hosted handler domain suffix must start with a dot.", {
           domainSuffix,
-          hint: "Set NEXT_PUBLIC_STACK_HOSTED_HANDLER_DOMAIN_SUFFIX to a value like '.built-with-stack-auth.com'.",
+          hint: "Set NEXT_PUBLIC_HEXCLAVE_HOSTED_HANDLER_DOMAIN_SUFFIX to a value like '.built-with-hexclave.com'.",
         });
       }
       return `https://${options.projectId}${domainSuffix}/${options.hostedPath}`;
@@ -70,7 +70,7 @@ export function getHostedHandlerUrlFromConfig(options: {
       if (!configuredTemplate.includes(hostedHandlerProjectIdPlaceholder) || !configuredTemplate.includes(hostedHandlerPathPlaceholder)) {
         throw new HexclaveAssertionError("The hosted handler URL template must contain {projectId} and {hostedPath}.", {
           hostedHandlerUrlTemplate: configuredTemplate,
-          hint: "Set NEXT_PUBLIC_STACK_HOSTED_HANDLER_URL_TEMPLATE to a value like 'https://{projectId}.built-with-stack-auth.com/{hostedPath}'.",
+          hint: "Set NEXT_PUBLIC_HEXCLAVE_HOSTED_HANDLER_URL_TEMPLATE to a value like 'https://{projectId}.built-with-hexclave.com/{hostedPath}'.",
         });
       }
       assertHostedHandlerTemplateHasProjectOrigin(configuredTemplate);
@@ -220,11 +220,11 @@ import.meta.vitest?.test("validateRedirectUrl matches exact and wildcard trusted
 
 import.meta.vitest?.test("validateRedirectUrl trusts implicit hosted handler domains", ({ expect }) => {
   const projectId = "12345678-1234-4234-8234-123456789abc";
-  expect(validateRedirectUrl(`https://${projectId}.built-with-stack-auth.com/anything`, {
+  expect(validateRedirectUrl(`https://${projectId}.built-with-hexclave.com/anything`, {
     allowLocalhost: false,
     trustedDomains: getImplicitlyTrustedDomainsForProject({ projectId }),
   })).toBe(true);
-  expect(validateRedirectUrl("https://other-project.built-with-stack-auth.com/anything", {
+  expect(validateRedirectUrl("https://other-project.built-with-hexclave.com/anything", {
     allowLocalhost: false,
     trustedDomains: getImplicitlyTrustedDomainsForProject({ projectId }),
   })).toBe(false);

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -531,7 +531,7 @@ describe("StackClientApp cross-domain auth", () => {
     }
 
     const errorUrl = new URL(redirectedUrl);
-    expect(errorUrl.origin).toBe(`https://${projectId}.built-with-stack-auth.com`);
+    expect(errorUrl.origin).toBe(`https://${projectId}.built-with-hexclave.com`);
     expect(errorUrl.pathname).toBe("/handler/error");
     expect(errorUrl.searchParams.get("errorCode")).toBe("SIGN_UP_REJECTED");
     expect(errorUrl.searchParams.get("message")).toBe("Your sign up was rejected by an administrator's sign-up rule.");
@@ -711,7 +711,7 @@ describe("StackClientApp cross-domain auth", () => {
     redirectBackUrl.searchParams.set("hexclave_cross_domain_code_challenge", handoffCodeChallenge);
     redirectBackUrl.searchParams.set("hexclave_cross_domain_after_callback_redirect_url", handoffAfterCallbackRedirect);
 
-    const arrivalUrl = new URL(`https://${projectId}.built-with-stack-auth.com/handler/sign-in`);
+    const arrivalUrl = new URL(`https://${projectId}.built-with-hexclave.com/handler/sign-in`);
     arrivalUrl.searchParams.set("after_auth_return_to", redirectBackUrl.toString());
     arrivalUrl.searchParams.set("hexclave_cross_domain_state", handoffState);
     arrivalUrl.searchParams.set("hexclave_cross_domain_code_challenge", handoffCodeChallenge);
@@ -750,7 +750,7 @@ describe("StackClientApp cross-domain auth", () => {
         .mockResolvedValue(crossDomainAuthorizeRedirect);
 
       // All redirect-back query params were dropped before the after-sign-in redirect.
-      windowMock.location.href = `https://${projectId}.built-with-stack-auth.com/handler/sign-in`;
+      windowMock.location.href = `https://${projectId}.built-with-hexclave.com/handler/sign-in`;
 
       const redirectUrl = await clientApp[hexclaveAppInternalsSymbol].getRedirectToHandlerUrl("afterSignIn");
 

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -59,6 +59,7 @@ import { EditableTeamMemberProfile, ReceivedTeamInvitation, SentTeamInvitation, 
 import { buildCliAuthConfirmUrl, getHostedHandlerUrl, isHostedHandlerUrlForProject, resolveHandlerUrls } from "../../url-targets";
 import { augmentUrlWithPersistedRedirectBackState, saveRedirectBackStateFromUrl } from "./redirect-back-state";
 import { recordRedirectAndThrowIfLoopDetected } from "./redirect-loop-breaker";
+import { scopePasskeyAuthenticationToHostname, scopePasskeyRegistrationToHostname } from "../../passkey-rp-id";
 import { ActiveSession, Auth, BaseUser, CurrentUser, InternalUserExtra, OAuthProvider, ProjectCurrentUser, SyncedPartialUser, TokenPartialUser, UserExtra, UserUpdateOptions, userUpdateOptionsToCrud, withUserDestructureGuard } from "../../users";
 import { StackClientApp, StackClientAppConstructorOptions, StackClientAppJson } from "../interfaces/client-app";
 import { _HexclaveAdminAppImplIncomplete } from "./admin-app-impl";
@@ -2513,12 +2514,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
 
         const { options_json, code } = initiationResult.data;
 
-        // HACK: Override the rpID to be the actual domain
-        if (options_json.rp.id !== "THIS_VALUE_WILL_BE_REPLACED.example.com") {
-          throw new HexclaveAssertionError(`Expected returned RP ID from server to equal sentinel, but found ${options_json.rp.id}`);
-        }
-
-        options_json.rp.id = hostname;
+        // Passkeys intentionally stay scoped to the hostname where they were
+        // registered. In particular, passkeys created on the legacy hosted
+        // components domain continue to work there but are not carried over to
+        // a replacement hosted domain.
+        scopePasskeyRegistrationToHostname(options_json, hostname);
 
         let attResp;
         try {
@@ -3882,11 +3882,10 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
 
         const { options_json, code } = initiationResult.data;
 
-        // HACK: Override the rpID to be the actual domain
-        if (options_json.rpId !== "THIS_VALUE_WILL_BE_REPLACED.example.com") {
-          throw new HexclaveAssertionError(`Expected returned RP ID from server to equal sentinel, but found ${options_json.rpId}`);
-        }
-        options_json.rpId = window.location.hostname;
+        // Keep authentication scoped to the current hostname. This deliberately
+        // does not add cross-domain compatibility for passkeys created on a
+        // previous hosted components domain.
+        scopePasskeyAuthenticationToHostname(options_json, window.location.hostname);
 
         const authentication_response = await startAuthentication({ optionsJSON: options_json });
         return await this._interface.signInWithPasskey({ authentication_response, code }, session);

--- a/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
@@ -32,6 +32,7 @@ import { Customer, CustomerProductsList, CustomerProductsRequestOptions, InlineP
 import { DataVaultStore } from "../../data-vault";
 import { EmailDeliveryInfo, SendEmailOptions } from "../../email";
 import { NotificationCategory } from "../../notification-categories";
+import { scopePasskeyRegistrationToHostname } from "../../passkey-rp-id";
 import { AdminProjectPermissionDefinition, AdminTeamPermission, AdminTeamPermissionDefinition } from "../../permissions";
 import { EditableTeamMemberProfile, ReceivedTeamInvitation, SentTeamInvitation, ServerListTeamsOptions, ServerListUsersOptions, ServerTeam, ServerTeamCreateOptions, ServerTeamUpdateOptions, ServerTeamUser, Team, serverTeamCreateOptionsToCrud, serverTeamUpdateOptionsToCrud } from "../../teams";
 import { ProjectCurrentServerUser, ServerOAuthProvider, ServerUser, ServerUserCreateOptions, ServerUserUpdateOptions, serverUserCreateOptionsToCrud, serverUserUpdateOptionsToCrud, withUserDestructureGuard } from "../../users";
@@ -935,7 +936,6 @@ export class _HexclaveServerAppImplIncomplete<HasTokenStore extends boolean, Pro
         return providers.find((p) => p.id === id) ?? null;
       },
       async registerPasskey(options?: { hostname?: string }): Promise<Result<undefined, KnownErrors["PasskeyRegistrationFailed"] | KnownErrors["PasskeyWebAuthnError"]>> {
-        // TODO remove duplicated code between this and the function in client-app-impl.ts
         const hostname = options?.hostname || (await app._getCurrentUrl())?.hostname;
         if (!hostname) {
           throw new HexclaveAssertionError("hostname must be provided if the Stack App does not have a redirect method");
@@ -950,12 +950,7 @@ export class _HexclaveServerAppImplIncomplete<HasTokenStore extends boolean, Pro
 
         const { options_json, code } = initiationResult.data;
 
-        // HACK: Override the rpID to be the actual domain
-        if (options_json.rp.id !== "THIS_VALUE_WILL_BE_REPLACED.example.com") {
-          throw new HexclaveAssertionError(`Expected returned RP ID from server to equal sentinel, but found ${options_json.rp.id}`);
-        }
-
-        options_json.rp.id = hostname;
+        scopePasskeyRegistrationToHostname(options_json, hostname);
 
         let attResp;
         try {

--- a/packages/template/src/lib/hexclave-app/passkey-rp-id.test.ts
+++ b/packages/template/src/lib/hexclave-app/passkey-rp-id.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from "vitest";
+import { scopePasskeyAuthenticationToHostname, scopePasskeyRegistrationToHostname } from "./passkey-rp-id";
+
+const passkeyRpIdSentinel = "THIS_VALUE_WILL_BE_REPLACED.example.com";
+
+describe.each([
+  "project-id.built-with-hexclave.com",
+  "project-id.built-with-stack-auth.com",
+])("passkeys on %s", (hostname) => {
+  it("scopes registration to the current hostname", () => {
+    const options = { rp: { id: passkeyRpIdSentinel } };
+
+    scopePasskeyRegistrationToHostname(options, hostname);
+
+    expect(options.rp.id).toBe(hostname);
+  });
+
+  it("scopes authentication to the current hostname", () => {
+    const options = { rpId: passkeyRpIdSentinel };
+
+    scopePasskeyAuthenticationToHostname(options, hostname);
+
+    expect(options.rpId).toBe(hostname);
+  });
+});
+
+it("rejects registration options without the server sentinel", () => {
+  expect(() => scopePasskeyRegistrationToHostname(
+    { rp: { id: "unexpected.example.com" } },
+    "project-id.built-with-hexclave.com",
+  )).toThrow("Expected returned RP ID from server to equal sentinel");
+});
+
+it("rejects authentication options without the server sentinel", () => {
+  expect(() => scopePasskeyAuthenticationToHostname(
+    { rpId: "unexpected.example.com" },
+    "project-id.built-with-hexclave.com",
+  )).toThrow("Expected returned RP ID from server to equal sentinel");
+});

--- a/packages/template/src/lib/hexclave-app/passkey-rp-id.ts
+++ b/packages/template/src/lib/hexclave-app/passkey-rp-id.ts
@@ -1,0 +1,23 @@
+import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+
+const passkeyRpIdSentinel = "THIS_VALUE_WILL_BE_REPLACED.example.com";
+
+export function scopePasskeyRegistrationToHostname(
+  options: { rp: { id?: string } },
+  hostname: string,
+): void {
+  if (options.rp.id !== passkeyRpIdSentinel) {
+    throw new HexclaveAssertionError(`Expected returned RP ID from server to equal sentinel, but found ${options.rp.id}`);
+  }
+  options.rp.id = hostname;
+}
+
+export function scopePasskeyAuthenticationToHostname(
+  options: { rpId?: string },
+  hostname: string,
+): void {
+  if (options.rpId !== passkeyRpIdSentinel) {
+    throw new HexclaveAssertionError(`Expected returned RP ID from server to equal sentinel, but found ${options.rpId}`);
+  }
+  options.rpId = hostname;
+}


### PR DESCRIPTION
## Summary

- change the default hosted-components domain from `*.built-with-stack-auth.com` to `*.built-with-hexclave.com`
- keep the backend compatible with exact project-specific callbacks and redirects on both the current and legacy cloud domains
- keep custom and self-hosted handler configurations isolated from the cloud compatibility behavior
- explicitly retain hostname-scoped passkey behavior, with shared registration/authentication RP-ID handling and coverage for both domains
- update hosted-components comments and migration documentation

## Impact

Current SDK builds generate hosted-component URLs on `*.built-with-hexclave.com`. Existing URLs generated by legacy SDKs continue to work on `*.built-with-stack-auth.com`. Passkeys are not transferred between domains; credentials remain usable only on the hostname where they were registered.

## Rollout requirements

1. Attach and verify `*.built-with-hexclave.com` and TLS on the hosted-components deployment.
2. Keep `*.built-with-stack-auth.com` attached to the same deployment and do not redirect it.
3. Deploy the backend dual-domain trust changes.
4. Audit and remove/update explicit `NEXT_PUBLIC_{HEXCLAVE,STACK}_HOSTED_HANDLER_{DOMAIN_SUFFIX,URL_TEMPLATE}` overrides. Conflicting old/new spellings fail fast.
5. Redeploy SDK-consuming builds, then publish SDKs with the new default.

## Validation

- `pnpm typecheck`
- affected-package lint for backend, shared/template SDK code, and hosted components
- focused URL, redirect, OAuth callback, cross-domain handoff, and passkey tests
- `pnpm build:packages`
- `pnpm -C packages/template build`
- three independent code reviews, including a final review after fixes

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Migrate hosted components and SDK defaults to `.built-with-hexclave.com` while keeping `.built-with-stack-auth.com` working. Redirects and OAuth trust both domains; passkeys remain scoped to the hostname where they were registered.

- **New Features**
  - Default hosted handler origin switched to `.built-with-hexclave.com`; backend trusts both cloud domains.
  - OAuth callback URIs generated for both domains.
  - Passkey RP-ID explicitly scoped to the current hostname via `scopePasskeyRegistrationToHostname` and `scopePasskeyAuthenticationToHostname`.
  - Hosted components read the project ID from either subdomain; migration docs updated with domain change and passkey behavior.

- **Migration**
  - Attach and verify `*.built-with-hexclave.com` (keep `*.built-with-stack-auth.com` attached; no redirect).
  - Deploy backend dual-domain trust, then redeploy SDK consumers and publish with new defaults.
  - Audit and remove conflicting `NEXT_PUBLIC_{HEXCLAVE,STACK}_HOSTED_HANDLER_{DOMAIN_SUFFIX,URL_TEMPLATE}` overrides.

<sup>Written for commit aaa71f02ff5448d80efbe77cb0a5e39bd642cbfe. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1819?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for current and legacy hosted-handler domains during domain migration.
  - OAuth redirect URLs now include supported hosted callback domains.
  - Passkey registration and authentication are scoped to the active hostname.

- **Bug Fixes**
  - Improved redirect and hostname validation across supported hosted domains.
  - Preserved compatibility with projects using legacy hosted URLs.

- **Documentation**
  - Clarified hosted-domain migration behavior and passkey domain scoping.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->