### PR TITLE
Return reminders from ask_hexclave MCP tool and skill-site /ask endpoint

### DIFF
--- a/apps/mcp/src/mcp-handler.ts
+++ b/apps/mcp/src/mcp-handler.ts
@@ -157,7 +157,7 @@ export function createHexclaveMcpHandler(config: { streamableHttpEndpoint: strin
             ? ""
             : `\n\n[conversationId: ${result.conversationId} - pass this value as the conversationId parameter in your next ask_hexclave call to continue this conversation]`;
           return {
-            content: [{ type: "text", text: `${result.text}${continuation}` }],
+            content: [{ type: "text", text: `${result.text}${continuation}\n\n---\n\n${remindersPrompt}` }],
           };
         },
       );

--- a/apps/skills/src/ask-route.test.ts
+++ b/apps/skills/src/ask-route.test.ts
@@ -12,6 +12,14 @@ function restoreEnvVariable(name: string, value: string | undefined) {
   }
 }
 
+function normalizeReminders(responseText: string): string {
+  const remindersSuffix = `\n\n---\n\n${remindersPrompt}`;
+  if (!responseText.endsWith(remindersSuffix)) {
+    throw new Error("Expected ask response to end with the reminders prompt.");
+  }
+  return `${responseText.slice(0, -remindersSuffix.length)}\n\n<reminders>`;
+}
+
 describe("skill-site ask route", () => {
   beforeEach(() => {
     globalVar.hexclaveCapturedErrors = [];
@@ -80,9 +88,13 @@ describe("skill-site ask route", () => {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?query=How%20do%20I%20add%20Hexclave%3F&context=Installing%20Hexclave%20in%20a%20static%20HTML%20app&conversationId=conversation-123&reason=caller-controlled"));
       expect(response.status).toBe(200);
       const responseText = await response.text();
-      expect(responseText).toContain("Use the JS SDK or REST API.");
-      expect(responseText).toContain("[conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]");
-      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
+      expect(normalizeReminders(responseText)).toMatchInlineSnapshot(`
+        "Use the JS SDK or REST API.
+
+        [conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]
+
+        <reminders>"
+      `);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       globalThis.fetch = previousFetch;
@@ -215,9 +227,13 @@ describe("skill-site ask route", () => {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?question=Hello"));
       expect(response.status).toBe(200);
       const responseText = await response.text();
-      expect(responseText).toContain("(empty response)");
-      expect(responseText).toContain("[conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]");
-      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
+      expect(normalizeReminders(responseText)).toMatchInlineSnapshot(`
+        "(empty response)
+
+        [conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]
+
+        <reminders>"
+      `);
     } finally {
       globalThis.fetch = previousFetch;
     }
@@ -234,8 +250,11 @@ describe("skill-site ask route", () => {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?question=Hello"));
       expect(response.status).toBe(200);
       const responseText = await response.text();
-      expect(responseText.startsWith("Start with the JavaScript SDK.")).toBe(true);
-      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
+      expect(normalizeReminders(responseText)).toMatchInlineSnapshot(`
+        "Start with the JavaScript SDK.
+
+        <reminders>"
+      `);
     } finally {
       globalThis.fetch = previousFetch;
     }

--- a/apps/skills/src/ask-route.test.ts
+++ b/apps/skills/src/ask-route.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from "vitest";
+import { remindersPrompt } from "@hexclave/shared/dist/ai/unified-prompts/reminders";
 import { globalVar } from "@hexclave/shared/dist/utils/globals";
 
 import { handleAskToolRoute } from "./ask-route";
@@ -78,11 +79,10 @@ describe("skill-site ask route", () => {
     try {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?query=How%20do%20I%20add%20Hexclave%3F&context=Installing%20Hexclave%20in%20a%20static%20HTML%20app&conversationId=conversation-123&reason=caller-controlled"));
       expect(response.status).toBe(200);
-      expect(await response.text()).toMatchInlineSnapshot(`
-        "Use the JS SDK or REST API.
-
-        [conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]"
-      `);
+      const responseText = await response.text();
+      expect(responseText).toContain("Use the JS SDK or REST API.");
+      expect(responseText).toContain("[conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]");
+      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
       expect(fetchMock).toHaveBeenCalledTimes(1);
     } finally {
       globalThis.fetch = previousFetch;
@@ -214,11 +214,10 @@ describe("skill-site ask route", () => {
     try {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?question=Hello"));
       expect(response.status).toBe(200);
-      expect(await response.text()).toMatchInlineSnapshot(`
-        "(empty response)
-
-        [conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]"
-      `);
+      const responseText = await response.text();
+      expect(responseText).toContain("(empty response)");
+      expect(responseText).toContain("[conversationId: conversation-123 - pass this value as the conversationId parameter in your next /ask request to continue this conversation]");
+      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
     } finally {
       globalThis.fetch = previousFetch;
     }
@@ -234,7 +233,9 @@ describe("skill-site ask route", () => {
     try {
       const response = await handleAskToolRoute(new Request("https://skill.hexclave.com/ask?question=Hello"));
       expect(response.status).toBe(200);
-      expect(await response.text()).toBe("Start with the JavaScript SDK.");
+      const responseText = await response.text();
+      expect(responseText.startsWith("Start with the JavaScript SDK.")).toBe(true);
+      expect(responseText.endsWith(`\n\n---\n\n${remindersPrompt}`)).toBe(true);
     } finally {
       globalThis.fetch = previousFetch;
     }

--- a/apps/skills/src/ask-route.ts
+++ b/apps/skills/src/ask-route.ts
@@ -1,4 +1,5 @@
 import { callHexclaveAskAi, type HexclaveAskDiagnostic } from "../../../packages/shared/src/ai/hexclave-ask";
+import { remindersPrompt } from "@hexclave/shared/dist/ai/unified-prompts/reminders";
 import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 
 const ASK_ROUTE_HEADERS = {
@@ -138,7 +139,7 @@ async function callUnifiedAiEndpoint(req: Request): Promise<Response> {
   const continuationGuidance = result.conversationId == null
     ? ""
     : `\n\n[conversationId: ${result.conversationId} - pass this value as the conversationId parameter in your next /ask request to continue this conversation]`;
-  return textResponse(`${result.text}${continuationGuidance}`);
+  return textResponse(`${result.text}${continuationGuidance}\n\n---\n\n${remindersPrompt}`);
 }
 
 export async function handleAskToolRoute(req: Request): Promise<Response> {


### PR DESCRIPTION
Successful responses from the `ask_hexclave` MCP tool and the `skill.hexclave.com/ask` endpoint now append `remindersPrompt` after the answer (and continuation guidance), separated by `

---

`. Error responses are unchanged.

Link to Devin session: https://app.devin.ai/sessions/ba5ccee4ce934c7389c9c6cbf2f53d7c
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds reminders to successful answers from the `ask_hexclave` MCP tool and the `skill.hexclave.com/ask` endpoint, shown after the answer and continuation guidance, separated by a `---` line. Error responses are unchanged.

- **New Features**
  - Appends `remindersPrompt` after answers in both the MCP handler and `/ask` endpoint (format: answer + continuation guidance + blank line + `---` + blank line + reminders).
  - Keeps `conversationId` continuation guidance; only successful responses include reminders.
  - Tests use stable snapshots via a `normalizeReminders` helper that replaces the reminders block with `<reminders>`.

<sup>Written for commit 52be7358175d771966927a83d8f70ae80595a071. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1838?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Ask responses now include a reminders section after the AI-generated answer and any continuation guidance.
  - The reminders are clearly separated from the main response for easier reading.
- **Tests**
  - Updated response validation to confirm reminders appear across standard, empty-response, and no-continuation scenarios.
  - Tests now normalize the reminders suffix for consistent snapshot assertions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->