### PR TITLE
Publish per-platform tar.zst dashboard archives (55 MB → 31 MB)

### DIFF
--- a/.github/workflows/dashboard-release.yaml
+++ b/.github/workflows/dashboard-release.yaml
@@ -73,6 +73,7 @@ jobs:
           set -euo pipefail
           assets=("$ZIP")
           while IFS= read -r asset; do assets+=("$asset"); done < <(find "$PLATFORM_ARCHIVES_DIR" -maxdepth 1 -type f -name '*.tar.zst' -print)
+          platform_live_shas='{}'
           # A published dashboard-v<version> asset is immutable, so never replace
           # it; advertise the sha of whatever asset is live. (The rebuild isn't
           # byte-reproducible — staged files get fresh mtimes — so we can't just
@@ -95,10 +96,24 @@ jobs:
             existing_assets="$(gh release view "$TAG" --json assets -q '.assets[].name')"
             for asset in "${assets[@]:1}"; do
               asset_name="$(basename "$asset")"
-              if ! grep -qx "$asset_name" <<<"$existing_assets"; then
+              expected_asset_sha="$(sha256sum "$asset" | cut -d' ' -f1)"
+              live_asset_sha="$expected_asset_sha"
+              if grep -qx "$asset_name" <<<"$existing_assets"; then
+                tmp="$(mktemp -d)"
+                gh release download "$TAG" -p "$asset_name" -D "$tmp"
+                live_asset_sha="$(sha256sum "$tmp/$asset_name" | cut -d' ' -f1)"
+                if [ "$live_asset_sha" != "$expected_asset_sha" ]; then
+                  echo "::warning::$TAG already has a published asset whose sha256 ($live_asset_sha) differs from this rebuild ($expected_asset_sha). Releases are immutable, so the existing asset is kept and advertised. A differing hash is expected for nondeterministic rebuilds of identical content; if you intended to ship NEW dashboard content, bump the version in apps/dashboard/package.json."
+                else
+                  echo "Existing $TAG asset matches the build; reusing it."
+                fi
+              else
                 echo "$TAG is missing $asset_name; uploading."
                 gh release upload "$TAG" "$asset"
               fi
+              platform_key="${asset_name#dashboard-${VERSION}-}"
+              platform_key="${platform_key%.tar.zst}"
+              platform_live_shas="$(jq --arg key "$platform_key" --arg sha "$live_asset_sha" '. + {($key): $sha}' <<<"$platform_live_shas")"
             done
           else
             gh release create "$TAG" "${assets[@]}" \
@@ -106,6 +121,7 @@ jobs:
               --notes "Standalone RDE dashboard build for \`hexclave dev\` (version $VERSION)."
           fi
           echo "live_sha=$live_sha" >> "$GITHUB_OUTPUT"
+          echo "platform_live_shas=$platform_live_shas" >> "$GITHUB_OUTPUT"
 
       - name: Update floating latest manifest
         env:
@@ -113,11 +129,17 @@ jobs:
           MANIFEST: ${{ steps.package.outputs.manifest }}
           VERSION: ${{ steps.package.outputs.version }}
           LIVE_SHA: ${{ steps.publish.outputs.live_sha }}
+          PLATFORM_LIVE_SHAS: ${{ steps.publish.outputs.platform_live_shas }}
         run: |
           set -euo pipefail
           # Advertise the live asset's sha, which may differ from the rebuild's.
           tmp="$(mktemp)"
-          jq --arg s "$LIVE_SHA" '.sha256 = $s' "$MANIFEST" > "$tmp"
+          jq --arg s "$LIVE_SHA" --argjson platform_shas "$PLATFORM_LIVE_SHAS" '
+            .sha256 = $s
+            | reduce ($platform_shas | to_entries[]) as $entry
+                (.platformArchives;
+                 .[$entry.key].sha256 = $entry.value)
+          ' "$MANIFEST" > "$tmp"
           mv "$tmp" "$MANIFEST"
           # dashboard-latest is only ever a plain X.Y.Z release. Refuse to advance
           # it to a prerelease/build-metadata version rather than guess SemVer

--- a/.github/workflows/dashboard-release.yaml
+++ b/.github/workflows/dashboard-release.yaml
@@ -16,6 +16,9 @@ on:
       - 'apps/dashboard/**'
       - 'packages/cli/scripts/package-dashboard-release.mjs'
       - 'packages/cli/scripts/copy-runtime-assets.mjs'
+      - 'packages/cli/src/lib/dashboard-release.ts'
+      - 'packages/cli/package.json'
+      - 'pnpm-lock.yaml'
       - '.github/workflows/dashboard-release.yaml'
 
 permissions:
@@ -63,10 +66,13 @@ jobs:
           TAG: ${{ steps.package.outputs.tag }}
           ZIP: ${{ steps.package.outputs.zip }}
           ZIP_NAME: ${{ steps.package.outputs.zip_name }}
+          PLATFORM_ARCHIVES_DIR: ${{ steps.package.outputs.platform_archives_dir }}
           VERSION: ${{ steps.package.outputs.version }}
           EXPECTED_SHA: ${{ steps.package.outputs.sha256 }}
         run: |
           set -euo pipefail
+          assets=("$ZIP")
+          while IFS= read -r asset; do assets+=("$asset"); done < <(find "$PLATFORM_ARCHIVES_DIR" -maxdepth 1 -type f -name '*.tar.zst' -print)
           # A published dashboard-v<version> asset is immutable, so never replace
           # it; advertise the sha of whatever asset is live. (The rebuild isn't
           # byte-reproducible — staged files get fresh mtimes — so we can't just
@@ -86,8 +92,16 @@ jobs:
               echo "$TAG exists without its asset; uploading."
               gh release upload "$TAG" "$ZIP" --clobber
             fi
+            existing_assets="$(gh release view "$TAG" --json assets -q '.assets[].name')"
+            for asset in "${assets[@]:1}"; do
+              asset_name="$(basename "$asset")"
+              if ! grep -qx "$asset_name" <<<"$existing_assets"; then
+                echo "$TAG is missing $asset_name; uploading."
+                gh release upload "$TAG" "$asset"
+              fi
+            done
           else
-            gh release create "$TAG" "$ZIP" \
+            gh release create "$TAG" "${assets[@]}" \
               --title "RDE dashboard $VERSION" \
               --notes "Standalone RDE dashboard build for \`hexclave dev\` (version $VERSION)."
           fi

--- a/.github/workflows/dashboard-release.yaml
+++ b/.github/workflows/dashboard-release.yaml
@@ -74,6 +74,22 @@ jobs:
           set -euo pipefail
           assets=("$ZIP")
           while IFS= read -r asset; do assets+=("$asset"); done < <(find "$PLATFORM_ARCHIVES_DIR" -maxdepth 1 -type f -name '*.tar.zst' -print)
+          for asset in "${assets[@]:1}"; do
+            asset_name="$(basename "$asset")"
+            case "$asset_name" in
+              "dashboard-${VERSION}-"*.tar.zst) ;;
+              *)
+                echo "::error::Unexpected platform archive name $asset_name for dashboard version $VERSION."
+                exit 1
+                ;;
+            esac
+            platform_key="${asset_name#dashboard-${VERSION}-}"
+            platform_key="${platform_key%.tar.zst}"
+            if ! jq -e --arg key "$platform_key" '(.platformArchives // {}) | has($key)' "$MANIFEST" >/dev/null; then
+              echo "::error::Platform archive $asset_name produced unknown manifest key $platform_key."
+              exit 1
+            fi
+          done
           platform_live_shas='{}'
           # A published dashboard-v<version> asset is immutable, so never replace
           # it; advertise the sha of whatever asset is live. (The rebuild isn't
@@ -97,13 +113,6 @@ jobs:
             existing_assets="$(gh release view "$TAG" --json assets -q '.assets[].name')"
             for asset in "${assets[@]:1}"; do
               asset_name="$(basename "$asset")"
-              case "$asset_name" in
-                "dashboard-${VERSION}-"*.tar.zst) ;;
-                *)
-                  echo "::error::Unexpected platform archive name $asset_name for dashboard version $VERSION."
-                  exit 1
-                  ;;
-              esac
               expected_asset_sha="$(sha256sum "$asset" | cut -d' ' -f1)"
               live_asset_sha="$expected_asset_sha"
               if grep -qx "$asset_name" <<<"$existing_assets"; then
@@ -121,10 +130,6 @@ jobs:
               fi
               platform_key="${asset_name#dashboard-${VERSION}-}"
               platform_key="${platform_key%.tar.zst}"
-              if ! jq -e --arg key "$platform_key" '(.platformArchives // {}) | has($key)' "$MANIFEST" >/dev/null; then
-                echo "::error::Platform archive $asset_name produced unknown manifest key $platform_key."
-                exit 1
-              fi
               platform_live_shas="$(jq --arg key "$platform_key" --arg sha "$live_asset_sha" '. + {($key): $sha}' <<<"$platform_live_shas")"
             done
           else

--- a/.github/workflows/dashboard-release.yaml
+++ b/.github/workflows/dashboard-release.yaml
@@ -69,6 +69,7 @@ jobs:
           PLATFORM_ARCHIVES_DIR: ${{ steps.package.outputs.platform_archives_dir }}
           VERSION: ${{ steps.package.outputs.version }}
           EXPECTED_SHA: ${{ steps.package.outputs.sha256 }}
+          MANIFEST: ${{ steps.package.outputs.manifest }}
         run: |
           set -euo pipefail
           assets=("$ZIP")
@@ -96,6 +97,13 @@ jobs:
             existing_assets="$(gh release view "$TAG" --json assets -q '.assets[].name')"
             for asset in "${assets[@]:1}"; do
               asset_name="$(basename "$asset")"
+              case "$asset_name" in
+                "dashboard-${VERSION}-"*.tar.zst) ;;
+                *)
+                  echo "::error::Unexpected platform archive name $asset_name for dashboard version $VERSION."
+                  exit 1
+                  ;;
+              esac
               expected_asset_sha="$(sha256sum "$asset" | cut -d' ' -f1)"
               live_asset_sha="$expected_asset_sha"
               if grep -qx "$asset_name" <<<"$existing_assets"; then
@@ -113,6 +121,10 @@ jobs:
               fi
               platform_key="${asset_name#dashboard-${VERSION}-}"
               platform_key="${platform_key%.tar.zst}"
+              if ! jq -e --arg key "$platform_key" '(.platformArchives // {}) | has($key)' "$MANIFEST" >/dev/null; then
+                echo "::error::Platform archive $asset_name produced unknown manifest key $platform_key."
+                exit 1
+              fi
               platform_live_shas="$(jq --arg key "$platform_key" --arg sha "$live_asset_sha" '. + {($key): $sha}' <<<"$platform_live_shas")"
             done
           else
@@ -137,10 +149,18 @@ jobs:
           jq --arg s "$LIVE_SHA" --argjson platform_shas "$PLATFORM_LIVE_SHAS" '
             .sha256 = $s
             | reduce ($platform_shas | to_entries[]) as $entry
-                (.platformArchives;
-                 .[$entry.key].sha256 = $entry.value)
+                (.;
+                 .platformArchives[$entry.key].sha256 = $entry.value)
           ' "$MANIFEST" > "$tmp"
           mv "$tmp" "$MANIFEST"
+          MANIFEST_PATH="$MANIFEST" pnpm exec tsx --eval '
+            import { readFileSync } from "fs";
+            import { parseDashboardManifest } from "./packages/cli/src/lib/dashboard-release.ts";
+            const path = process.env.MANIFEST_PATH;
+            if (path == null || parseDashboardManifest(JSON.parse(readFileSync(path, "utf8"))) == null) {
+              throw new Error("Patched dashboard manifest failed CLI parser validation.");
+            }
+          '
           # dashboard-latest is only ever a plain X.Y.Z release. Refuse to advance
           # it to a prerelease/build-metadata version rather than guess SemVer
           # prerelease ordering in bash (`sort -V` is not a SemVer comparator).

--- a/.github/workflows/dashboard-release.yaml
+++ b/.github/workflows/dashboard-release.yaml
@@ -150,6 +150,7 @@ jobs:
         run: |
           set -euo pipefail
           # Advertise the live asset's sha, which may differ from the rebuild's.
+          expected_platform_keys="$(jq -c '.platformArchives // {} | keys' "$MANIFEST")"
           tmp="$(mktemp)"
           jq --arg s "$LIVE_SHA" --argjson platform_shas "$PLATFORM_LIVE_SHAS" '
             .sha256 = $s
@@ -158,12 +159,24 @@ jobs:
                  .platformArchives[$entry.key].sha256 = $entry.value)
           ' "$MANIFEST" > "$tmp"
           mv "$tmp" "$MANIFEST"
-          MANIFEST_PATH="$MANIFEST" pnpm exec tsx --eval '
+          # The patch above must survive the CLI's own validation: a manifest the
+          # parser rejects makes every CLI fall back to the previous release, and a
+          # platformArchives block it silently drops downgrades everyone to the zip.
+          MANIFEST_PATH="$MANIFEST" EXPECTED_PLATFORM_KEYS="$expected_platform_keys" pnpm exec tsx --eval '
             import { readFileSync } from "fs";
             import { parseDashboardManifest } from "./packages/cli/src/lib/dashboard-release.ts";
             const path = process.env.MANIFEST_PATH;
-            if (path == null || parseDashboardManifest(JSON.parse(readFileSync(path, "utf8"))) == null) {
+            const expectedKeys = process.env.EXPECTED_PLATFORM_KEYS;
+            if (path == null || expectedKeys == null) {
+              throw new Error("Manifest validation is missing MANIFEST_PATH or EXPECTED_PLATFORM_KEYS.");
+            }
+            const manifest = parseDashboardManifest(JSON.parse(readFileSync(path, "utf8")));
+            if (manifest == null) {
               throw new Error("Patched dashboard manifest failed CLI parser validation.");
+            }
+            const keys = JSON.stringify(Object.keys(manifest.platformArchives ?? {}).sort());
+            if (keys !== JSON.stringify(JSON.parse(expectedKeys).sort())) {
+              throw new Error(`Patched dashboard manifest advertises platform archives ${keys}, expected ${expectedKeys}.`);
             }
           '
           # dashboard-latest is only ever a plain X.Y.Z release. Refuse to advance

--- a/packages/cli/package.json
+++ b/packages/cli/package.json
@@ -35,10 +35,11 @@
     "@hexclave/shared": "workspace:*",
     "commander": "^13.1.0",
     "extract-zip": "^2.0.1",
-    "jiti": "^2.4.2"
+    "jiti": "^2.4.2",
+    "tar": "^7.4.3"
   },
   "devDependencies": {
-    "@types/node": "20.17.6",
+    "@types/node": "22.15.21",
     "rimraf": "^6.0.1",
     "tsdown": "^0.22.3",
     "typescript": "6.0.3"

--- a/packages/cli/scripts/package-dashboard-release.mjs
+++ b/packages/cli/scripts/package-dashboard-release.mjs
@@ -43,12 +43,19 @@ const zipPath = join(outDir, zipName);
 const manifestPath = join(outDir, "manifest.json");
 const platformArchivesDir = join(outDir, "platform");
 const tag = `dashboard-v${version}`;
+// Level 15 measured at ~75 seconds for all six archives, versus ~168 seconds
+// at level 19; it stays under the two-minute packaging budget while saving
+// about 3 MB per archive compared with level 10.
+const ZSTD_COMPRESSION_LEVEL = 15;
 
 function getAssetUrl(name, subdirectory) {
   const path = subdirectory == null ? name : `${subdirectory}/${name}`;
-  return baseUrlOverride != null && baseUrlOverride.length > 0
-    ? `${baseUrlOverride}/${path}`
-    : `https://github.com/${repository}/releases/download/${tag}/${name}`;
+  if (baseUrlOverride != null && baseUrlOverride.length > 0) {
+    // Local mirrors expose the same on-disk subdirectory layout as the package
+    // output; GitHub release assets are intentionally flat and ignore it.
+    return `${baseUrlOverride}/${path}`;
+  }
+  return `https://github.com/${repository}/releases/download/${tag}/${name}`;
 }
 
 const assetUrl = getAssetUrl(zipName);
@@ -71,7 +78,9 @@ function getVendorInfo(dir) {
   const sdkPackage = findClaudeSdkPackage(dir);
   if (sdkPackage == null) throw new Error(`Could not find the staged Claude Agent SDK under ${dir}.`);
   const vendorDir = join(sdkPackage, "vendor");
-  const components = readdirSync(vendorDir).filter((name) => existsSync(join(vendorDir, name)));
+  const components = readdirSync(vendorDir, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => entry.name);
   if (components.length === 0) throw new Error(`The staged Claude Agent SDK has no vendor components under ${vendorDir}.`);
   return { vendorDir, components };
 }
@@ -123,7 +132,7 @@ async function createTarZstd(sourceDir, archivePath, vendorInfo, platformKey) {
   const vendorFilter = createVendorFilter(vendorInfo, platformKey);
   await pipeline(
     tar.c({ cwd: sourceDir, filter: vendorFilter.filter, noMtime: true, portable: true }, ["."]),
-    zlib.createZstdCompress({ params: { [zlib.constants.ZSTD_c_compressionLevel]: 3 } }),
+    zlib.createZstdCompress({ params: { [zlib.constants.ZSTD_c_compressionLevel]: ZSTD_COMPRESSION_LEVEL } }),
     createWriteStream(archivePath),
   );
   vendorFilter.assert();
@@ -140,7 +149,7 @@ rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 execFileSync("zip", ["-q", "-r", "-X", zipPath, "."], { cwd: dashboardDist, stdio: "inherit" });
 
-// 3. Build one archive per supported SDK vendor platform from copies of the
+// 3. Stream one archive per supported SDK vendor platform from the single
 // staged runtime. The dashboard itself is built only once.
 mkdirSync(platformArchivesDir, { recursive: true });
 const platformArchives = {};

--- a/packages/cli/scripts/package-dashboard-release.mjs
+++ b/packages/cli/scripts/package-dashboard-release.mjs
@@ -1,13 +1,18 @@
 #!/usr/bin/env node
 // Packages the standalone RDE dashboard into a GitHub Release artifact: a
-// dashboard-<version>.zip plus a manifest.json ({ version, sha256, url }) that
+// dashboard-<version>.zip plus platform-specific tar.zst archives and a
+// manifest.json ({ version, sha256, url, platformArchives }) that
 // dashboard-release.ts fetches at runtime. Run by dashboard-release.yaml;
-// requires the `zip` CLI (present on ubuntu runners).
+// requires the `zip` CLI (present on ubuntu runners) and the approved `tar`
+// package dependency.
 import { execFileSync } from "child_process";
 import { createHash } from "crypto";
-import { appendFileSync, existsSync, mkdirSync, readFileSync, rmSync, writeFileSync } from "fs";
+import { appendFileSync, createWriteStream, existsSync, mkdirSync, readdirSync, readFileSync, rmSync, writeFileSync } from "fs";
 import { dirname, join, resolve } from "path";
 import { fileURLToPath } from "url";
+import * as zlib from "node:zlib";
+import { pipeline } from "stream/promises";
+import * as tar from "tar";
 
 const __dirname = dirname(fileURLToPath(import.meta.url));
 const packageRoot = resolve(__dirname, "..");
@@ -36,10 +41,93 @@ const outDir = join(packageRoot, "dashboard-release");
 const zipName = `dashboard-${version}.zip`;
 const zipPath = join(outDir, zipName);
 const manifestPath = join(outDir, "manifest.json");
+const platformArchivesDir = join(outDir, "platform");
 const tag = `dashboard-v${version}`;
-const assetUrl = baseUrlOverride != null && baseUrlOverride.length > 0
-  ? `${baseUrlOverride}/${zipName}`
-  : `https://github.com/${repository}/releases/download/${tag}/${zipName}`;
+
+function getAssetUrl(name, subdirectory) {
+  const path = subdirectory == null ? name : `${subdirectory}/${name}`;
+  return baseUrlOverride != null && baseUrlOverride.length > 0
+    ? `${baseUrlOverride}/${path}`
+    : `https://github.com/${repository}/releases/download/${tag}/${name}`;
+}
+
+const assetUrl = getAssetUrl(zipName);
+
+function findClaudeSdkPackage(dir) {
+  const scopedPackagesDir = join(dir, "apps", "dashboard", ".next", "node_modules", "@anthropic-ai");
+  if (!existsSync(scopedPackagesDir)) return undefined;
+  for (const entry of readdirSync(scopedPackagesDir, { withFileTypes: true })) {
+    if (!entry.isDirectory()) continue;
+    const entryPath = join(scopedPackagesDir, entry.name);
+    const packageJsonPath = join(entryPath, "package.json");
+    if (!existsSync(packageJsonPath)) continue;
+    const packageJson = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+    if (packageJson.name === "@anthropic-ai/claude-agent-sdk") return entryPath;
+  }
+  return undefined;
+}
+
+function getVendorInfo(dir) {
+  const sdkPackage = findClaudeSdkPackage(dir);
+  if (sdkPackage == null) throw new Error(`Could not find the staged Claude Agent SDK under ${dir}.`);
+  const vendorDir = join(sdkPackage, "vendor");
+  const components = readdirSync(vendorDir).filter((name) => existsSync(join(vendorDir, name)));
+  if (components.length === 0) throw new Error(`The staged Claude Agent SDK has no vendor components under ${vendorDir}.`);
+  return { vendorDir, components };
+}
+
+function supportedPlatformKeys(vendorInfo) {
+  const keys = new Set();
+  for (const vendorName of vendorInfo.components) {
+    for (const entry of readdirSync(join(vendorInfo.vendorDir, vendorName), { withFileTypes: true })) {
+      const match = /^([^/]+)-(darwin|linux|win32)$/.exec(entry.name);
+      if (entry.isDirectory() && match != null) keys.add(`${match[2]}-${match[1]}`);
+    }
+  }
+  return [...keys].sort();
+}
+
+function createVendorFilter(vendorInfo, platformKey) {
+  const [platform, arch] = platformKey.split("-");
+  const vendorPlatformKey = `${arch}-${platform}`;
+  const selected = new Set();
+  const rejected = new Set();
+  return {
+    filter(path) {
+      const match = /\/vendor\/([^/]+)\/([^/]+)(?:\/|$)/.exec(path);
+      if (match == null || !vendorInfo.components.includes(match[1])) return true;
+      const component = match[1];
+      if (match[2] === vendorPlatformKey) {
+        selected.add(component);
+        return true;
+      }
+      rejected.add(`${component}/${match[2]}`);
+      return false;
+    },
+    assert() {
+      const expected = new Set(vendorInfo.components);
+      if (selected.size !== expected.size || [...expected].some((component) => !selected.has(component))) {
+        throw new Error(`Platform ${platformKey} selected ${[...selected].join(", ") || "no"} vendor components; expected ${[...expected].join(", ")}.`);
+      }
+      if (rejected.size === 0) {
+        throw new Error(`Platform ${platformKey} did not filter any non-${vendorPlatformKey} vendor directories.`);
+      }
+    },
+  };
+}
+
+async function createTarZstd(sourceDir, archivePath, vendorInfo, platformKey) {
+  if (typeof zlib.createZstdCompress !== "function") {
+    throw new Error("This Node.js runtime does not provide createZstdCompress; cannot package tar.zst archives.");
+  }
+  const vendorFilter = createVendorFilter(vendorInfo, platformKey);
+  await pipeline(
+    tar.c({ cwd: sourceDir, filter: vendorFilter.filter, noMtime: true, portable: true }, ["."]),
+    zlib.createZstdCompress({ params: { [zlib.constants.ZSTD_c_compressionLevel]: 3 } }),
+    createWriteStream(archivePath),
+  );
+  vendorFilter.assert();
+}
 
 // 1. Stage the standalone dashboard runtime into dist/dashboard.
 execFileSync(process.execPath, [join(__dirname, "copy-runtime-assets.mjs")], { stdio: "inherit" });
@@ -52,15 +140,34 @@ rmSync(outDir, { recursive: true, force: true });
 mkdirSync(outDir, { recursive: true });
 execFileSync("zip", ["-q", "-r", "-X", zipPath, "."], { cwd: dashboardDist, stdio: "inherit" });
 
-// 3. Hash the archive and write the manifest the CLI fetches at runtime.
+// 3. Build one archive per supported SDK vendor platform from copies of the
+// staged runtime. The dashboard itself is built only once.
+mkdirSync(platformArchivesDir, { recursive: true });
+const platformArchives = {};
+const vendorInfo = getVendorInfo(dashboardDist);
+for (const platformKey of supportedPlatformKeys(vendorInfo)) {
+  const archiveName = `dashboard-${version}-${platformKey}.tar.zst`;
+  const archivePath = join(platformArchivesDir, archiveName);
+  await createTarZstd(dashboardDist, archivePath, vendorInfo, platformKey);
+  platformArchives[platformKey] = {
+    sha256: createHash("sha256").update(readFileSync(archivePath)).digest("hex"),
+    url: getAssetUrl(archiveName, "platform"),
+  };
+}
+
+// 4. Hash the archive and write the manifest the CLI fetches at runtime.
 const sha256 = createHash("sha256").update(readFileSync(zipPath)).digest("hex");
-writeFileSync(manifestPath, `${JSON.stringify({ version, sha256, url: assetUrl }, null, 2)}\n`);
+writeFileSync(manifestPath, `${JSON.stringify({ version, sha256, url: assetUrl, platformArchives }, null, 2)}\n`);
 
 console.log(`Packaged dashboard ${version}`);
 console.log(`  zip:      ${zipPath}`);
 console.log(`  sha256:   ${sha256}`);
 console.log(`  url:      ${assetUrl}`);
 console.log(`  manifest: ${manifestPath}`);
+for (const [platformKey, archive] of Object.entries(platformArchives)) {
+  console.log(`  ${platformKey}: ${archive.url}`);
+  console.log(`    sha256: ${archive.sha256}`);
+}
 
 // Expose values to the release workflow.
 if (process.env.GITHUB_OUTPUT) {
@@ -73,6 +180,7 @@ if (process.env.GITHUB_OUTPUT) {
       `zip_name=${zipName}`,
       `sha256=${sha256}`,
       `manifest=${manifestPath}`,
+      `platform_archives_dir=${platformArchivesDir}`,
       "",
     ].join("\n"),
   );

--- a/packages/cli/src/lib/dashboard-release.test.ts
+++ b/packages/cli/src/lib/dashboard-release.test.ts
@@ -1,4 +1,7 @@
-import { describe, expect, it } from "vitest";
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { afterEach, describe, expect, it } from "vitest";
 import {
   DASHBOARD_DIR_OVERRIDE_ENV_VAR,
   DASHBOARD_MANIFEST_URL_ENV_VAR,
@@ -7,12 +10,20 @@ import {
   dashboardPlatformKey,
   dashboardVersionDir,
   hasZstdSupport,
+  latestCachedDashboard,
   parseDashboardManifest,
   pickLatestVersion,
   selectDashboardArchive,
 } from "./dashboard-release.js";
 
 const VALID_SHA = "a".repeat(64);
+const temporaryDirectories: string[] = [];
+
+afterEach(() => {
+  for (const directory of temporaryDirectories.splice(0)) {
+    rmSync(directory, { recursive: true, force: true });
+  }
+});
 
 describe("parseDashboardManifest", () => {
   it("accepts a well-formed manifest and lowercases the digest", () => {
@@ -142,6 +153,17 @@ describe("dashboard archive selection", () => {
   it("keeps platform-specific and universal cache directories separate", () => {
     expect(dashboardVersionDir("1.2.3", "linux-x64")).not.toBe(dashboardVersionDir("1.2.3"));
     expect(dashboardVersionDir("1.2.3", "linux-x64")).toContain("1.2.3--linux-x64");
+  });
+
+  it("never returns a platform cache from the universal lookup", () => {
+    const cacheRoot = mkdtempSync(join(tmpdir(), "dashboard-cache-test-"));
+    temporaryDirectories.push(cacheRoot);
+    const platformRoot = join(cacheRoot, "1.2.3--linux-x64");
+    mkdirSync(join(platformRoot, "apps", "dashboard"), { recursive: true });
+    writeFileSync(join(platformRoot, ".hexclave-complete"), "hash\n");
+    writeFileSync(join(platformRoot, "apps", "dashboard", "server.js"), "");
+
+    expect(latestCachedDashboard(undefined, cacheRoot)).toBeUndefined();
   });
 });
 

--- a/packages/cli/src/lib/dashboard-release.test.ts
+++ b/packages/cli/src/lib/dashboard-release.test.ts
@@ -4,8 +4,12 @@ import {
   DASHBOARD_MANIFEST_URL_ENV_VAR,
   dashboardDirOverride,
   dashboardManifestUrl,
+  dashboardPlatformKey,
+  dashboardVersionDir,
+  hasZstdSupport,
   parseDashboardManifest,
   pickLatestVersion,
+  selectDashboardArchive,
 } from "./dashboard-release.js";
 
 const VALID_SHA = "a".repeat(64);
@@ -60,6 +64,84 @@ describe("parseDashboardManifest", () => {
     expect(parseDashboardManifest({ version: "1.2", sha256: VALID_SHA, url: "https://x/y.zip" })).toBeNull();
     expect(parseDashboardManifest({ version: "latest", sha256: VALID_SHA, url: "https://x/y.zip" })).toBeNull();
     expect(parseDashboardManifest({ version: "1.2.3/../x", sha256: VALID_SHA, url: "https://x/y.zip" })).toBeNull();
+  });
+
+  it("accepts optional platform archives while retaining the universal zip fields", () => {
+    expect(parseDashboardManifest({
+      version: "1.2.3",
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+      platformArchives: {
+        "linux-x64": { sha256: VALID_SHA.toUpperCase(), url: "https://x/dashboard-linux-x64.tar.zst" },
+      },
+    })).toEqual({
+      version: "1.2.3",
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+      platformArchives: {
+        "linux-x64": { sha256: VALID_SHA, url: "https://x/dashboard-linux-x64.tar.zst" },
+      },
+    });
+  });
+
+  it("ignores malformed platform archives so the universal zip remains usable", () => {
+    expect(parseDashboardManifest({
+      version: "1.2.3",
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+      platformArchives: { "linux-x64": { sha256: "bad", url: "https://x/dashboard.tar.zst" } },
+    })).toEqual({ version: "1.2.3", sha256: VALID_SHA, url: "https://x/dashboard.zip" });
+    expect(parseDashboardManifest({
+      version: "1.2.3",
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+      platformArchives: { "plan9-x64": { sha256: VALID_SHA, url: "https://x/dashboard.tar.zst" } },
+    })).toEqual({ version: "1.2.3", sha256: VALID_SHA, url: "https://x/dashboard.zip" });
+  });
+});
+
+describe("dashboard archive selection", () => {
+  const manifest = {
+    version: "1.2.3",
+    sha256: VALID_SHA,
+    url: "https://x/dashboard.zip",
+    platformArchives: {
+      "linux-x64": { sha256: "b".repeat(64), url: "https://x/dashboard-linux-x64.tar.zst" },
+    },
+  };
+
+  it("uses the platform archive when one matches", () => {
+    expect(selectDashboardArchive(manifest, "linux-x64")).toEqual({
+      sha256: "b".repeat(64),
+      url: "https://x/dashboard-linux-x64.tar.zst",
+      cacheSuffix: "linux-x64",
+    });
+  });
+
+  it("falls back to the universal zip for an unsupported or missing platform", () => {
+    expect(selectDashboardArchive(manifest, "darwin-arm64")).toEqual({
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+    });
+    expect(selectDashboardArchive(manifest, "win32-x64")).toEqual({
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+    });
+    expect(dashboardPlatformKey("linux", "x64")).toBe("linux-x64");
+    expect(dashboardPlatformKey("aix", "ppc64")).toBeUndefined();
+  });
+
+  it("falls back when zstd is unavailable at runtime", () => {
+    expect(hasZstdSupport({ createZstdCompress: undefined, createZstdDecompress: undefined })).toBe(false);
+    expect(selectDashboardArchive(manifest, "linux-x64", false)).toEqual({
+      sha256: VALID_SHA,
+      url: "https://x/dashboard.zip",
+    });
+  });
+
+  it("keeps platform-specific and universal cache directories separate", () => {
+    expect(dashboardVersionDir("1.2.3", "linux-x64")).not.toBe(dashboardVersionDir("1.2.3"));
+    expect(dashboardVersionDir("1.2.3", "linux-x64")).toContain("1.2.3--linux-x64");
   });
 });
 

--- a/packages/cli/src/lib/dashboard-release.ts
+++ b/packages/cli/src/lib/dashboard-release.ts
@@ -216,16 +216,26 @@ function isVersionNewer(candidate: ParsedVersion, current: ParsedVersion): boole
   return false;
 }
 
-function latestCachedDashboard(platformKey?: DashboardPlatformKey): { version: string, root: string } | undefined {
-  const root = dashboardCacheRoot();
+export function latestCachedDashboard(
+  platformKey?: DashboardPlatformKey,
+  cacheRoot: string = dashboardCacheRoot(),
+): { version: string, root: string } | undefined {
+  const root = cacheRoot;
   if (!existsSync(root)) return undefined;
   const suffix = platformKey == null ? "" : `--${platformKey}`;
   const cached = readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && entry.name.endsWith(suffix))
+    .filter((entry) => (
+      entry.isDirectory()
+      && (platformKey == null
+        ? !DASHBOARD_PLATFORM_KEYS.some((supportedKey) => entry.name.endsWith(`--${supportedKey}`))
+        : entry.name.endsWith(suffix))
+    ))
     .map((entry) => {
       const version = suffix.length === 0 ? entry.name : entry.name.slice(0, -suffix.length);
-      return isDashboardCached(version, platformKey)
-        ? { version, root: dashboardVersionDir(version, platformKey) }
+      const cachedRoot = join(root, platformKey == null ? version : `${version}--${platformKey}`);
+      return existsSync(join(cachedRoot, DASHBOARD_COMPLETE_MARKER))
+        && existsSync(join(cachedRoot, DASHBOARD_SERVER_RELATIVE_PATH))
+        ? { version, root: cachedRoot }
         : undefined;
     })
     .filter((entry): entry is { version: string, root: string } => entry != null);

--- a/packages/cli/src/lib/dashboard-release.ts
+++ b/packages/cli/src/lib/dashboard-release.ts
@@ -172,8 +172,12 @@ export function dashboardVersionDir(version: string, cacheSuffix?: DashboardPlat
   return join(dashboardCacheRoot(), cacheSuffix == null ? version : `${version}--${cacheSuffix}`);
 }
 
-export function isDashboardCached(version: string, cacheSuffix?: DashboardPlatformKey): boolean {
-  const dir = dashboardVersionDir(version, cacheSuffix);
+export function isDashboardCached(
+  version: string,
+  cacheSuffix?: DashboardPlatformKey,
+  cacheRoot: string = dashboardCacheRoot(),
+): boolean {
+  const dir = join(cacheRoot, cacheSuffix == null ? version : `${version}--${cacheSuffix}`);
   return existsSync(join(dir, DASHBOARD_COMPLETE_MARKER)) && existsSync(join(dir, DASHBOARD_SERVER_RELATIVE_PATH));
 }
 
@@ -220,10 +224,9 @@ export function latestCachedDashboard(
   platformKey?: DashboardPlatformKey,
   cacheRoot: string = dashboardCacheRoot(),
 ): { version: string, root: string } | undefined {
-  const root = cacheRoot;
-  if (!existsSync(root)) return undefined;
+  if (!existsSync(cacheRoot)) return undefined;
   const suffix = platformKey == null ? "" : `--${platformKey}`;
-  const cached = readdirSync(root, { withFileTypes: true })
+  const cached = readdirSync(cacheRoot, { withFileTypes: true })
     .filter((entry) => (
       entry.isDirectory()
       && (platformKey == null
@@ -232,10 +235,9 @@ export function latestCachedDashboard(
     ))
     .map((entry) => {
       const version = suffix.length === 0 ? entry.name : entry.name.slice(0, -suffix.length);
-      const cachedRoot = join(root, platformKey == null ? version : `${version}--${platformKey}`);
-      return existsSync(join(cachedRoot, DASHBOARD_COMPLETE_MARKER))
-        && existsSync(join(cachedRoot, DASHBOARD_SERVER_RELATIVE_PATH))
-        ? { version, root: cachedRoot }
+      const root = join(cacheRoot, platformKey == null ? version : `${version}--${platformKey}`);
+      return isDashboardCached(version, platformKey, cacheRoot)
+        ? { version, root }
         : undefined;
     })
     .filter((entry): entry is { version: string, root: string } => entry != null);

--- a/packages/cli/src/lib/dashboard-release.ts
+++ b/packages/cli/src/lib/dashboard-release.ts
@@ -3,13 +3,16 @@ import { createReadStream, createWriteStream, existsSync, mkdirSync, readdirSync
 import { dirname, join } from "path";
 import { Readable } from "stream";
 import { pipeline } from "stream/promises";
+import * as zlib from "node:zlib";
+import * as tar from "tar";
 import extractZip from "extract-zip";
 import { devEnvStatePath } from "./dev-env-state.js";
 import { CliError, errorMessage } from "./errors.js";
 
-// The RDE dashboard ships as a zipped standalone build attached to a GitHub
-// Release rather than bundled in the CLI tarball; `hexclave dev` fetches the
-// newest one at runtime and caches it. Publishing side: dashboard-release.yaml.
+// The development-environment dashboard ships as standalone archives attached
+// to a GitHub Release rather than bundled in the CLI tarball; `hexclave dev`
+// fetches the newest one at runtime and caches it. Publishing side:
+// dashboard-release.yaml.
 
 const DASHBOARD_REPO = "hexclave/hexclave";
 // Floating manifest pointing at the newest build — a stable download URL (no API
@@ -30,6 +33,9 @@ const LOG_PREFIX = "[Hexclave] ";
 // `version` becomes a cache dir name and the manifest is untrusted, so require a
 // path-safe semver.
 const SAFE_VERSION_REGEX = /^v?\d+\.\d+\.\d+(?:[-+][0-9A-Za-z.-]+)*$/;
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return value != null && typeof value === "object" && !Array.isArray(value);
+}
 // Don't hang forever on a slow host; a timeout falls through to the offline cache.
 const MANIFEST_FETCH_TIMEOUT_MS = 10_000;
 const DASHBOARD_DOWNLOAD_TIMEOUT_MS = 5 * 60_000;
@@ -54,6 +60,12 @@ export type DashboardManifest = {
   version: string,
   sha256: string,
   url: string,
+  platformArchives?: Record<string, DashboardPlatformArchive>,
+};
+
+export type DashboardPlatformArchive = {
+  sha256: string,
+  url: string,
 };
 
 export type ResolvedDashboard = {
@@ -61,17 +73,85 @@ export type ResolvedDashboard = {
   version: string,
 };
 
+export const DASHBOARD_PLATFORM_KEYS = [
+  "darwin-arm64",
+  "darwin-x64",
+  "linux-arm64",
+  "linux-x64",
+  "win32-arm64",
+  "win32-x64",
+] as const;
+export type DashboardPlatformKey = (typeof DASHBOARD_PLATFORM_KEYS)[number];
+
 function logDashboard(message: string): void {
   console.warn(`${LOG_PREFIX}${message}`);
 }
 
 export function parseDashboardManifest(raw: unknown): DashboardManifest | null {
-  if (raw == null || typeof raw !== "object") return null;
-  const manifest = raw as Record<string, unknown>;
+  if (!isRecord(raw)) return null;
+  const manifest = raw;
   if (typeof manifest.version !== "string" || !SAFE_VERSION_REGEX.test(manifest.version)) return null;
   if (typeof manifest.sha256 !== "string" || !/^[0-9a-f]{64}$/i.test(manifest.sha256)) return null;
   if (typeof manifest.url !== "string" || !isAllowedDownloadUrl(manifest.url)) return null;
-  return { version: manifest.version, sha256: manifest.sha256.toLowerCase(), url: manifest.url };
+  let platformArchives: Record<string, DashboardPlatformArchive> | undefined;
+  if (manifest.platformArchives != null) {
+    if (!isRecord(manifest.platformArchives)) {
+      return { version: manifest.version, sha256: manifest.sha256.toLowerCase(), url: manifest.url };
+    }
+    const validPlatformArchives: Record<string, DashboardPlatformArchive> = {};
+    for (const [platform, value] of Object.entries(manifest.platformArchives)) {
+      if (!DASHBOARD_PLATFORM_KEYS.some((supportedKey) => supportedKey === platform)) continue;
+      if (!isRecord(value)) continue;
+      const archive = value;
+      if (
+        typeof archive.sha256 !== "string"
+        || !/^[0-9a-f]{64}$/i.test(archive.sha256)
+        || typeof archive.url !== "string"
+        || !isAllowedDownloadUrl(archive.url)
+      ) {
+        continue;
+      }
+      validPlatformArchives[platform] = {
+        sha256: archive.sha256.toLowerCase(),
+        url: archive.url,
+      };
+    }
+    if (Object.keys(validPlatformArchives).length > 0) platformArchives = validPlatformArchives;
+  }
+  return {
+    version: manifest.version,
+    sha256: manifest.sha256.toLowerCase(),
+    url: manifest.url,
+    ...(platformArchives == null ? {} : { platformArchives }),
+  };
+}
+
+export function dashboardPlatformKey(
+  platform: NodeJS.Platform = process.platform,
+  arch: string = process.arch,
+): DashboardPlatformKey | undefined {
+  const key = `${platform}-${arch}`;
+  return DASHBOARD_PLATFORM_KEYS.find((supportedKey) => supportedKey === key);
+}
+
+type ZstdCapability = {
+  createZstdCompress?: unknown,
+  createZstdDecompress?: unknown,
+};
+
+export function hasZstdSupport(zlibModule: ZstdCapability = zlib): boolean {
+  return typeof zlibModule.createZstdCompress === "function" && typeof zlibModule.createZstdDecompress === "function";
+}
+
+export function selectDashboardArchive(
+  manifest: DashboardManifest,
+  platformKey = dashboardPlatformKey(),
+  zstdAvailable = hasZstdSupport(),
+): { sha256: string, url: string, cacheSuffix?: DashboardPlatformKey } {
+  const platformArchive = !zstdAvailable || platformKey == null ? undefined : manifest.platformArchives?.[platformKey];
+  return platformArchive == null
+    ? { sha256: manifest.sha256, url: manifest.url }
+    : { ...platformArchive, cacheSuffix: platformKey };
 }
 
 export function dashboardDirOverride(env: NodeJS.ProcessEnv = process.env): string | undefined {
@@ -88,12 +168,12 @@ export function dashboardCacheRoot(): string {
   return join(dirname(devEnvStatePath()), DASHBOARD_CACHE_DIR_NAME);
 }
 
-export function dashboardVersionDir(version: string): string {
-  return join(dashboardCacheRoot(), version);
+export function dashboardVersionDir(version: string, cacheSuffix?: DashboardPlatformKey): string {
+  return join(dashboardCacheRoot(), cacheSuffix == null ? version : `${version}--${cacheSuffix}`);
 }
 
-export function isDashboardCached(version: string): boolean {
-  const dir = dashboardVersionDir(version);
+export function isDashboardCached(version: string, cacheSuffix?: DashboardPlatformKey): boolean {
+  const dir = dashboardVersionDir(version, cacheSuffix);
   return existsSync(join(dir, DASHBOARD_COMPLETE_MARKER)) && existsSync(join(dir, DASHBOARD_SERVER_RELATIVE_PATH));
 }
 
@@ -136,13 +216,21 @@ function isVersionNewer(candidate: ParsedVersion, current: ParsedVersion): boole
   return false;
 }
 
-export function latestCachedDashboardVersion(): string | undefined {
+function latestCachedDashboard(platformKey?: DashboardPlatformKey): { version: string, root: string } | undefined {
   const root = dashboardCacheRoot();
   if (!existsSync(root)) return undefined;
+  const suffix = platformKey == null ? "" : `--${platformKey}`;
   const cached = readdirSync(root, { withFileTypes: true })
-    .filter((entry) => entry.isDirectory() && isDashboardCached(entry.name))
-    .map((entry) => entry.name);
-  return pickLatestVersion(cached);
+    .filter((entry) => entry.isDirectory() && entry.name.endsWith(suffix))
+    .map((entry) => {
+      const version = suffix.length === 0 ? entry.name : entry.name.slice(0, -suffix.length);
+      return isDashboardCached(version, platformKey)
+        ? { version, root: dashboardVersionDir(version, platformKey) }
+        : undefined;
+    })
+    .filter((entry): entry is { version: string, root: string } => entry != null);
+  const version = pickLatestVersion(cached.map((entry) => entry.version));
+  return version == null ? undefined : cached.find((entry) => entry.version === version);
 }
 
 export async function fetchDashboardManifest(env: NodeJS.ProcessEnv = process.env): Promise<DashboardManifest | null> {
@@ -166,52 +254,67 @@ async function sha256File(path: string): Promise<string> {
   return hash.digest("hex");
 }
 
-async function downloadDashboardRelease(manifest: DashboardManifest, onProgress?: (message: string) => void): Promise<void> {
+async function downloadDashboardRelease(
+  manifest: DashboardManifest,
+  archive: { sha256: string, url: string, cacheSuffix?: DashboardPlatformKey },
+  onProgress?: (message: string) => void,
+): Promise<void> {
   const cacheRoot = dashboardCacheRoot();
   mkdirSync(cacheRoot, { recursive: true });
   // Unique temp names so parallel runs don't collide; publish is an atomic rename.
   const suffix = `${process.pid}-${randomBytes(8).toString("hex")}`;
-  const tmpZip = join(cacheRoot, `.download-${manifest.version}-${suffix}.zip`);
+  const tmpArchive = join(
+    cacheRoot,
+    `.download-${manifest.version}-${suffix}${archive.cacheSuffix == null ? ".zip" : ".tar.zst"}`,
+  );
   const tmpDir = join(cacheRoot, `.extract-${manifest.version}-${suffix}`);
-  const targetDir = dashboardVersionDir(manifest.version);
+  const targetDir = dashboardVersionDir(manifest.version, archive.cacheSuffix);
   try {
     onProgress?.(`Downloading Hexclave dashboard ${manifest.version}`);
-    const response = await fetch(manifest.url, { redirect: "follow", signal: AbortSignal.timeout(DASHBOARD_DOWNLOAD_TIMEOUT_MS) });
+    const response = await fetch(archive.url, { redirect: "follow", signal: AbortSignal.timeout(DASHBOARD_DOWNLOAD_TIMEOUT_MS) });
     // The manifest URL passed isAllowedDownloadUrl, but redirects can land on a
     // different host/scheme; re-check the final URL before streaming the archive.
     if (!isAllowedDownloadUrl(response.url)) {
       throw new CliError(`Dashboard ${manifest.version} download was redirected to a disallowed URL (${response.url}).`);
     }
     if (!response.ok || response.body == null) {
-      throw new CliError(`Failed to download dashboard ${manifest.version} (HTTP ${response.status}) from ${manifest.url}.`);
+      throw new CliError(`Failed to download dashboard ${manifest.version} (HTTP ${response.status}) from ${archive.url}.`);
     }
-    await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(tmpZip));
+    await pipeline(Readable.fromWeb(response.body as Parameters<typeof Readable.fromWeb>[0]), createWriteStream(tmpArchive));
 
     onProgress?.(`Verifying Hexclave dashboard ${manifest.version}`);
-    const digest = await sha256File(tmpZip);
-    if (digest !== manifest.sha256) {
-      throw new CliError(`Dashboard ${manifest.version} failed its integrity check (expected ${manifest.sha256}, got ${digest}).`);
+    const digest = await sha256File(tmpArchive);
+    if (digest !== archive.sha256) {
+      throw new CliError(`Dashboard ${manifest.version} failed its integrity check (expected ${archive.sha256}, got ${digest}).`);
     }
 
     rmSync(tmpDir, { recursive: true, force: true });
     mkdirSync(tmpDir, { recursive: true });
     onProgress?.(`Extracting Hexclave dashboard ${manifest.version}`);
-    await extractZip(tmpZip, { dir: tmpDir });
+    if (archive.cacheSuffix == null) {
+      await extractZip(tmpArchive, { dir: tmpDir });
+    } else {
+      await pipeline(
+        createReadStream(tmpArchive),
+        zlib.createZstdDecompress(),
+        tar.x({ cwd: tmpDir, strict: true, preservePaths: false }),
+      );
+    }
     if (!existsSync(join(tmpDir, DASHBOARD_SERVER_RELATIVE_PATH))) {
       throw new CliError(`Dashboard ${manifest.version} archive is missing its server entrypoint.`);
     }
-    writeFileSync(join(tmpDir, DASHBOARD_COMPLETE_MARKER), `${manifest.sha256}\n`);
+    writeFileSync(join(tmpDir, DASHBOARD_COMPLETE_MARKER), `${archive.sha256}\n`);
 
     // Publish atomically, never rmSync-ing a *valid* targetDir — a concurrent
     // `hexclave dev` may be reading it. The marker is written before the rename,
     // so any fully-published dir passes isDashboardCached.
-    if (isDashboardCached(manifest.version)) {
+    if (isDashboardCached(manifest.version, archive.cacheSuffix)) {
       return;
     }
     try {
       renameSync(tmpDir, targetDir);
     } catch {
-      if (isDashboardCached(manifest.version)) {
+      if (isDashboardCached(manifest.version, archive.cacheSuffix)) {
         return;
       }
       // targetDir exists but isn't valid — an interrupted publish left a partial
@@ -221,7 +324,7 @@ async function downloadDashboardRelease(manifest: DashboardManifest, onProgress?
       renameSync(tmpDir, targetDir);
     }
   } finally {
-    rmSync(tmpZip, { force: true });
+    rmSync(tmpArchive, { force: true });
     rmSync(tmpDir, { recursive: true, force: true });
   }
 }
@@ -242,26 +345,27 @@ export async function resolveDashboardRuntime(opts: {
 
   const manifest = opts.manifest !== undefined ? opts.manifest : await fetchDashboardManifest();
   if (manifest != null) {
-    if (isDashboardCached(manifest.version)) {
-      return { root: dashboardVersionDir(manifest.version), version: manifest.version };
+    const archive = selectDashboardArchive(manifest);
+    if (isDashboardCached(manifest.version, archive.cacheSuffix)) {
+      return { root: dashboardVersionDir(manifest.version, archive.cacheSuffix), version: manifest.version };
     }
     try {
-      await downloadDashboardRelease(manifest, opts.onProgress);
-      return { root: dashboardVersionDir(manifest.version), version: manifest.version };
+      await downloadDashboardRelease(manifest, archive, opts.onProgress);
+      return { root: dashboardVersionDir(manifest.version, archive.cacheSuffix), version: manifest.version };
     } catch (error) {
-      const cached = latestCachedDashboardVersion();
+      const cached = latestCachedDashboard(dashboardPlatformKey()) ?? latestCachedDashboard();
       if (cached != null) {
-        logDashboard(`Failed to download dashboard ${manifest.version} (${errorMessage(error)}); using cached ${cached}.`);
-        return { root: dashboardVersionDir(cached), version: cached };
+        logDashboard(`Failed to download dashboard ${manifest.version} (${errorMessage(error)}); using cached ${cached.version}.`);
+        return cached;
       }
       throw error;
     }
   }
 
-  const cached = latestCachedDashboardVersion();
+  const cached = latestCachedDashboard(dashboardPlatformKey()) ?? latestCachedDashboard();
   if (cached != null) {
-    logDashboard(`Offline: using cached Hexclave dashboard ${cached}.`);
-    return { root: dashboardVersionDir(cached), version: cached };
+    logDashboard(`Offline: using cached Hexclave dashboard ${cached.version}.`);
+    return cached;
   }
 
   throw new CliError([

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1640,7 +1640,7 @@ importers:
         version: link:../shared-backend
       '@inquirer/prompts':
         specifier: ^7.0.0
-        version: 7.10.1(@types/node@20.17.6)
+        version: 7.10.1(@types/node@22.15.21)
       '@sentry/node':
         specifier: ^10.42.0
         version: 10.45.0
@@ -1653,10 +1653,13 @@ importers:
       jiti:
         specifier: ^2.4.2
         version: 2.6.1
+      tar:
+        specifier: ^7.4.3
+        version: 7.4.3
     devDependencies:
       '@types/node':
-        specifier: 20.17.6
-        version: 20.17.6
+        specifier: 22.15.21
+        version: 22.15.21
       rimraf:
         specifier: ^6.0.1
         version: 6.1.2
@@ -2666,6 +2669,9 @@ importers:
   sdks/spec: {}
 
 packages:
+  '@types/node@22.15.21':
+    resolution: {integrity: sha512-EV/37Td6c+MgKAbkcLG6vqZ2zEYHD7bvSrzqqs2RIhbA6w3x+Dqz8MZM3sP6kGTeLrdoOgKZe+Xja7tUB2DNkQ==}
+
 
   '@ai-sdk/gateway@3.0.41':
     resolution: {integrity: sha512-dYNhtvEomccNNGSxfSP8f4g6yPcoDHyQ6Rb7dALFE0FvvVP9UqfFWi3D2dLIz0VVKaSkiNLQAJ7lsdTVlBdRrw==}
@@ -17745,6 +17751,131 @@ packages:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
 
 snapshots:
+  '@inquirer/checkbox@4.3.2(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/confirm@5.1.21(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/core@10.3.2(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      cli-width: 4.1.0
+      mute-stream: 2.0.0
+      signal-exit: 4.1.0
+      wrap-ansi: 6.2.0
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/editor@4.2.23(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/external-editor': 1.0.3(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/expand@4.0.23(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/external-editor@1.0.3(@types/node@22.15.21)':
+    dependencies:
+      chardet: 2.1.1
+      iconv-lite: 0.7.0
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/input@4.3.1(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/number@3.0.23(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/password@4.0.23(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/prompts@7.10.1(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/checkbox': 4.3.2(@types/node@22.15.21)
+      '@inquirer/confirm': 5.1.21(@types/node@22.15.21)
+      '@inquirer/editor': 4.2.23(@types/node@22.15.21)
+      '@inquirer/expand': 4.0.23(@types/node@22.15.21)
+      '@inquirer/input': 4.3.1(@types/node@22.15.21)
+      '@inquirer/number': 3.0.23(@types/node@22.15.21)
+      '@inquirer/password': 4.0.23(@types/node@22.15.21)
+      '@inquirer/rawlist': 4.1.11(@types/node@22.15.21)
+      '@inquirer/search': 3.2.2(@types/node@22.15.21)
+      '@inquirer/select': 4.4.2(@types/node@22.15.21)
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/rawlist@4.1.11(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/search@3.2.2(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/select@4.4.2(@types/node@22.15.21)':
+    dependencies:
+      '@inquirer/ansi': 1.0.2
+      '@inquirer/core': 10.3.2(@types/node@22.15.21)
+      '@inquirer/figures': 1.0.15
+      '@inquirer/type': 3.0.10(@types/node@22.15.21)
+      yoctocolors-cjs: 2.1.3
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@inquirer/type@3.0.10(@types/node@22.15.21)':
+    optionalDependencies:
+      '@types/node': 22.15.21
+
+  '@types/node@22.15.21':
+    dependencies:
+      undici-types: 6.21.0
+
 
   '@ai-sdk/gateway@3.0.41(zod@3.25.76)':
     dependencies:


### PR DESCRIPTION
Stacked on #1807. The development-environment dashboard download goes from **54.6 MB to 31.6 MB** by switching the container from zip/deflate to tar+zstd and shipping only the Claude Agent SDK vendor binaries for the platform doing the download.

The zip stays published and `manifest.json`'s `url`/`sha256` keep pointing at it, so already-released CLIs are unaffected. New CLIs read an added optional field:

```jsonc
{
  "version": "1.0.62",
  "sha256": "…", "url": ".../dashboard-1.0.62.zip",   // universal, unchanged
  "platformArchives": {
    "linux-x64": { "sha256": "…", "url": ".../dashboard-1.0.62-linux-x64.tar.zst" },
    // darwin/linux/win32 × arm64/x64
  }
}
```

`selectDashboardArchive()` picks `platformArchives[`${process.platform}-${process.arch}`]` and falls back to the universal zip when the platform is absent, the entry fails validation, or — importantly — the running Node has no zstd: `node:zlib`'s zstd API only exists from 22.15 while the repo's `engines` allows 22.13, so support is a runtime check (`hasZstdSupport()`) rather than a load-time import. Platform and universal downloads cache under separate directories (`<version>--<platform>` vs `<version>`) so the two can't be mistaken for each other.

Packaging still builds the dashboard once; each platform archive is streamed straight out of the single staged tree with a `tar.c` filter that drops the other platforms' `vendor/**` directories, and throws if it ever selects the wrong set. Sizes per platform, zstd level 15 (~75 s for all six; level 19 tripled that for ~3 MB more):

| | size |
|---|---|
| universal zip | 54.6 MB |
| linux-x64 / arm64 | 31.6 / 31.2 MB |
| darwin-x64 / arm64 | 31.1 / 30.8 MB |
| win32-x64 / arm64 | 31.1 / 30.7 MB |

Verified by serving the archives + manifest over loopback and letting `resolveDashboardRuntime()` download, verify, extract and boot them: HTTP 200 on `/`, the SDK imports, `rg --version` runs from `vendor/ripgrep/x64-linux`, no wrong-platform vendor dirs, and the zip fallback path still resolves. Extraction rejects `..`, absolute paths and symlink escapes; sha256 is still checked before extraction and publishing is still an atomic rename.

Adds `tar` as a `@hexclave/cli` dependency (approved) and bumps the package's `@types/node` to 22.x, which the package already required via `engines`.


Link to Devin session: https://app.devin.ai/sessions/e96c507fc4a14363b5dc099c2afb234b
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Publish per-platform tar.zst dashboard archives to cut downloads from 54.6 MB to ~31 MB and speed up `hexclave dev`. New CLIs prefer a platform archive; older CLIs keep using the universal zip. The release workflow reuses live asset hashes and preserves platform manifest entries.

- New Features
  - Add per‑platform tar.zst archives for `darwin/linux/win32` on `arm64/x64` (~30–32 MB) with only platform‑specific SDK vendor binaries; packaging uses `tar` and runtime extraction uses zstd/tar with integrity and path‑traversal checks.
  - Extend `manifest.json` with `platformArchives` so the runtime selects a matching entry or falls back to the universal zip (and when Node lacks zstd), with separate caches `<version>--<platform>` vs `<version>`; bump `@types/node` to `22.15.21`.

- Bug Fixes
  - Release workflow reuses live SHA256s for both zip and per‑platform assets, validates archive names and manifest keys, re‑validates the patched manifest with the CLI parser, and preserves the exact `platformArchives` key set.
  - Hardened parsing and cache logic: ignore unknown/malformed platform entries, never mix universal and per‑platform cache directories, prefer a platform cache and cleanly fall back to the universal cache.

<sup>Written for commit fafc14abe8fc27976503eb2279a21c8773e71187. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1825?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

