### PR TITLE
fix(template): reject self-referential after-auth redirects

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-location.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-location.ts
@@ -1,0 +1,7 @@
+/**
+ * Query and hash parameters commonly change between redirect hops, so loop prevention and
+ * after-auth self-target checks intentionally compare only the origin and pathname.
+ */
+export function getComparableRedirectLocation(url: URL): string {
+  return `${url.origin}${url.pathname}`;
+}

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-breaker.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-loop-breaker.ts
@@ -1,5 +1,6 @@
 import { HexclaveAssertionError, captureError } from "@hexclave/shared/dist/utils/errors";
 import { readSessionStorageItem, removeSessionStorageItem, writeSessionStorageItem } from "../../../../utils/session-storage";
+import { getComparableRedirectLocation } from "./redirect-location";
 
 /**
  * Last line of defense against redirect loops (most importantly in hosted components flows, where
@@ -69,14 +70,6 @@ function readBreadcrumbs(): RedirectBreadcrumb[] {
 
 function writeBreadcrumbs(breadcrumbs: RedirectBreadcrumb[]): void {
   writeSessionStorageItem(breadcrumbsStorageKey, JSON.stringify(breadcrumbs));
-}
-
-/**
- * Loop iterations usually differ only in nonce-style query params (`code`, `state`,
- * `after_auth_return_to`, ...), so redirects are compared by origin + pathname only.
- */
-function getComparableRedirectLocation(url: URL): string {
-  return `${url.origin}${url.pathname}`;
 }
 
 export function recordRedirectAndThrowIfLoopDetected(options: { currentUrl: URL, targetUrl: URL }): void {

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
@@ -3,6 +3,10 @@ import { planRedirectToHandler } from "./redirect-page-urls";
 
 const defaultAfterAuthUrl = "/";
 const localOAuthCallbackUrl = "/handler/oauth-callback";
+const afterAuthHandlers: readonly ("afterSignIn" | "afterSignUp")[] = [
+  "afterSignIn",
+  "afterSignUp",
+];
 
 async function planAfterAuthRedirect(
   handlerName: "afterSignIn" | "afterSignUp",
@@ -22,20 +26,25 @@ async function planAfterAuthRedirect(
 }
 
 describe("after-auth redirect planning", () => {
-  it.each(["afterSignIn", "afterSignUp"] as const)(
-    "falls back to the default when %s_auth_return_to points to the current page",
-    async (handlerName) => {
-      await expect(
-        planAfterAuthRedirect(
-          handlerName,
-          "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fhandler%2Fsign-in",
-        ),
-      ).resolves.toEqual({
-        type: "redirect",
-        url: defaultAfterAuthUrl,
-      });
-    },
-  );
+  it("falls back to the default when after_auth_return_to points to the current page", async () => {
+    await expect(
+      Promise.all(afterAuthHandlers.map((handlerName) => planAfterAuthRedirect(
+        handlerName,
+        "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fhandler%2Fsign-in",
+      ))),
+    ).resolves.toMatchInlineSnapshot(`
+      [
+        {
+          "type": "redirect",
+          "url": "/",
+        },
+        {
+          "type": "redirect",
+          "url": "/",
+        },
+      ]
+    `);
+  });
 
   it("honors a different after_auth_return_to path", async () => {
     await expect(
@@ -43,10 +52,12 @@ describe("after-auth redirect planning", () => {
         "afterSignIn",
         "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fdashboard",
       ),
-    ).resolves.toEqual({
-      type: "redirect",
-      url: "/dashboard",
-    });
+    ).resolves.toMatchInlineSnapshot(`
+      {
+        "type": "redirect",
+        "url": "/dashboard",
+      }
+    `);
   });
 
   it("treats query and hash differences on the current path as self-referential", async () => {
@@ -55,9 +66,11 @@ describe("after-auth redirect planning", () => {
         "afterSignUp",
         "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fhandler%2Fsign-in%3Ftab%3Dpassword%23details",
       ),
-    ).resolves.toEqual({
-      type: "redirect",
-      url: defaultAfterAuthUrl,
-    });
+    ).resolves.toMatchInlineSnapshot(`
+      {
+        "type": "redirect",
+        "url": "/",
+      }
+    `);
   });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, it } from "vitest";
+import { planRedirectToHandler } from "./redirect-page-urls";
+
+const defaultAfterAuthUrl = "/";
+const localOAuthCallbackUrl = "/handler/oauth-callback";
+
+async function planAfterAuthRedirect(
+  handlerName: "afterSignIn" | "afterSignUp",
+  currentUrl: string,
+) {
+  return await planRedirectToHandler({
+    handlerName,
+    rawHandlerUrl: defaultAfterAuthUrl,
+    noRedirectBack: false,
+    currentUrl: new URL(currentUrl),
+    localOAuthCallbackUrl,
+    getCrossDomainHandoffParams: async () => ({
+      state: "state",
+      codeChallenge: "code-challenge",
+    }),
+  });
+}
+
+describe("after-auth redirect planning", () => {
+  it.each(["afterSignIn", "afterSignUp"] as const)(
+    "falls back to the default when %s_auth_return_to points to the current page",
+    async (handlerName) => {
+      await expect(
+        planAfterAuthRedirect(
+          handlerName,
+          "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fhandler%2Fsign-in",
+        ),
+      ).resolves.toEqual({
+        type: "redirect",
+        url: defaultAfterAuthUrl,
+      });
+    },
+  );
+
+  it("honors a different after_auth_return_to path", async () => {
+    await expect(
+      planAfterAuthRedirect(
+        "afterSignIn",
+        "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fdashboard",
+      ),
+    ).resolves.toEqual({
+      type: "redirect",
+      url: "/dashboard",
+    });
+  });
+
+  it("treats query and hash differences on the current path as self-referential", async () => {
+    await expect(
+      planAfterAuthRedirect(
+        "afterSignUp",
+        "https://hosted.example.test/handler/sign-in?after_auth_return_to=%2Fhandler%2Fsign-in%3Ftab%3Dpassword%23details",
+      ),
+    ).resolves.toEqual({
+      type: "redirect",
+      url: defaultAfterAuthUrl,
+    });
+  });
+});

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
@@ -73,4 +73,39 @@ describe("after-auth redirect planning", () => {
       }
     `);
   });
+
+  it("preserves a cross-domain handoff when its same-origin target matches the current path", async () => {
+    const currentUrl = new URL("https://hosted.example.test/handler/oauth-callback");
+    const redirectBackTarget = new URL("https://hosted.example.test/handler/oauth-callback");
+    redirectBackTarget.searchParams.set("hexclave_cross_domain_auth", "1");
+    redirectBackTarget.searchParams.set("hexclave_cross_domain_state", "state");
+    redirectBackTarget.searchParams.set("hexclave_cross_domain_code_challenge", "code-challenge");
+    redirectBackTarget.searchParams.set(
+      "hexclave_cross_domain_after_callback_redirect_url",
+      "https://app.example.test/callback",
+    );
+    currentUrl.searchParams.set("after_auth_return_to", redirectBackTarget.pathname + redirectBackTarget.search);
+
+    await expect(
+      planRedirectToHandler({
+        handlerName: "afterSignIn",
+        rawHandlerUrl: defaultAfterAuthUrl,
+        noRedirectBack: false,
+        currentUrl,
+        localOAuthCallbackUrl,
+        getCrossDomainHandoffParams: async () => ({
+          state: "state",
+          codeChallenge: "code-challenge",
+        }),
+      }),
+    ).resolves.toMatchInlineSnapshot(`
+      {
+        "afterCallbackRedirectUrl": "https://app.example.test/callback",
+        "codeChallenge": "code-challenge",
+        "redirectUri": "https://app.example.test/handler/oauth-callback?hexclave_cross_domain_auth=1&hexclave_cross_domain_state=state&hexclave_cross_domain_code_challenge=code-challenge&hexclave_cross_domain_after_callback_redirect_url=https%3A%2F%2Fapp.example.test%2Fcallback",
+        "state": "state",
+        "type": "cross-domain-authorize",
+      }
+    `);
+  });
 });

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.ts
@@ -227,19 +227,19 @@ export async function planRedirectToHandler(options: {
       return { type: "redirect", url: options.rawHandlerUrl };
     }
     const redirectBackTarget = new URL(redirectBackUrl, options.currentUrl);
-    // A return target pointing back to the current auth page can never complete authentication;
-    // use the configured post-auth destination instead of feeding automaticRedirect a self-loop.
-    if (
-      getComparableRedirectLocation(redirectBackTarget)
-      === getComparableRedirectLocation(options.currentUrl)
-    ) {
-      return { type: "redirect", url: options.rawHandlerUrl };
-    }
     const crossDomainHandoff = getCrossDomainHandoffForRedirect({
       currentUrl: options.currentUrl,
       redirectBackTarget,
     });
     if (crossDomainHandoff == null) {
+      // A return target pointing back to the current auth page can never complete authentication;
+      // cross-domain handoffs are excluded because their query parameters carry the next auth hop.
+      if (
+        getComparableRedirectLocation(redirectBackTarget)
+        === getComparableRedirectLocation(options.currentUrl)
+      ) {
+        return { type: "redirect", url: options.rawHandlerUrl };
+      }
       return { type: "redirect", url: redirectBackUrl };
     }
     let state = crossDomainHandoff.handoffParams.state;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.ts
@@ -1,6 +1,7 @@
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { getRelativePart } from "@hexclave/shared/dist/utils/urls";
 import { HandlerUrls } from "../../common";
+import { getComparableRedirectLocation } from "./redirect-location";
 
 export const crossDomainAuthQueryParams = {
   marker: "hexclave_cross_domain_auth",
@@ -226,6 +227,14 @@ export async function planRedirectToHandler(options: {
       return { type: "redirect", url: options.rawHandlerUrl };
     }
     const redirectBackTarget = new URL(redirectBackUrl, options.currentUrl);
+    // A return target pointing back to the current auth page can never complete authentication;
+    // use the configured post-auth destination instead of feeding automaticRedirect a self-loop.
+    if (
+      getComparableRedirectLocation(redirectBackTarget)
+      === getComparableRedirectLocation(options.currentUrl)
+    ) {
+      return { type: "redirect", url: options.rawHandlerUrl };
+    }
     const crossDomainHandoff = getCrossDomainHandoffForRedirect({
       currentUrl: options.currentUrl,
       redirectBackTarget,


### PR DESCRIPTION
## Summary

An `after_auth_return_to` pointing at the auth page you're currently on made auth unrecoverable: sign-in would authenticate, read the return target, and redirect to itself until `recordRedirectAndThrowIfLoopDetected` gave up with `Redirect loop detected: .../handler/sign-in -> .../handler/sign-in`, leaving the page stuck on a skeleton until session storage was cleared.

Repro: open `/handler/sign-up?after_auth_return_to=%2Fhandler%2Fsign-in` (the sign-up page preserves the param when you click through to Sign In), then sign in.

`planRedirectToHandler` now discards a return target that resolves to the current page and falls back to the configured post-auth URL:

```ts
const redirectBackTarget = new URL(redirectBackUrl, options.currentUrl);
if (getComparableRedirectLocation(redirectBackTarget) === getComparableRedirectLocation(options.currentUrl)) {
  return { type: "redirect", url: options.rawHandlerUrl };
}
```

The origin+pathname comparison (query/hash ignored) is the same one the redirect-loop breaker already used, so the two now agree by construction — `getComparableRedirectLocation` moved out of `redirect-loop-breaker.ts` into a shared `redirect-location.ts`. The check is deliberately limited to *the current page*, not auth handler paths in general, so multi-hop flows (OAuth, MFA, magic link, cross-domain handoff) that legitimately carry the return target across several pages are unaffected.

Tests cover the self-target fallback for both `afterSignIn` and `afterSignUp`, a different-path target still being honored, and query/hash-only differences still counting as self-referential.

Verified in the browser against a local dev project: the repro above now lands on the default post-sign-in destination with no assertion and no skeleton hang.


Link to Devin session: https://app.devin.ai/sessions/b210029220544aecb77fcb5b34ca98f7
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents auth redirect loops by rejecting self-referential `after_auth_return_to` targets and falling back to the default post-auth URL. Cross-domain handoffs are preserved, and origin+pathname comparison is shared for consistent behavior.

- **Bug Fixes**
  - In `planRedirectToHandler`, ignore a return target that resolves to the current auth page (query/hash ignored) and redirect to the configured post-auth URL.
  - Exclude cross-domain handoffs from the self-target check so OAuth/MFA/magic-link flows proceed.
  - Add inline-snapshot tests for `afterSignIn`/`afterSignUp`: self-target falls back; different paths are honored; query/hash-only diffs count as self; cross-domain same-path handoff is preserved.

- **Refactors**
  - Extract `getComparableRedirectLocation` to `redirect-location.ts` and reuse it across redirect checks.

<sup>Written for commit 9f58558d1f49a46376bd9ff6d2906c96f93d03bc. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1827?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Prevented authentication redirects from looping back to the current sign-in page by comparing redirect destinations using only origin and path.
  * Improved after-auth redirect planning to fall back to the default return target when the configured return is effectively self-referential (including cases that differ only by query/hash).
* **Tests**
  * Added coverage for default returns, alternate paths, query/hash variations, and cross-domain handoff redirect plans to ensure the expected redirect outputs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->