### PR TITLE
Show the administrator's public restriction reason on the onboarding screen

### DIFF
--- a/apps/hosted-components/src/hosted-components/auth/onboarding-page.tsx
+++ b/apps/hosted-components/src/hosted-components/auth/onboarding-page.tsx
@@ -68,6 +68,17 @@ export function HostedOnboarding(props: {
       } as any;
     }
 
+    if (demoMode === "admin-restricted") {
+      return {
+        ...baseMockUser,
+        isRestricted: true,
+        primaryEmail: "user@example.com",
+        restrictedReason: { type: "restricted_by_administrator" },
+        restrictedByAdmin: true,
+        restrictedByAdminReason: "Your sign-up was flagged by our fraud prevention rules.",
+      } as any;
+    }
+
     if (demoMode === "other-restricted") {
       return {
         ...baseMockUser,
@@ -330,6 +341,8 @@ export function HostedOnboarding(props: {
     );
   }
 
+  const isRestrictedByAdmin = restrictedReason?.type === "restricted_by_administrator";
+
   // Generic setup-required state
   return (
     <HostedAuthShell fullPage={props.fullPage}>
@@ -338,10 +351,14 @@ export function HostedOnboarding(props: {
           <AlertTriangle className="h-6 w-6" />
         </div>
         <Typography type="h2" className="mb-2 text-xl font-semibold tracking-tight">
-          Complete your account setup
+          {isRestrictedByAdmin ? "Your account has been restricted" : "Complete your account setup"}
         </Typography>
         <Typography className="text-sm text-muted-foreground">
-          You have not yet completed your account setup. Please reach out to support if you believe this is an error.
+          {/* The public reason is set by the project's administrators (sign-up rules or manually), so it's the most
+          helpful thing we can show; the generic sentences are only fallbacks for when they didn't provide one. */}
+          {isRestrictedByAdmin
+            ? user.restrictedByAdminReason ?? "An administrator has restricted your account. Please reach out to support if you believe this is an error."
+            : "You have not yet completed your account setup. Please reach out to support if you believe this is an error."}
         </Typography>
       </div>
 

--- a/packages/shared/src/interface/page-component-versions.ts
+++ b/packages/shared/src/interface/page-component-versions.ts
@@ -1635,6 +1635,7 @@ export function getCustomPagePrompts(): Record<PageComponentKey, CustomPagePromp
         - Handle restricted reasons:
           - \`email_not_verified\` and no primary email => ask user for email and call \`user.update({ primaryEmail })\`.
           - \`email_not_verified\` with primary email => show verification step, resend via \`user.sendVerificationEmail()\`, allow changing email.
+          - \`restricted_by_administrator\` => show \`user.restrictedByAdminReason\` (the public reason set by an administrator), falling back to a generic restricted message.
           - Any other restricted reason => show generic setup-required state.
         - Provide sign-out path from onboarding states.
       `,
@@ -1653,6 +1654,18 @@ export function getCustomPagePrompts(): Record<PageComponentKey, CustomPagePromp
           if (!user || user.isAnonymous) {
             void runAsynchronously(hexclaveApp.redirectToSignIn());
             return null;
+          }
+
+          if (user.restrictedReason?.type === "restricted_by_administrator") {
+            return (
+              <MessageCard
+                title="Your account has been restricted"
+                secondaryButtonText="Sign out"
+                secondaryAction={async () => await user.signOut()}
+              >
+                {user.restrictedByAdminReason ?? "An administrator has restricted your account."}
+              </MessageCard>
+            );
           }
 
           if (user.restrictedReason?.type !== "email_not_verified") {

--- a/packages/template/src/components-page/onboarding.test.tsx
+++ b/packages/template/src/components-page/onboarding.test.tsx
@@ -1,0 +1,178 @@
+// @vitest-environment jsdom
+
+import React, { act } from "react";
+import { createRoot, type Root } from "react-dom/client";
+import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import type { CurrentUser } from "../lib/hexclave-app";
+import type { StackClientApp } from "../lib/hexclave-app/apps/interfaces/client-app";
+import { TranslationProviderClient } from "../providers/translation-provider-client";
+import { Onboarding } from "./onboarding";
+
+const appMockState = vi.hoisted(() => ({
+  app: null as unknown,
+  user: null as unknown,
+}));
+
+vi.mock("..", () => ({
+  useStackApp: () => {
+    if (appMockState.app == null) {
+      throw new Error("Expected test app to be set before rendering.");
+    }
+    return appMockState.app;
+  },
+  useUser: () => appMockState.user,
+}));
+
+vi.mock("@hexclave/ui", async () => {
+  const React = await import("react");
+  return {
+    Button: (props: { children: React.ReactNode, onClick?: () => void }) => (
+      <button type="button" onClick={props.onClick}>{props.children}</button>
+    ),
+    Input: (props: Record<string, unknown>) => <input {...props} />,
+    Typography: (props: { children: React.ReactNode }) => <div>{props.children}</div>,
+    cn: (...classes: (string | false | null | undefined)[]) => classes.filter(Boolean).join(" "),
+  };
+});
+
+const previousActEnvironment = Reflect.get(globalThis, "IS_REACT_ACT_ENVIRONMENT");
+
+function createAppTestDouble() {
+  const app = {
+    redirectToSignIn: vi.fn(async () => {}),
+    redirectToAfterSignIn: vi.fn(async () => {}),
+  };
+
+  // This test double intentionally implements only the StackClientApp surface that Onboarding touches.
+  return app as unknown as StackClientApp<true> & {
+    redirectToSignIn: ReturnType<typeof vi.fn>,
+    redirectToAfterSignIn: ReturnType<typeof vi.fn>,
+  };
+}
+
+function createUserTestDouble(user: Partial<CurrentUser>) {
+  // Same as the app test double: only the surface Onboarding touches.
+  return {
+    isAnonymous: false,
+    isRestricted: true,
+    restrictedReason: null,
+    restrictedByAdmin: false,
+    restrictedByAdminReason: null,
+    primaryEmail: "user@example.com",
+    signOut: vi.fn(async () => {}),
+    ...user,
+  } as unknown as CurrentUser;
+}
+
+let root: Root | null = null;
+let container: HTMLDivElement | null = null;
+
+async function renderOnboarding(options: {
+  app: StackClientApp<true>,
+  user: unknown,
+}) {
+  appMockState.app = options.app;
+  appMockState.user = options.user;
+  container = document.createElement("div");
+  document.body.append(container);
+  root = createRoot(container);
+  await act(async () => {
+    root?.render(
+      <TranslationProviderClient quetzalKeys={new Map()} quetzalLocale={new Map()}>
+        <Onboarding />
+      </TranslationProviderClient>
+    );
+  });
+  return container;
+}
+
+describe("Onboarding", () => {
+  beforeEach(() => {
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", true);
+  });
+
+  afterEach(() => {
+    act(() => {
+      root?.unmount();
+    });
+    container?.remove();
+    root = null;
+    container = null;
+    appMockState.app = null;
+    appMockState.user = null;
+    vi.restoreAllMocks();
+    Reflect.set(globalThis, "IS_REACT_ACT_ENVIRONMENT", previousActEnvironment);
+  });
+
+  it("redirects signed-out users to sign-in", async () => {
+    const app = createAppTestDouble();
+
+    const container = await renderOnboarding({ app, user: null });
+
+    expect(app.redirectToSignIn).toHaveBeenCalled();
+    expect(container.textContent).toBe("");
+  });
+
+  it("redirects anonymous users to sign-in", async () => {
+    const app = createAppTestDouble();
+
+    const container = await renderOnboarding({ app, user: createUserTestDouble({ isAnonymous: true, restrictedReason: { type: "anonymous" } }) });
+
+    expect(app.redirectToSignIn).toHaveBeenCalled();
+    expect(container.textContent).toBe("");
+  });
+
+  it("redirects users that are no longer restricted to their destination", async () => {
+    const app = createAppTestDouble();
+
+    await renderOnboarding({ app, user: createUserTestDouble({ isRestricted: false }) });
+
+    expect(app.redirectToAfterSignIn).toHaveBeenCalled();
+    expect(app.redirectToSignIn).not.toHaveBeenCalled();
+  });
+
+  it("shows the administrator's public reason to admin-restricted users", async () => {
+    const app = createAppTestDouble();
+
+    const container = await renderOnboarding({
+      app,
+      user: createUserTestDouble({
+        restrictedReason: { type: "restricted_by_administrator" },
+        restrictedByAdmin: true,
+        restrictedByAdminReason: "Your sign-up was flagged by our fraud prevention rules.",
+      }),
+    });
+
+    expect(container.textContent).toContain("Your account has been restricted");
+    expect(container.textContent).toContain("Your sign-up was flagged by our fraud prevention rules.");
+    expect(container.textContent).not.toContain("Complete your account setup");
+  });
+
+  it("falls back to a generic restricted message when no public reason is set", async () => {
+    const app = createAppTestDouble();
+
+    const container = await renderOnboarding({
+      app,
+      user: createUserTestDouble({
+        restrictedReason: { type: "restricted_by_administrator" },
+        restrictedByAdmin: true,
+        restrictedByAdminReason: null,
+      }),
+    });
+
+    expect(container.textContent).toContain("Your account has been restricted");
+    expect(container.textContent).toContain("An administrator has restricted your account.");
+  });
+
+  it("shows the setup-required message for unknown restricted reasons", async () => {
+    const app = createAppTestDouble();
+
+    const container = await renderOnboarding({
+      app,
+      // The reason types are a closed union, so an unknown reason can only come from a newer backend.
+      user: createUserTestDouble({ restrictedReason: { type: "some_future_reason" } as unknown as CurrentUser["restrictedReason"] }),
+    });
+
+    expect(container.textContent).toContain("Complete your account setup");
+  });
+});

--- a/packages/template/src/components-page/onboarding.tsx
+++ b/packages/template/src/components-page/onboarding.tsx
@@ -50,6 +50,23 @@ export function Onboarding(props: {
     return <VerifyEmailScreen user={user} email={user.primaryEmail} fullPage={props.fullPage} />;
   }
 
+  if (restrictedReason?.type === "restricted_by_administrator") {
+    return (
+      <MessageCard
+        title={t("Your account has been restricted")}
+        fullPage={!!props.fullPage}
+        secondaryButtonText={t("Sign out")}
+        secondaryAction={async () => {
+          await user.signOut();
+        }}
+      >
+        {/* The public reason is set by the project's administrators (sign-up rules or manually), so it's the most
+        helpful thing we can show; the generic sentence is only a fallback for when they didn't provide one. */}
+        <p>{user.restrictedByAdminReason ?? t("An administrator has restricted your account. Please reach out to support if you believe this is an error.")}</p>
+      </MessageCard>
+    );
+  }
+
   // Unknown restricted reason - show generic message
   return (
     <MessageCard

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -2152,6 +2152,8 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       isAnonymous: crud.is_anonymous,
       isRestricted: crud.is_restricted,
       restrictedReason: crud.restricted_reason,
+      restrictedByAdmin: crud.restricted_by_admin,
+      restrictedByAdminReason: crud.restricted_by_admin_reason,
       toClientJson(): CurrentUserCrud['Client']['Read'] {
         return crud;
       }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/server-app-impl.ts
@@ -603,20 +603,11 @@ export class _HexclaveServerAppImplIncomplete<HasTokenStore extends boolean, Pro
     }
     // END_PLATFORM
 
-    // Type assertion needed because the new restricted_by_admin fields may not be reflected in TypeScript types yet
-    // after schema changes - the runtime values are present after the schema is updated
-    const crudWithAdminRestriction = crud as typeof crud & {
-      restricted_by_admin: boolean,
-      restricted_by_admin_reason: string | null,
-      restricted_by_admin_private_details: string | null,
-    };
     const serverUser = withUserDestructureGuard({
       ...super._createBaseUser(crud),
       lastActiveAt: new Date(crud.last_active_at_millis),
       serverMetadata: crud.server_metadata,
-      restrictedByAdmin: crudWithAdminRestriction.restricted_by_admin,
-      restrictedByAdminReason: crudWithAdminRestriction.restricted_by_admin_reason,
-      restrictedByAdminPrivateDetails: crudWithAdminRestriction.restricted_by_admin_private_details,
+      restrictedByAdminPrivateDetails: crud.restricted_by_admin_private_details,
       countryCode: crud.country_code,
       riskScores: {
         signUp: {

--- a/packages/template/src/lib/hexclave-app/users/index.ts
+++ b/packages/template/src/lib/hexclave-app/users/index.ts
@@ -137,6 +137,15 @@ export type BaseUser = {
    * Null if the user is not restricted.
    */
   readonly restrictedReason: RestrictedReason | null,
+  /** Whether the user is restricted by an administrator. Can be set manually or by sign-up rules. */
+  readonly restrictedByAdmin: boolean,
+  /**
+   * Public reason shown to the user explaining why an administrator restricted them, or null if none was given.
+   *
+   * This is intentionally readable by the user themselves (unlike `restrictedByAdminPrivateDetails`, which is
+   * server-only), so onboarding screens can tell them why they can't continue.
+   */
+  readonly restrictedByAdminReason: string | null,
   toClientJson(): CurrentUserCrud["Client"]["Read"],
 
   /**
@@ -354,10 +363,6 @@ export type ServerBaseUser = {
   setServerMetadata(metadata: any): Promise<void>,
   setClientReadOnlyMetadata(metadata: any): Promise<void>,
 
-  /** Whether the user is restricted by an administrator. Can be set manually or by sign-up rules. */
-  readonly restrictedByAdmin: boolean,
-  /** Public reason shown to the user explaining why they are restricted. Optional. */
-  readonly restrictedByAdminReason: string | null,
   /** Private details about the restriction (e.g., which sign-up rule triggered). Only visible to server access and above. */
   readonly restrictedByAdminPrivateDetails: string | null,
   /** Best-effort ISO country code captured at sign-up time from request geo headers. */

--- a/sdks/implementations/swift/Sources/StackAuth/Models/CurrentUser.swift
+++ b/sdks/implementations/swift/Sources/StackAuth/Models/CurrentUser.swift
@@ -23,6 +23,8 @@ public actor CurrentUser {
     public var isAnonymous: Bool { userData.isAnonymous }
     public var isRestricted: Bool { userData.isRestricted }
     public var restrictedReason: User.RestrictedReason? { userData.restrictedReason }
+    public var restrictedByAdmin: Bool { userData.restrictedByAdmin }
+    public var restrictedByAdminReason: String? { userData.restrictedByAdminReason }
     public var oauthProviders: [User.OAuthProviderInfo] { userData.oauthProviders }
     
     init(client: APIClient, json: [String: Any]) {

--- a/sdks/implementations/swift/Sources/StackAuth/Models/ServerUser.swift
+++ b/sdks/implementations/swift/Sources/StackAuth/Models/ServerUser.swift
@@ -22,6 +22,9 @@ public actor ServerUser {
     public let isAnonymous: Bool
     public let isRestricted: Bool
     public let restrictedReason: User.RestrictedReason?
+    public let restrictedByAdmin: Bool
+    public let restrictedByAdminReason: String?
+    public let restrictedByAdminPrivateDetails: String?
     public let oauthProviders: [User.OAuthProviderInfo]
     
     init(client: APIClient, json: [String: Any]) {
@@ -59,6 +62,10 @@ public actor ServerUser {
         } else {
             self.restrictedReason = nil
         }
+        
+        self.restrictedByAdmin = json["restricted_by_admin"] as? Bool ?? false
+        self.restrictedByAdminReason = json["restricted_by_admin_reason"] as? String
+        self.restrictedByAdminPrivateDetails = json["restricted_by_admin_private_details"] as? String
         
         if let providers = json["oauth_providers"] as? [[String: Any]] {
             self.oauthProviders = providers.map { User.OAuthProviderInfo(id: $0["id"] as? String ?? "") }

--- a/sdks/implementations/swift/Sources/StackAuth/Models/User.swift
+++ b/sdks/implementations/swift/Sources/StackAuth/Models/User.swift
@@ -19,6 +19,8 @@ public struct User: @unchecked Sendable {
     public let isAnonymous: Bool
     public let isRestricted: Bool
     public let restrictedReason: RestrictedReason?
+    public let restrictedByAdmin: Bool
+    public let restrictedByAdminReason: String?
     public let oauthProviders: [OAuthProviderInfo]
     
     public struct RestrictedReason: Sendable {
@@ -60,6 +62,9 @@ extension User {
         } else {
             self.restrictedReason = nil
         }
+        
+        self.restrictedByAdmin = json["restricted_by_admin"] as? Bool ?? false
+        self.restrictedByAdminReason = json["restricted_by_admin_reason"] as? String
         
         if let providers = json["oauth_providers"] as? [[String: Any]] {
             self.oauthProviders = providers.map { OAuthProviderInfo(id: $0["id"] as? String ?? "") }

--- a/sdks/spec/src/types/users/base-user.spec.md
+++ b/sdks/spec/src/types/users/base-user.spec.md
@@ -52,6 +52,13 @@ isRestricted: bool
 restrictedReason: { type: "anonymous" | "email_not_verified" | "restricted_by_administrator" } | null
   The reason why user is restricted, or null if not restricted.
 
+restrictedByAdmin: bool
+  Whether the user is restricted by an administrator (set manually or by sign-up rules).
+
+restrictedByAdminReason: string | null
+  Public reason shown to the user explaining why an administrator restricted them, or null if none was given.
+  Readable by the user themselves, unlike the server-only restrictedByAdminPrivateDetails.
+
 
 ## Deprecated Properties
 

--- a/sdks/spec/src/types/users/server-user.spec.md
+++ b/sdks/spec/src/types/users/server-user.spec.md
@@ -14,6 +14,9 @@ lastActiveAt: Date
 serverMetadata: json
   Server-only metadata, not visible to client.
 
+restrictedByAdminPrivateDetails: string | null
+  Private details about the restriction (e.g. which sign-up rule triggered it), never visible to the client.
+
 
 ## Server-specific Update Methods
 


### PR DESCRIPTION
Users restricted by an administrator landed on the generic "Complete your account setup" card, even when the admin had set a public reason for the restriction. The public reason existed in the client CRUD read schema but wasn't exposed on the client user type, so no UI could read it.

- `BaseUser` now has `restrictedByAdmin` + `restrictedByAdminReason` (moved off `ServerBaseUser`; `restrictedByAdminPrivateDetails` stays server-only), mapped in `_createBaseUser`. This also removes a now-unnecessary cast in `server-app-impl`.
- `Onboarding` (SDK) and `HostedOnboarding` handle `restricted_by_administrator` separately: title "Your account has been restricted", body `user.restrictedByAdminReason` with a generic fallback when no reason is set. The setup-required card remains only for unknown/future restriction reasons.
- Custom onboarding page prompt + SDK spec + Swift SDK updated to match.
- New `onboarding.test.tsx` covers the redirects (signed-out, anonymous, no-longer-restricted) and all three restricted-state renders.


Link to Devin session: https://app.devin.ai/sessions/19768c9c3f1549f395a47f5b8246ff0b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show the administrator’s public restriction reason during onboarding so affected users see a clear message instead of the generic setup card. Updates the user model and SDKs to surface this info.

- **New Features**
  - Expose `restrictedByAdmin` and `restrictedByAdminReason` on `BaseUser`; mapped in the client app; `restrictedByAdminPrivateDetails` stays server-only.
  - Update onboarding UIs in `packages/template` and `apps/hosted-components` to show “Your account has been restricted” and display the public reason with a safe fallback; keep the generic card for other/unknown reasons. Custom onboarding page prompt/spec updated to handle `restricted_by_administrator`.
  - Swift SDK (`sdks/implementations/swift`) now surfaces these fields on `User` and `CurrentUser`, and adds `restrictedByAdmin`, `restrictedByAdminReason`, and `restrictedByAdminPrivateDetails` on `ServerUser`.
  - Add `onboarding.test.tsx` to cover redirects and all restricted-state renders.

<sup>Written for commit f5b8c0b8f3b5f34dece4ab8e1b2eec54382c1c3b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1822?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Added support for administrator-restricted accounts across user models and SDKs.
  - Onboarding now displays the administrator-provided restriction reason, with a fallback message.
  - Added a sign-out action for restricted accounts.
  - Server-side user data now includes private administrator restriction details.

- **Documentation**
  - Documented administrator restriction status, public reasons, and private details.

- **Tests**
  - Added coverage for restricted-account onboarding scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->