### PR TITLE
feat(hosted-components): development-only page note with customization prompt

### DIFF
--- a/apps/hosted-components/src/components/development-page-note.tsx
+++ b/apps/hosted-components/src/components/development-page-note.tsx
@@ -1,7 +1,7 @@
 import { useStackApp } from "@hexclave/react";
 import { getCustomPagePrompts } from "@hexclave/shared/dist/interface/handler-urls";
 import { Code2, X } from "lucide-react";
-import { useEffect, useState } from "react";
+import { useEffect, useRef, useState } from "react";
 
 import { Badge, Button, CopyButton } from "~/components/ui";
 
@@ -32,6 +32,7 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
   const project = useStackApp().useProject();
   const [dismissed, setDismissed] = useState<boolean | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
+  const noteRef = useRef<HTMLElement>(null);
 
   useEffect(() => {
     let wasDismissed = false;
@@ -45,6 +46,38 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
     }
     setDismissed(wasDismissed);
   }, []);
+
+  useEffect(() => {
+    const note = noteRef.current;
+    if (note == null) {
+      return;
+    }
+
+    const root = document.documentElement;
+    const updateNoteHeight = () => {
+      root.style.setProperty(
+        "--hexclave-development-page-note-height",
+        `${note.getBoundingClientRect().height}px`,
+      );
+      root.dataset.hexclaveDevelopmentPageNoteVisible = "true";
+    };
+
+    updateNoteHeight();
+    if (typeof ResizeObserver === "undefined") {
+      return () => {
+        root.style.removeProperty("--hexclave-development-page-note-height");
+        delete root.dataset.hexclaveDevelopmentPageNoteVisible;
+      };
+    }
+
+    const observer = new ResizeObserver(updateNoteHeight);
+    observer.observe(note);
+    return () => {
+      observer.disconnect();
+      root.style.removeProperty("--hexclave-development-page-note-height");
+      delete root.dataset.hexclaveDevelopmentPageNoteVisible;
+    };
+  }, [dismissed, showPrompt]);
 
   if (!project.isDevelopmentEnvironment || dismissed !== false) {
     return null;
@@ -60,6 +93,7 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
   return (
     <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-5 sm:pb-[calc(1.25rem+env(safe-area-inset-bottom))]">
       <section
+        ref={noteRef}
         aria-label="Development information"
         className="pointer-events-auto max-h-[60vh] w-full max-w-[640px] overflow-hidden rounded-2xl border border-black/[0.09] bg-white/90 p-4 text-foreground shadow-xl shadow-black/[0.08] backdrop-blur-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200 dark:border-white/[0.12] dark:bg-zinc-950/90 dark:shadow-black/30 sm:p-5"
       >

--- a/apps/hosted-components/src/components/development-page-note.tsx
+++ b/apps/hosted-components/src/components/development-page-note.tsx
@@ -1,7 +1,7 @@
 import { useStackApp } from "@hexclave/react";
 import { getCustomPagePrompts } from "@hexclave/shared/dist/interface/handler-urls";
 import { Code2, X } from "lucide-react";
-import { useState } from "react";
+import { useEffect, useState } from "react";
 
 import { Badge, Button, CopyButton } from "~/components/ui";
 
@@ -30,12 +30,23 @@ const customPagePrompts = getCustomPagePrompts();
 
 export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
   const project = useStackApp().useProject();
-  const [dismissed, setDismissed] = useState(
-    () => typeof window !== "undefined" && sessionStorage.getItem(DISMISSED_STORAGE_KEY) === "true",
-  );
+  const [dismissed, setDismissed] = useState<boolean | null>(null);
   const [showPrompt, setShowPrompt] = useState(false);
 
-  if (!project.isDevelopmentEnvironment || dismissed) {
+  useEffect(() => {
+    let wasDismissed = false;
+    if (typeof window !== "undefined") {
+      // Storage may be unavailable in partitioned or third-party browser contexts.
+      try {
+        wasDismissed = window.sessionStorage.getItem(DISMISSED_STORAGE_KEY) === "true";
+      } catch {
+        wasDismissed = false;
+      }
+    }
+    setDismissed(wasDismissed);
+  }, []);
+
+  if (!project.isDevelopmentEnvironment || dismissed !== false) {
     return null;
   }
 
@@ -71,7 +82,12 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
             size="icon"
             className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground"
             onClick={() => {
-              sessionStorage.setItem(DISMISSED_STORAGE_KEY, "true");
+              // Storage may be unavailable in partitioned or third-party browser contexts.
+              try {
+                window.sessionStorage.setItem(DISMISSED_STORAGE_KEY, "true");
+              } catch {
+                // Keep the dismissal in memory when browser storage is unavailable.
+              }
               setDismissed(true);
             }}
           >

--- a/apps/hosted-components/src/components/development-page-note.tsx
+++ b/apps/hosted-components/src/components/development-page-note.tsx
@@ -1,0 +1,112 @@
+import { useStackApp } from "@hexclave/react";
+import { getCustomPagePrompts } from "@hexclave/shared/dist/interface/handler-urls";
+import { Code2, X } from "lucide-react";
+import { useState } from "react";
+
+import { Badge, Button, CopyButton } from "~/components/ui";
+
+export type DevelopmentPageKey =
+  | "signIn"
+  | "signUp"
+  | "forgotPassword"
+  | "passwordReset"
+  | "emailVerification"
+  | "accountSettings"
+  | "mfa"
+  | "error"
+  | "teamInvitation"
+  | "cliAuthConfirm"
+  | "onboarding";
+
+type DevelopmentPageNoteProps = {
+  pageKey?: DevelopmentPageKey,
+  pageTitle?: string,
+  description?: string,
+};
+
+const DISMISSED_STORAGE_KEY = "hexclave-development-page-note-dismissed";
+
+const customPagePrompts = getCustomPagePrompts();
+
+export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
+  const project = useStackApp().useProject();
+  const [dismissed, setDismissed] = useState(
+    () => typeof window !== "undefined" && sessionStorage.getItem(DISMISSED_STORAGE_KEY) === "true",
+  );
+  const [showPrompt, setShowPrompt] = useState(false);
+
+  if (!project.isDevelopmentEnvironment || dismissed) {
+    return null;
+  }
+
+  const prompt = props.pageKey == null ? null : customPagePrompts[props.pageKey];
+  const title = props.pageTitle ?? prompt?.title;
+  const description = props.description
+    ?? (title == null
+      ? "This is Hexclave's default hosted page. Configure your own page to customize this experience."
+      : `You’re viewing Hexclave’s default ${title} page. Customize it by pasting the prompt below into your coding agent.`);
+
+  return (
+    <div className="pointer-events-none fixed inset-x-0 bottom-0 z-50 flex justify-center px-3 pb-[calc(0.75rem+env(safe-area-inset-bottom))] sm:px-5 sm:pb-[calc(1.25rem+env(safe-area-inset-bottom))]">
+      <section
+        aria-label="Development information"
+        className="pointer-events-auto max-h-[60vh] w-full max-w-[640px] overflow-hidden rounded-2xl border border-black/[0.09] bg-white/90 p-4 text-foreground shadow-xl shadow-black/[0.08] backdrop-blur-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200 dark:border-white/[0.12] dark:bg-zinc-950/90 dark:shadow-black/30 sm:p-5"
+      >
+        <div className="flex items-start gap-3">
+          <div className="min-w-0 flex-1">
+            <div className="flex items-center gap-2">
+              <Code2 className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <p className="text-sm font-semibold tracking-tight">Development info</p>
+              <Badge variant="secondary" className="rounded-full px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+                Not visible in production
+              </Badge>
+            </div>
+            <p className="mt-2 text-xs leading-relaxed text-muted-foreground sm:text-sm">
+              {description}
+            </p>
+          </div>
+          <Button
+            aria-label="Dismiss development information"
+            variant="ghost"
+            size="icon"
+            className="h-7 w-7 shrink-0 rounded-lg text-muted-foreground"
+            onClick={() => {
+              sessionStorage.setItem(DISMISSED_STORAGE_KEY, "true");
+              setDismissed(true);
+            }}
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+
+        {prompt != null && (
+          <div className="mt-4 flex flex-wrap items-center gap-2">
+            <CopyButton
+              aria-label="Copy customization prompt"
+              content={prompt.fullPrompt}
+              size="sm"
+              className="h-8 rounded-lg px-3 text-xs"
+            >
+              Copy prompt
+            </CopyButton>
+            <Button
+              variant="ghost"
+              size="sm"
+              className="h-8 rounded-lg px-3 text-xs"
+              aria-expanded={showPrompt}
+              onClick={() => setShowPrompt((current) => !current)}
+            >
+              {showPrompt ? "Hide prompt" : "Show prompt"}
+            </Button>
+          </div>
+        )}
+
+        {prompt != null && showPrompt && (
+          <pre className="mt-4 max-h-[calc(60vh-10rem)] overflow-y-auto whitespace-pre-wrap break-words rounded-xl border border-black/[0.08] bg-black/[0.025] p-3 text-[11px] leading-[1.55] text-foreground/80 ring-1 ring-inset ring-black/[0.025] dark:border-white/[0.10] dark:bg-white/[0.04] dark:text-foreground/75 dark:ring-white/[0.025]">
+            <code>{prompt.fullPrompt}</code>
+          </pre>
+        )}
+      </section>
+    </div>
+  );
+}

--- a/apps/hosted-components/src/components/development-page-note.tsx
+++ b/apps/hosted-components/src/components/development-page-note.tsx
@@ -95,14 +95,17 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
       <section
         ref={noteRef}
         aria-label="Development information"
-        className="pointer-events-auto max-h-[60vh] w-full max-w-[640px] overflow-hidden rounded-2xl border border-black/[0.09] bg-white/90 p-4 text-foreground shadow-xl shadow-black/[0.08] backdrop-blur-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200 dark:border-white/[0.12] dark:bg-zinc-950/90 dark:shadow-black/30 sm:p-5"
+        className="pointer-events-auto max-h-[60vh] w-full max-w-[640px] overflow-hidden rounded-2xl border border-blue-200/70 bg-blue-50/90 p-4 text-foreground shadow-xl shadow-blue-950/[0.08] backdrop-blur-xl animate-in fade-in-0 slide-in-from-bottom-2 duration-200 dark:border-blue-400/[0.22] dark:bg-blue-950/80 dark:shadow-blue-950/40 sm:p-5"
       >
         <div className="flex items-start gap-3">
           <div className="min-w-0 flex-1">
             <div className="flex items-center gap-2">
-              <Code2 className="h-4 w-4 shrink-0 text-muted-foreground" aria-hidden="true" />
+              <Code2 className="h-4 w-4 shrink-0 text-blue-600 dark:text-blue-300" aria-hidden="true" />
               <p className="text-sm font-semibold tracking-tight">Development info</p>
-              <Badge variant="secondary" className="rounded-full px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.08em] text-muted-foreground">
+              <Badge
+                variant="secondary"
+                className="rounded-full border border-blue-200/70 bg-blue-100/60 px-2 py-0.5 text-[9px] font-medium uppercase tracking-[0.08em] text-blue-700 dark:border-blue-400/20 dark:bg-blue-400/10 dark:text-blue-200"
+              >
                 Not visible in production
               </Badge>
             </div>
@@ -152,7 +155,7 @@ export function DevelopmentPageNote(props: DevelopmentPageNoteProps) {
         )}
 
         {prompt != null && showPrompt && (
-          <pre className="mt-4 max-h-[calc(60vh-10rem)] overflow-y-auto whitespace-pre-wrap break-words rounded-xl border border-black/[0.08] bg-black/[0.025] p-3 text-[11px] leading-[1.55] text-foreground/80 ring-1 ring-inset ring-black/[0.025] dark:border-white/[0.10] dark:bg-white/[0.04] dark:text-foreground/75 dark:ring-white/[0.025]">
+          <pre className="mt-4 max-h-[calc(60vh-10rem)] overflow-y-auto whitespace-pre-wrap break-words rounded-xl border border-blue-200/70 bg-blue-100/40 p-3 text-[11px] leading-[1.55] text-foreground/80 ring-1 ring-inset ring-blue-200/40 dark:border-blue-400/[0.18] dark:bg-blue-900/30 dark:text-foreground/75 dark:ring-blue-300/[0.08]">
             <code>{prompt.fullPrompt}</code>
           </pre>
         )}

--- a/apps/hosted-components/src/components/ui/copy-button.tsx
+++ b/apps/hosted-components/src/components/ui/copy-button.tsx
@@ -10,7 +10,7 @@ import { cn } from "./utils";
 const CopyButton = forwardRefIfNeeded<
   HTMLButtonElement,
   ButtonProps & { content: string }
->(({ content, ...props }, ref) => {
+>(({ content, children, ...props }, ref) => {
   const [copied, setCopied] = useState(false);
   const resetTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
 
@@ -26,7 +26,7 @@ const CopyButton = forwardRefIfNeeded<
     <Button
       variant="secondary"
       {...props}
-      className={cn("h-6 w-6 p-1", props.className)}
+      className={cn(children == null ? "h-6 w-6 p-1" : "gap-1.5", props.className)}
       ref={ref}
       onClick={async (...args) => {
         await props.onClick?.(...args);
@@ -39,6 +39,7 @@ const CopyButton = forwardRefIfNeeded<
       }}
     >
       {copied ? <Check className="text-success" /> : <Copy />}
+      {children != null && <span>{children}</span>}
     </Button>
   );
 });

--- a/apps/hosted-components/src/routes/__root.tsx
+++ b/apps/hosted-components/src/routes/__root.tsx
@@ -198,6 +198,12 @@ function RootDocument({ children }: { children: ReactNode }) {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
+        <style>{`
+          html[data-hexclave-development-page-note-visible] [data-hexclave-handler-page] {
+            overflow-y: auto;
+            padding-bottom: var(--hexclave-development-page-note-height);
+          }
+        `}</style>
       </head>
       <body style={{ fontFamily: "'Inter', sans-serif", margin: 0 }}>
         {children}

--- a/apps/hosted-components/src/routes/__root.tsx
+++ b/apps/hosted-components/src/routes/__root.tsx
@@ -198,12 +198,6 @@ function RootDocument({ children }: { children: ReactNode }) {
         <link rel="preconnect" href="https://fonts.googleapis.com" />
         <link rel="preconnect" href="https://fonts.gstatic.com" crossOrigin="anonymous" />
         <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet" />
-        <style>{`
-          html[data-hexclave-development-page-note-visible] [data-hexclave-handler-page] {
-            overflow-y: auto;
-            padding-bottom: var(--hexclave-development-page-note-height);
-          }
-        `}</style>
       </head>
       <body style={{ fontFamily: "'Inter', sans-serif", margin: 0 }}>
         {children}

--- a/apps/hosted-components/src/routes/email-verification-demo.tsx
+++ b/apps/hosted-components/src/routes/email-verification-demo.tsx
@@ -9,7 +9,9 @@ export const Route = createFileRoute('/email-verification-demo')({
 function EmailVerificationDemoPage() {
   return (
     <>
-      <EmailVerification searchParams={{ code: "demo-email-verification-code" }} fullPage />
+      <div data-hexclave-handler-page className="min-h-screen w-full">
+        <EmailVerification searchParams={{ code: "demo-email-verification-code" }} fullPage />
+      </div>
       <DevelopmentPageNote
         pageKey="emailVerification"
         description="This is a demo of Hexclave's default email-verification page. Use the prompt below to customize your own page."

--- a/apps/hosted-components/src/routes/email-verification-demo.tsx
+++ b/apps/hosted-components/src/routes/email-verification-demo.tsx
@@ -1,10 +1,19 @@
 import { EmailVerification } from '@hexclave/react';
 import { createFileRoute } from '@tanstack/react-router';
+import { DevelopmentPageNote } from "~/components/development-page-note";
 
 export const Route = createFileRoute('/email-verification-demo')({
   component: EmailVerificationDemoPage,
 });
 
 function EmailVerificationDemoPage() {
-  return <EmailVerification searchParams={{ code: "demo-email-verification-code" }} fullPage />;
+  return (
+    <>
+      <EmailVerification searchParams={{ code: "demo-email-verification-code" }} fullPage />
+      <DevelopmentPageNote
+        pageKey="emailVerification"
+        description="This is a demo of Hexclave's default email-verification page. Use the prompt below to customize your own page."
+      />
+    </>
+  );
 }

--- a/apps/hosted-components/src/routes/handler/$.tsx
+++ b/apps/hosted-components/src/routes/handler/$.tsx
@@ -25,64 +25,64 @@ type HostedPage = {
   render: () => ReactNode,
 };
 
-const hostedPages: Partial<Record<string, HostedPage>> = {
-  "account-settings": {
+const hostedPages = new Map<string, HostedPage>([
+  ["account-settings", {
     pageKey: "accountSettings",
     render: () => <HostedAccountSettings fullPage />,
-  },
-  "sign-in": {
+  }],
+  ["sign-in", {
     pageKey: "signIn",
     render: () => <HostedSignIn fullPage automaticRedirect />,
-  },
-  "log-in": {
+  }],
+  ["log-in", {
     pageKey: "signIn",
     render: () => <HostedSignIn fullPage automaticRedirect />,
-  },
-  "sign-up": {
+  }],
+  ["sign-up", {
     pageKey: "signUp",
     render: () => <HostedSignUp fullPage automaticRedirect />,
-  },
-  register: {
+  }],
+  ["register", {
     pageKey: "signUp",
     render: () => <HostedSignUp fullPage automaticRedirect />,
-  },
-  "forgot-password": {
+  }],
+  ["forgot-password", {
     pageKey: "forgotPassword",
     render: () => <HostedForgotPassword fullPage />,
-  },
-  "password-reset": {
+  }],
+  ["password-reset", {
     pageKey: "passwordReset",
     render: () => <HostedPasswordReset fullPage />,
-  },
-  "email-verification": {
+  }],
+  ["email-verification", {
     pageKey: "emailVerification",
     render: () => <HostedEmailVerification fullPage />,
-  },
-  mfa: {
+  }],
+  ["mfa", {
     pageKey: "mfa",
     render: () => <HostedMfa fullPage />,
-  },
-  error: {
+  }],
+  ["error", {
     pageKey: "error",
     render: () => <HostedError fullPage />,
-  },
-  "team-invitation": {
+  }],
+  ["team-invitation", {
     pageKey: "teamInvitation",
     render: () => <HostedTeamInvitation fullPage />,
-  },
-  "cli-auth-confirm": {
+  }],
+  ["cli-auth-confirm", {
     pageKey: "cliAuthConfirm",
     render: () => <HostedCliAuthConfirm fullPage />,
-  },
-  onboarding: {
+  }],
+  ["onboarding", {
     pageKey: "onboarding",
     render: () => <HostedOnboarding fullPage />,
-  },
-};
+  }],
+]);
 
 function HandlerPage() {
   const location = useLocation();
-  const hostedPage = hostedPages[getHostedHandlerPath(location.pathname)];
+  const hostedPage = hostedPages.get(getHostedHandlerPath(location.pathname));
 
   if (hostedPage == null) {
     return <HexclaveHandler fullPage />;

--- a/apps/hosted-components/src/routes/handler/$.tsx
+++ b/apps/hosted-components/src/routes/handler/$.tsx
@@ -1,5 +1,7 @@
 import { createFileRoute, useLocation } from '@tanstack/react-router';
 import { HexclaveHandler } from '@hexclave/react';
+import type { ReactNode } from "react";
+import { DevelopmentPageNote, type DevelopmentPageKey } from "~/components/development-page-note";
 import { HostedAccountSettings } from '../../hosted-components/account-settings/index';
 import {
   HostedEmailVerification,
@@ -18,55 +20,91 @@ export const Route = createFileRoute('/handler/$')({
   component: HandlerPage,
 });
 
+type HostedPage = {
+  pageKey: DevelopmentPageKey,
+  render: () => ReactNode,
+};
+
+const hostedPages: Partial<Record<string, HostedPage>> = {
+  "account-settings": {
+    pageKey: "accountSettings",
+    render: () => <HostedAccountSettings fullPage />,
+  },
+  "sign-in": {
+    pageKey: "signIn",
+    render: () => <HostedSignIn fullPage automaticRedirect />,
+  },
+  "log-in": {
+    pageKey: "signIn",
+    render: () => <HostedSignIn fullPage automaticRedirect />,
+  },
+  "sign-up": {
+    pageKey: "signUp",
+    render: () => <HostedSignUp fullPage automaticRedirect />,
+  },
+  register: {
+    pageKey: "signUp",
+    render: () => <HostedSignUp fullPage automaticRedirect />,
+  },
+  "forgot-password": {
+    pageKey: "forgotPassword",
+    render: () => <HostedForgotPassword fullPage />,
+  },
+  "password-reset": {
+    pageKey: "passwordReset",
+    render: () => <HostedPasswordReset fullPage />,
+  },
+  "email-verification": {
+    pageKey: "emailVerification",
+    render: () => <HostedEmailVerification fullPage />,
+  },
+  mfa: {
+    pageKey: "mfa",
+    render: () => <HostedMfa fullPage />,
+  },
+  error: {
+    pageKey: "error",
+    render: () => <HostedError fullPage />,
+  },
+  "team-invitation": {
+    pageKey: "teamInvitation",
+    render: () => <HostedTeamInvitation fullPage />,
+  },
+  "cli-auth-confirm": {
+    pageKey: "cliAuthConfirm",
+    render: () => <HostedCliAuthConfirm fullPage />,
+  },
+  onboarding: {
+    pageKey: "onboarding",
+    render: () => <HostedOnboarding fullPage />,
+  },
+};
+
 function HandlerPage() {
   const location = useLocation();
-  const hostedHandlerPath = getHostedHandlerPath(location.pathname);
+  const hostedPage = hostedPages[getHostedHandlerPath(location.pathname)];
 
-  if (hostedHandlerPath === 'account-settings') {
-    return <HostedAccountSettings fullPage />;
+  if (hostedPage == null) {
+    return <HexclaveHandler fullPage />;
   }
 
-  if (hostedHandlerPath === 'sign-in' || hostedHandlerPath === 'log-in') {
-    return <HostedSignIn fullPage automaticRedirect />;
-  }
+  return (
+    <WithDevelopmentPageNote pageKey={hostedPage.pageKey}>
+      {hostedPage.render()}
+    </WithDevelopmentPageNote>
+  );
+}
 
-  if (hostedHandlerPath === 'sign-up' || hostedHandlerPath === 'register') {
-    return <HostedSignUp fullPage automaticRedirect />;
-  }
-
-  if (hostedHandlerPath === 'forgot-password') {
-    return <HostedForgotPassword fullPage />;
-  }
-
-  if (hostedHandlerPath === 'password-reset') {
-    return <HostedPasswordReset fullPage />;
-  }
-
-  if (hostedHandlerPath === 'email-verification') {
-    return <HostedEmailVerification fullPage />;
-  }
-
-  if (hostedHandlerPath === 'mfa') {
-    return <HostedMfa fullPage />;
-  }
-
-  if (hostedHandlerPath === 'error') {
-    return <HostedError fullPage />;
-  }
-
-  if (hostedHandlerPath === 'team-invitation') {
-    return <HostedTeamInvitation fullPage />;
-  }
-
-  if (hostedHandlerPath === 'cli-auth-confirm') {
-    return <HostedCliAuthConfirm fullPage />;
-  }
-
-  if (hostedHandlerPath === 'onboarding') {
-    return <HostedOnboarding fullPage />;
-  }
-
-  return <HexclaveHandler fullPage />;
+function WithDevelopmentPageNote(props: {
+  pageKey: DevelopmentPageKey,
+  children: ReactNode,
+}) {
+  return (
+    <>
+      {props.children}
+      <DevelopmentPageNote pageKey={props.pageKey} />
+    </>
+  );
 }
 
 function getHostedHandlerPath(pathname: string) {

--- a/apps/hosted-components/src/routes/index.tsx
+++ b/apps/hosted-components/src/routes/index.tsx
@@ -19,7 +19,7 @@ function HandlerPage() {
 
   return (
     <>
-      <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "100vh", fontFamily: "system-ui, sans-serif" }}>
+      <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "100vh", paddingBottom: "var(--hexclave-development-page-note-height, 0px)", fontFamily: "system-ui, sans-serif" }}>
         <div style={{ position: "absolute", top: "1rem", right: "1rem" }}>
           <HostedUserButton />
         </div>

--- a/apps/hosted-components/src/routes/index.tsx
+++ b/apps/hosted-components/src/routes/index.tsx
@@ -1,5 +1,6 @@
 import { useUser } from "@hexclave/react";
 import { createFileRoute } from '@tanstack/react-router';
+import { DevelopmentPageNote } from "~/components/development-page-note";
 import { HostedUserButton } from "~/components/hosted-user-button";
 
 export const Route = createFileRoute('/')({
@@ -17,16 +18,19 @@ function HandlerPage() {
   const name = user.displayName || user.primaryEmail || "User";
 
   return (
-    <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "100vh", fontFamily: "system-ui, sans-serif" }}>
-      <div style={{ position: "absolute", top: "1rem", right: "1rem" }}>
-        <HostedUserButton />
+    <>
+      <div style={{ position: "relative", display: "flex", flexDirection: "column", alignItems: "center", justifyContent: "center", minHeight: "100vh", fontFamily: "system-ui, sans-serif" }}>
+        <div style={{ position: "absolute", top: "1rem", right: "1rem" }}>
+          <HostedUserButton />
+        </div>
+        <h1 style={{ fontSize: "1.5rem", fontWeight: 500, marginBottom: "0.5rem" }}>
+          Welcome, {name}
+        </h1>
+        <p style={{ color: "#666", fontSize: "0.875rem" }}>
+          You are signed in.
+        </p>
       </div>
-      <h1 style={{ fontSize: "1.5rem", fontWeight: 500, marginBottom: "0.5rem" }}>
-        Welcome, {name}
-      </h1>
-      <p style={{ color: "#666", fontSize: "0.875rem" }}>
-        You are signed in.
-      </p>
-    </div>
+      <DevelopmentPageNote description="This is Hexclave's default post-sign-in landing page. Configure your own afterSignIn URL to customize what users see after signing in." />
+    </>
   );
 }

--- a/apps/hosted-components/src/styles.css
+++ b/apps/hosted-components/src/styles.css
@@ -174,3 +174,8 @@ html:has(head > [data-stack-theme="dark"]) .hosted-skeleton {
   --ring: inherit !important;
   --radius: inherit !important;
 }
+
+html[data-hexclave-development-page-note-visible] [data-hexclave-handler-page] {
+  overflow-y: auto;
+  padding-bottom: var(--hexclave-development-page-note-height);
+}


### PR DESCRIPTION
## Summary

Every hosted-components page now shows a floating "Development info" note when the project is a development environment, telling the developer they're on Hexclave's default page and handing them the same customization prompt the devtool indicator shows.

Visibility is driven by the project, not the build: `useStackApp().useProject().isDevelopmentEnvironment` — so it also appears in a production build of the hosted app when the project is a development environment, and never for real projects.

New `DevelopmentPageNote` (`apps/hosted-components/src/components/development-page-note.tsx`):

```tsx
<DevelopmentPageNote pageKey="signIn" />   // header + description + Copy prompt / Show prompt
<DevelopmentPageNote description="..." />  // promptless variant (landing page)
```

The prompt comes from `getCustomPagePrompts()[pageKey]` in `@hexclave/shared`, i.e. the same source the devtool uses — no SDK public API was widened for this. The note is collapsed by default (long prompts stay out of the way), dismissible for the browser session via `sessionStorage`, and capped at `60vh` with the prompt block scrolling inside it.

`handler/$.tsx` was rewritten from a chain of `if (path === ...)` returns into a `path -> { pageKey, render }` map so the note is attached in exactly one place; the generic `<HexclaveHandler fullPage />` fallback deliberately has no note.

`CopyButton` gained a labelled variant — it previously dropped `children` and hardcoded icon-only sizing:

```diff
-className={cn("h-6 w-6 p-1", props.className)}
+className={cn(children == null ? "h-6 w-6 p-1" : "gap-1.5", props.className)}
 {copied ? <Check /> : <Copy />}
+{children != null && <span>{children}</span>}
```

Verified in the browser against a local development-environment project on every page (light + dark).


Link to Devin session: https://app.devin.ai/sessions/b210029220544aecb77fcb5b34ca98f7
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a development-only "Development info" note to hosted pages with a copyable customization prompt, now styled with a blue tint. Visibility is tied to the project’s dev environment, so it never appears for real projects.

- **New Features**
  - Introduced `DevelopmentPageNote` (`pageKey`/`pageTitle`/`description`), blue‑tinted, collapsed by default, session-dismissible, with copy and show/hide controls for prompts from `getCustomPagePrompts()` in `@hexclave/shared`.
  - Injected the note across hosted handler routes via a shared wrapper; excluded from the generic fallback.
  - Added tailored notes to the landing page and the email-verification demo; `CopyButton` now supports an optional label while keeping icon-only sizing when no children are provided.

- **Bug Fixes**
  - Tolerates unavailable `sessionStorage` in partitioned/third-party contexts and keeps dismissal in memory when storage fails.
  - Hardened hosted handler lookup with a path→page map and safe fallback to the generic handler; the note only renders for known pages.
  - Reserved layout space for the note via a global CSS rule: when the note is visible, pages marked with `data-hexclave-handler-page` get bottom padding and scroll correctly.

<sup>Written for commit c1360578b9accab1604c43a18daccd535a5f0e36. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1820?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added a fixed “Development info” banner on hosted pages in development, with optional page-specific guidance.
  - Banner dismissal is persisted for the session and remembered across relevant pages/routes.
  - Banner can copy guidance and expand/collapse full details when available.
- **Improvements**
  - Updated the copy button to optionally display accompanying text alongside the icon.
- **UI/UX**
  - Handler and post-sign-in pages now reserve bottom space for the banner and enable smooth vertical scrolling while it’s visible.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->