### PR TITLE
Await snapshot replication for bulldozer-js row writes

### DIFF
--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -426,7 +426,12 @@ async function setStoredRow(options: { tenancyId: string, tableId: string, rowId
     throw new StatusError(StatusError.BadRequest, `Row tenancyId ${readRowTenancyId(options.rowData)} does not match URL tenancyId ${options.tenancyId}`);
   }
   try {
-    await bulldozerDb.withSnapshot(async snapshot => await snapshot.setOrDeleteRow({
+    // Replicated: reads (item quantities, owned products, …) serve the snapshot root, which only moves
+    // forward once a write has replicated. A non-replicated write returns before that, so a caller that
+    // writes a subscription and immediately reads its items can observe the pre-write state until the
+    // next tick pushes the root forward — waiting here gives HTTP callers read-your-writes. Replication
+    // happens after the write lock is released, so this doesn't serialize concurrent writers.
+    await bulldozerDb.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({
       tableId: options.tableId,
       rowIdentifier: options.rowId,
       newRowData: options.rowData as unknown as PiledriverObject,
@@ -489,7 +494,8 @@ async function setStoredRowsFromBodies(options: { tenancyId: string, tableId: st
     return { rowIdentifier: readStringField(rowData, idField), newRowData: rowData as unknown as PiledriverObject };
   });
   try {
-    await bulldozerDb.withSnapshot(async snapshot => await snapshot.setOrDeleteRows({ tableId: options.tableId, rows }));
+    // Replicated for the same read-your-writes reason as the single-row write above.
+    await bulldozerDb.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRows({ tableId: options.tableId, rows }));
   } catch (error) {
     // A batch is one cascade, so a cascade-phase failure can't be pinned to a single row.
     // Attach the table + the batch's row identifiers (no rowData here, to keep batch events small).

--- a/apps/bulldozer-js/src/index.ts
+++ b/apps/bulldozer-js/src/index.ts
@@ -426,11 +426,7 @@ async function setStoredRow(options: { tenancyId: string, tableId: string, rowId
     throw new StatusError(StatusError.BadRequest, `Row tenancyId ${readRowTenancyId(options.rowData)} does not match URL tenancyId ${options.tenancyId}`);
   }
   try {
-    // Replicated: reads (item quantities, owned products, …) serve the snapshot root, which only moves
-    // forward once a write has replicated. A non-replicated write returns before that, so a caller that
-    // writes a subscription and immediately reads its items can observe the pre-write state until the
-    // next tick pushes the root forward — waiting here gives HTTP callers read-your-writes. Replication
-    // happens after the write lock is released, so this doesn't serialize concurrent writers.
+    // Replicated, so that a caller reading right after this write doesn't see the pre-write snapshot root.
     await bulldozerDb.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRow({
       tableId: options.tableId,
       rowIdentifier: options.rowId,
@@ -494,7 +490,6 @@ async function setStoredRowsFromBodies(options: { tenancyId: string, tableId: st
     return { rowIdentifier: readStringField(rowData, idField), newRowData: rowData as unknown as PiledriverObject };
   });
   try {
-    // Replicated for the same read-your-writes reason as the single-row write above.
     await bulldozerDb.withSnapshotReplicated(async snapshot => await snapshot.setOrDeleteRows({ tableId: options.tableId, rows }));
   } catch (error) {
     // A batch is one cascade, so a cascade-phase failure can't be pinned to a single row.

--- a/apps/e2e/tests/backend/endpoints/api/v1/index.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/index.test.ts
@@ -15,7 +15,7 @@ describe("without project ID", () => {
         "status": 200,
         "body": deindent\`
           Welcome to the Hexclave API endpoint! Please refer to the documentation at https://docs.hexclave.com.
-
+          
           Authentication: None
         \`,
         "headers": Headers { <some fields may have been hidden> },


### PR DESCRIPTION
Fixes a class of timing flakes in the e2e suite (payments item quantities, email delivery stats, payments-perf).

`bulldozer-js` HTTP row writes used `withSnapshot` (`replicated: false`), which returns before the write is replicated, while reads serve the snapshot root — which only moves forward on a replicated write. Between the two, the only replicated write is the ~1s tick loop, so a caller that writes a subscription and immediately reads its item quantities could observe the pre-write state for up to a tick.

```diff
 async function setStoredRow(...) {
-  await bulldozerDb.withSnapshot(s => s.setOrDeleteRow(...));
+  await bulldozerDb.withSnapshotReplicated(s => s.setOrDeleteRow(...));
 async function setStoredRowsFromBodies(...) {
-  await bulldozerDb.withSnapshot(s => s.setOrDeleteRows(...));
+  await bulldozerDb.withSnapshotReplicated(s => s.setOrDeleteRows(...));
```

Replication is awaited after the write lock is released, so concurrent writers aren't serialized by this.

Also restores the whitespace-only line in the `/api/v1` inline snapshot in `index.test.ts`, which had been stripped and no longer matched the response body (unrelated to the timing issue, but failing on `dev`).


Link to Devin session: https://app.devin.ai/sessions/d42559d85b564acaaead7561f17b6ba9
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Await snapshot replication for HTTP row writes in `bulldozer-js` to guarantee read-your-writes and remove e2e timing flakes (payments item quantities, email delivery stats, payments-perf). Also restores a whitespace-only line in the `/api/v1` inline snapshot.

- **Bug Fixes**
  - Use `withSnapshotReplicated` for single and batch writes so reads see the replicated snapshot root; replication awaits after the write lock, so writers aren’t serialized.
  - Restore the whitespace-only line in the `/api/v1` inline snapshot test.

<sup>Written for commit 335e74f330dffb9cc744ac368214955fe399c541. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1831?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved read-your-writes behavior by switching stored write operations to use replicated snapshot handling, ensuring newly written data is immediately visible to subsequent reads.

* **Tests**
  * Updated the API v1 endpoint test to match revised whitespace formatting in the expected response body.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->