### PR TITLE
feat(workflows): scope the sandbox run token to server access

### DIFF
--- a/apps/backend/src/lib/workflows/compile-scan.test.ts
+++ b/apps/backend/src/lib/workflows/compile-scan.test.ts
@@ -69,15 +69,15 @@ export default workflow("x", { on: ["user.created"] }, async () => {});
   test("enforces the allowlist through esbuild module resolution", async () => {
     // The quote is inside a comment and deliberately confuses the
     // best-effort source scanner; esbuild still parses and canonicalizes it.
-    const result = await compileWorkflowBundle(`import/*"*/{HexclaveAdminApp}from"@hexclave/js";export default HexclaveAdminApp;`);
+    const result = await compileWorkflowBundle(`import/*"*/{HexclaveServerApp}from"@hexclave/js";export default HexclaveServerApp;`);
     expect(result.status).toBe("error");
     if (result.status === "error") expect(result.error).toContain("@hexclave/js");
   });
 
   test("rejects attempts to import or embed the trusted runtime module marker", async () => {
     for (const source of [
-      `if (false) {} import/*"*/{ HexclaveAdminApp }from"@hexclave/workflows-internal-admin-runtime"; export default HexclaveAdminApp;`,
-      `export default "@hexclave/workflows-internal-admin-runtime";`,
+      `if (false) {} import/*"*/{ HexclaveServerApp }from"@hexclave/workflows-internal-server-runtime"; export default HexclaveServerApp;`,
+      `export default "@hexclave/workflows-internal-server-runtime";`,
     ]) {
       const result = await compileWorkflowBundle(source);
       expect(result.status).toBe("error");
@@ -115,13 +115,13 @@ describe("getUsedStdlibPackages", () => {
 });
 
 describe("workflow runtime dependencies", () => {
-  test("pins the published Hexclave AdminApp package", () => {
+  test("pins the published Hexclave SDK package", () => {
     expect(getWorkflowsRuntimeEnv(WORKFLOWS_CURRENT_RUNTIME_ENV_VERSION).runtimeNodeModules).toEqual({
       "@hexclave/js": "1.0.52",
     });
   });
 
-  test("keeps the real admin SDK as a sandbox-resolved import", async () => {
+  test("keeps the real server SDK as a sandbox-resolved import", async () => {
     const result = await compileWorkflowBundle(`
 import { workflow } from "@hexclave/workflows";
 export default workflow("x", { on: ["user.created"] }, async () => {});
@@ -129,13 +129,22 @@ export default workflow("x", { on: ["user.created"] }, async () => {});
     expect(result.status).toBe("ok");
     if (result.status === "ok") {
       expect(result.data.compiledBundle).toContain("@hexclave/js");
-      expect(result.data.compiledBundle).toContain("HexclaveAdminApp");
+      expect(result.data.compiledBundle).toContain("HexclaveServerApp");
     }
   });
 
-  test("constructs the inert manifest AdminApp with the reserved internal project ID", () => {
+  test("constructs the inert manifest ServerApp with the reserved internal project ID", () => {
     expect(WORKFLOWS_RUNTIME_PACKAGE_SOURCE).toContain('projectId: appCredentials?.projectId ?? "internal"');
     expect(WORKFLOWS_RUNTIME_PACKAGE_SOURCE).not.toContain('projectId: appCredentials?.projectId ?? "workflow-manifest"');
+  });
+
+  test("hands the sandbox a server credential and no admin one", () => {
+    // The run token is server-scoped (run-token.tsx) and the auth path refuses
+    // it on admin-type requests, so a shim that constructed an AdminApp — or
+    // filled an admin key slot — would only produce runtime auth failures.
+    expect(WORKFLOWS_RUNTIME_PACKAGE_SOURCE).toContain("new HexclaveServerApp({");
+    expect(WORKFLOWS_RUNTIME_PACKAGE_SOURCE).not.toContain("HexclaveAdminApp");
+    expect(WORKFLOWS_RUNTIME_PACKAGE_SOURCE).not.toContain("superSecretAdminKey");
   });
 });
 

--- a/apps/backend/src/lib/workflows/compile.tsx
+++ b/apps/backend/src/lib/workflows/compile.tsx
@@ -22,11 +22,13 @@ import { WORKFLOWS_ENTRY_JS, WORKFLOWS_RUNTIME_PACKAGE_SOURCE } from "./runtime-
  */
 const IMPORT_ALLOWLIST_EXACT = ["@hexclave/workflows"];
 const STDLIB_PACKAGES = ["date-fns"];
-// The workflow runtime itself needs the real Admin SDK, while user source
+// The workflow runtime itself needs the real Server SDK, while user source
 // must not import it. Bundle the trusted runtime through a private external
 // sentinel and rewrite that one canonical import afterward; a user-authored
 // "@hexclave/js" import is therefore rejected by esbuild resolution.
-const WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL = "@hexclave/workflows-internal-admin-runtime";
+// (The sentinel never survives compilation — it is rewritten before the bundle
+// is stored — so renaming it does not affect already-synced versions.)
+const WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL = "@hexclave/workflows-internal-server-runtime";
 
 // Written for module specifiers in static imports, re-exports, dynamic
 // imports, and requires. Comments/strings can theoretically fool a regex
@@ -69,8 +71,8 @@ export function validateWorkflowSource(source: string): Result<null, string> {
   if (sizeBytes > WORKFLOW_SOURCE_MAX_BYTES) {
     return Result.error(`Workflow source is ${sizeBytes} bytes, exceeding the ${WORKFLOW_SOURCE_MAX_BYTES}-byte (128 KiB) limit`);
   }
-  if (source.includes(WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL)) {
-    return Result.error(`Workflow source contains the reserved internal module marker ${JSON.stringify(WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL)}`);
+  if (source.includes(WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL)) {
+    return Result.error(`Workflow source contains the reserved internal module marker ${JSON.stringify(WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL)}`);
   }
   // Non-literal imports can evade an allowlist scanner and resolve arbitrary
   // packages or Node built-ins at runtime. Workflows do not need dynamic
@@ -102,10 +104,10 @@ export async function compileWorkflowBundle(source: string): Promise<Result<{ co
 
   const runtimePackageSource = WORKFLOWS_RUNTIME_PACKAGE_SOURCE.replace(
     '"@hexclave/js"',
-    JSON.stringify(WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL),
+    JSON.stringify(WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL),
   );
   if (runtimePackageSource === WORKFLOWS_RUNTIME_PACKAGE_SOURCE) {
-    throw new HexclaveAssertionError("Workflow runtime no longer contains the expected Admin SDK import");
+    throw new HexclaveAssertionError("Workflow runtime no longer contains the expected Server SDK import");
   }
   const bundleResult = await bundleJavaScript({
     "/workflow.ts": source,
@@ -116,19 +118,19 @@ export async function compileWorkflowBundle(source: string): Promise<Result<{ co
     },
     // The stdlib stays a real import, resolved against the sandbox's
     // nodeModules at the exact pinned version.
-    keepAsImports: [...STDLIB_PACKAGES, WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL],
+    keepAsImports: [...STDLIB_PACKAGES, WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL],
     format: "esm",
     sourcemap: false,
   });
   if (bundleResult.status === "error") {
     return Result.error(`Workflow source failed to compile: ${bundleResult.error}`);
   }
-  if (!bundleResult.data.includes(WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL)) {
-    throw new HexclaveAssertionError("Workflow bundle omitted the trusted runtime Admin SDK import");
+  if (!bundleResult.data.includes(WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL)) {
+    throw new HexclaveAssertionError("Workflow bundle omitted the trusted runtime Server SDK import");
   }
-  const sentinelSpecifier = JSON.stringify(WORKFLOW_RUNTIME_ADMIN_IMPORT_SENTINEL);
+  const sentinelSpecifier = JSON.stringify(WORKFLOW_RUNTIME_SDK_IMPORT_SENTINEL);
   if (bundleResult.data.split(sentinelSpecifier).length !== 2) {
-    throw new HexclaveAssertionError("Workflow bundle contains an unexpected number of trusted runtime Admin SDK imports");
+    throw new HexclaveAssertionError("Workflow bundle contains an unexpected number of trusted runtime Server SDK imports");
   }
   // Replace only the canonical module specifier. The marker is rejected
   // from author source above, so user strings can never be rewritten.

--- a/apps/backend/src/lib/workflows/engine.tsx
+++ b/apps/backend/src/lib/workflows/engine.tsx
@@ -18,6 +18,7 @@ import { listCronOccurrences, MAX_CATCHUP_WINDOW_MS, parseCronExpression } from 
 import {
   WORKFLOWS_DEFAULT_LIMITS,
   WORKFLOWS_PROTOCOL_VERSION,
+  type WorkflowSandboxCredentials,
   type WorkflowSandboxEvent,
   type WorkflowSandboxInput,
   type WorkflowSandboxOutcome,
@@ -811,9 +812,11 @@ async function executeClaimedRun(run: ClaimedRunRow, tenancy: Tenancy, deadlineM
     return;
   }
 
-  // Short-lived project-admin credentials, minted per claim. Workflow source
-  // is admin-authored and deliberately receives the complete AdminApp. The
-  // expiry must cover the longest possible CHAIN of steps under this claim
+  // Short-lived project-server credentials, minted per claim. Workflow source
+  // is admin-authored, but it only ever needs to read and write project data,
+  // so it receives the ServerApp surface and a token the auth path refuses on
+  // admin-type requests. The expiry must cover the longest possible CHAIN of
+  // steps under this claim
   // (the lease is renewed at every step boundary, but the credential is not
   // re-minted). Worst case: the loop's deadline check admits one more
   // invocation at up to 150s after the tick started, that invocation may run
@@ -830,19 +833,21 @@ async function executeClaimedRun(run: ClaimedRunRow, tenancy: Tenancy, deadlineM
     leaseToken: run.leaseToken,
     expiresInMs: WORKFLOW_RUN_TOKEN_TTL_MS,
   });
-  const credentials = {
+  // Annotated so that re-adding an admin key here is a compile error rather
+  // than a silent restoration of admin scope: passed as a variable into the
+  // input literal below, this object would otherwise never see an
+  // excess-property check.
+  const credentials: WorkflowSandboxCredentials = {
     apiUrl: getWorkflowsSandboxApiUrl(),
     projectId: tenancy.project.id,
     branchId: tenancy.branchId,
-    // The run token rides in the SDK's existing project-credential slots.
-    // Both hold the same value: the SDK attaches the server key on server- and
-    // admin-type requests and adds the admin key on admin ones, and the auth
-    // path recognises a run token in either. Reusing these slots (rather than
-    // adding a dedicated header) keeps the credential change entirely inside
-    // the engine — stored bundles pin their runtime shim forever, so a new
-    // header would strand every already-synced workflow version.
+    // The run token rides in the SDK's existing secret-server-key slot.
+    // Reusing that slot (rather than adding a dedicated header) keeps the
+    // credential change entirely inside the engine — stored bundles pin their
+    // runtime shim forever, so a new header would strand every already-synced
+    // workflow version. Nothing is put in the admin slot: the token is
+    // server-scoped and the auth path rejects it on admin-type requests.
     secretServerKey: runToken,
-    superSecretAdminKey: runToken,
   };
 
   const triggerPayload = run.triggerPayload as { ts_millis: number, data: unknown };

--- a/apps/backend/src/lib/workflows/protocol.tsx
+++ b/apps/backend/src/lib/workflows/protocol.tsx
@@ -14,6 +14,14 @@
 // protocol's semantics (it cannot import backend code). If you change
 // anything here, bump WORKFLOWS_PROTOCOL_VERSION and update the runtime
 // source in the same commit.
+//
+// The one exception is DROPPING a field the engine simply stops sending, when
+// every stored runtime already reads it defensively (`input.x?.y ?? default`).
+// Such a field cannot break an old bundle, and bumping the version for it
+// would be strictly worse: stored runtimes compare the version for strict
+// equality, so a bump makes every already-synced workflow refuse to run. See
+// WorkflowSandboxCredentials below for the case this was written for. Adding,
+// renaming, or changing the meaning of a field is NOT covered by this.
 
 export const WORKFLOWS_PROTOCOL_VERSION = 1;
 
@@ -41,12 +49,21 @@ export type WorkflowSandboxLimits = {
   inlineSleepBudgetMs: number,
 };
 
+/**
+ * The run token rides in the server-key slot only: it is a SERVER-scoped
+ * credential (see run-token.tsx), so there is nothing to put in an admin slot.
+ *
+ * Dropping the former `superSecretAdminKey` field did NOT need a protocol
+ * version bump: already-stored runtimes read it as
+ * `appCredentials?.superSecretAdminKey ?? <inert placeholder>`, so omitting it
+ * degrades them to exactly the intended scope (their server calls keep
+ * working, their admin calls stop) instead of breaking the invocation.
+ */
 export type WorkflowSandboxCredentials = {
   apiUrl: string,
   projectId: string,
   branchId: string,
   secretServerKey: string,
-  superSecretAdminKey: string,
 };
 
 export type WorkflowSandboxInput = {

--- a/apps/backend/src/lib/workflows/run-token.test.ts
+++ b/apps/backend/src/lib/workflows/run-token.test.ts
@@ -13,7 +13,7 @@ import {
   authenticateWorkflowRunToken,
   authenticateWorkflowRunTokenRequestOrThrow,
   createWorkflowRunToken,
-  getWorkflowRunTokenFromHeaders,
+  getWorkflowRunTokenForRequest,
   isWorkflowRunToken,
   verifyWorkflowRunTokenClaims,
   WORKFLOW_RUN_TOKEN_PREFIX,
@@ -80,7 +80,7 @@ describe("workflow run token — cryptographic layer", () => {
     // `decodeAccessToken` parses an access-token audience positionally as
     // aud.split(":")[0]. If a run token were ever replayed in the access-token
     // header, that parse must not yield a real project id — otherwise the
-    // issuer claim would be the only thing separating a project-admin
+    // issuer claim would be the only thing separating a project-server
     // credential from an end-user one.
     const token = await mint();
     const aud = String(jose.decodeJwt(token.slice(WORKFLOW_RUN_TOKEN_PREFIX.length)).aud);
@@ -279,25 +279,32 @@ describe("workflow run token — live state check", () => {
   });
 });
 
-describe("workflow run token — header routing", () => {
-  test("returns null when neither header holds a run token", () => {
-    expect(getWorkflowRunTokenFromHeaders({ secretServerKey: null, superSecretAdminKey: null })).toBeNull();
-    expect(getWorkflowRunTokenFromHeaders({ secretServerKey: "ssk_abc123", superSecretAdminKey: "sak_abc123" })).toBeNull();
+describe("workflow run token — request routing (server scope)", () => {
+  test("authenticates server-type requests", () => {
+    expect(getWorkflowRunTokenForRequest({ requestType: "server", secretServerKey: "wrt_x" })).toBe("wrt_x");
   });
 
-  test("routes a token in the admin header", () => {
-    expect(getWorkflowRunTokenFromHeaders({ secretServerKey: "ssk_abc123", superSecretAdminKey: "wrt_x" }))
-      .toEqual({ token: "wrt_x", fromAdminHeader: true });
+  test("authenticates client-type requests, which are strictly weaker", () => {
+    expect(getWorkflowRunTokenForRequest({ requestType: "client", secretServerKey: "wrt_x" })).toBe("wrt_x");
   });
 
-  test("routes a token in the server header", () => {
-    expect(getWorkflowRunTokenFromHeaders({ secretServerKey: "wrt_x", superSecretAdminKey: null }))
-      .toEqual({ token: "wrt_x", fromAdminHeader: false });
+  test("NEVER authenticates admin-type requests — this is the token's scope boundary", () => {
+    // The whole point of the credential being server-scoped. An admin-type
+    // request must fall through to the ordinary admin-key path instead.
+    expect(getWorkflowRunTokenForRequest({ requestType: "admin", secretServerKey: "wrt_x" })).toBeNull();
   });
 
-  test("prefers the admin header when both hold tokens", () => {
-    expect(getWorkflowRunTokenFromHeaders({ secretServerKey: "wrt_server", superSecretAdminKey: "wrt_admin" }))
-      .toEqual({ token: "wrt_admin", fromAdminHeader: true });
+  test("ignores real keys and absent credentials", () => {
+    expect(getWorkflowRunTokenForRequest({ requestType: "server", secretServerKey: "ssk_abc123" })).toBeNull();
+    expect(getWorkflowRunTokenForRequest({ requestType: "server", secretServerKey: null })).toBeNull();
+    expect(getWorkflowRunTokenForRequest({ requestType: "client", secretServerKey: "pck_abc123" })).toBeNull();
+  });
+
+  test("only reads the server-key header — a token in the admin slot is not routed here", () => {
+    // A `wrt_` value in the admin header must be left to the ApiKeySet lookup,
+    // which cannot match it. Routing it here would hand admin scope back.
+    expect(getWorkflowRunTokenForRequest({ requestType: "admin", secretServerKey: null })).toBeNull();
+    expect(getWorkflowRunTokenForRequest({ requestType: "server", secretServerKey: null })).toBeNull();
   });
 });
 
@@ -310,9 +317,9 @@ describe("workflow run token — auth-path entry point", () => {
     consoleLogSpy.mockClear();
   });
 
-  const authenticateRequest = async (overrides?: { token?: string, fromAdminHeader?: boolean, tenancyId?: string | null }) => {
+  const authenticateRequest = async (overrides?: { token?: string, tenancyId?: string | null }) => {
     return await authenticateWorkflowRunTokenRequestOrThrow({
-      credential: { token: overrides?.token ?? await mint(), fromAdminHeader: overrides?.fromAdminHeader ?? true },
+      token: overrides?.token ?? await mint(),
       projectId: PROJECT_ID,
       branchId: CLAIMS.branchId,
       tenancyId: overrides && "tenancyId" in overrides ? overrides.tenancyId ?? null : CLAIMS.tenancyId,
@@ -325,30 +332,25 @@ describe("workflow run token — auth-path entry point", () => {
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 
-  test("maps a rejection to the invalid-admin-key error when the token rode in the admin header", async () => {
+  test("maps a rejection to the invalid-server-key error — the token is a server credential, never an admin one", async () => {
     findUniqueMock.mockResolvedValue({ state: "CANCELED", leaseToken: CLAIMS.leaseToken, workflowId: CLAIMS.workflowId });
-    await expect(authenticateRequest({ fromAdminHeader: true })).rejects.toThrow(KnownErrors.InvalidSuperSecretAdminKey);
-  });
-
-  test("maps a rejection to the invalid-server-key error when the token rode in the server header", async () => {
-    findUniqueMock.mockResolvedValue({ state: "CANCELED", leaseToken: CLAIMS.leaseToken, workflowId: CLAIMS.workflowId });
-    await expect(authenticateRequest({ fromAdminHeader: false })).rejects.toThrow(KnownErrors.InvalidSecretServerKey);
+    await expect(authenticateRequest()).rejects.toThrow(KnownErrors.InvalidSecretServerKey);
   });
 
   test("treats an unresolved tenancy as an authentication failure, without a log line or a DB read", async () => {
-    await expect(authenticateRequest({ tenancyId: null })).rejects.toThrow(KnownErrors.InvalidSuperSecretAdminKey);
+    await expect(authenticateRequest({ tenancyId: null })).rejects.toThrow(KnownErrors.InvalidSecretServerKey);
     expect(consoleLogSpy).not.toHaveBeenCalled();
     expect(findUniqueMock).not.toHaveBeenCalled();
   });
 
   test("does not log rejections reachable by unauthenticated callers (forged signature)", async () => {
-    await expect(authenticateRequest({ token: await mintRaw({ expirationTime: "-60s" }) })).rejects.toThrow(KnownErrors.InvalidSuperSecretAdminKey);
+    await expect(authenticateRequest({ token: await mintRaw({ expirationTime: "-60s" }) })).rejects.toThrow(KnownErrors.InvalidSecretServerKey);
     expect(consoleLogSpy).not.toHaveBeenCalled();
   });
 
   test("logs when a GENUINE engine-minted token is rejected (canceled run still calling out)", async () => {
     findUniqueMock.mockResolvedValue({ state: "CANCELED", leaseToken: CLAIMS.leaseToken, workflowId: CLAIMS.workflowId });
-    await expect(authenticateRequest()).rejects.toThrow(KnownErrors.InvalidSuperSecretAdminKey);
+    await expect(authenticateRequest()).rejects.toThrow(KnownErrors.InvalidSecretServerKey);
     expect(consoleLogSpy).toHaveBeenCalledTimes(1);
     expect(consoleLogSpy.mock.calls[0][0]).toContain("run-not-running");
   });

--- a/apps/backend/src/lib/workflows/run-token.tsx
+++ b/apps/backend/src/lib/workflows/run-token.tsx
@@ -7,7 +7,7 @@ import * as jose from "jose";
 import { JOSEError } from "jose/errors";
 
 // The bearer credential a workflow run uses to call back into the public API
-// as project admin (`hexclaveApp.getUser(...)` and friends).
+// with project SERVER access (`hexclaveApp.getUser(...)` and friends).
 //
 // This is a signed, self-describing token rather than a row in `ApiKeySet`.
 // Earlier revisions minted a real API key set per claim, which had three
@@ -18,8 +18,14 @@ import { JOSEError } from "jose/errors";
 // is persisted, so nothing can leak into a CRUD or need cleaning up, and
 // revocation falls out of the run's own state (see below).
 //
-// SECURITY MODEL — the token grants FULL PROJECT ADMIN, so every one of these
-// properties is load-bearing:
+// SECURITY MODEL — the token grants PROJECT SERVER access and is refused on
+// admin-type requests (see smart-request.tsx), so it cannot reach project
+// configuration, API keys, or the other admin-only surfaces. It also satisfies
+// client-type requests, which are strictly weaker; note that makes it slightly
+// BROADER than a real secret server key, which is ignored on the client path
+// (that path only ever consults the publishable client key). What it cannot do
+// is exceed server scope. That is still every user, team and piece of project
+// data, so every one of these properties is load-bearing:
 //   * Signed with the per-audience key derived from HEXCLAVE_SERVER_SECRET, on
 //     a `workflow-run:<projectId>` audience. Because `getPrivateJwks` derives
 //     the key from the audience, a token minted for one project is not merely
@@ -28,7 +34,7 @@ import { JOSEError } from "jose/errors";
 //     The audience puts the constant FIRST on purpose: `decodeAccessToken`
 //     parses an access-token audience positionally as `aud.split(":")[0]`, so
 //     a `<projectId>:workflow-run` audience would yield a real project id
-//     there and leave `iss` as the only thing separating a project-admin
+//     there and leave `iss` as the only thing separating a project-server
 //     credential from an end-user one. With the constant first, that parse
 //     produces a non-existent project and the replay fails for two
 //     independent reasons instead of one.
@@ -57,8 +63,8 @@ import { JOSEError } from "jose/errors";
 // request, not just workflow machinery.
 
 /**
- * Distinguishes a run token from a real API key in the credential header.
- * Real keys are `pck_`/`ssk_`/`sak_` followed by base32 (see
+ * Distinguishes a run token from a real API key in the secret-server-key
+ * header. Real keys are `pck_`/`ssk_`/`sak_` followed by base32 (see
  * `createApiKeySet`), so `wrt_` is unreachable by construction rather than
  * merely improbable.
  */
@@ -134,6 +140,31 @@ export async function createWorkflowRunToken(options: WorkflowRunTokenClaims & {
 /** Cheap syntactic check so the auth path can route a credential header without doing crypto. */
 export function isWorkflowRunToken(value: string | null | undefined): value is string {
   return typeof value === "string" && value.startsWith(WORKFLOW_RUN_TOKEN_PREFIX);
+}
+
+/**
+ * The single authority on whether a request is a candidate for run-token
+ * authentication: it is, exactly when the secret-server-key header carries a
+ * `wrt_` value AND the request is not admin-type. Returns the token to
+ * authenticate (crypto + live state still have to run), or null.
+ *
+ * Admin-type requests are excluded because the token is server-scoped; they
+ * are left to the ordinary admin-key path, where a `wrt_` value in the admin
+ * header is simply a key that matches no row.
+ *
+ * This lives here, rather than inline in the auth path, because TWO decisions
+ * must agree: whether to authenticate with the token, and whether to skip the
+ * ApiKeySet lookup for that header. If they ever disagreed — a skipped lookup
+ * whose branch is not taken — the auth path would dereference a query it never
+ * built, turning an unauthenticated request into a 500. One predicate, used
+ * for both, makes that class of bug unreachable rather than merely absent.
+ */
+export function getWorkflowRunTokenForRequest(options: {
+  requestType: "client" | "server" | "admin",
+  secretServerKey: string | null,
+}): string | null {
+  if (options.requestType === "admin") return null;
+  return isWorkflowRunToken(options.secretServerKey) ? options.secretServerKey : null;
 }
 
 /**
@@ -242,30 +273,6 @@ export async function authenticateWorkflowRunToken(options: {
   return Result.ok(claims);
 }
 
-export type WorkflowRunTokenRequestCredential = {
-  token: string,
-  /** Which credential header carried the token — determines which KnownError a rejection maps to. */
-  fromAdminHeader: boolean,
-};
-
-/**
- * Routes the two project-credential headers: returns the run token if either
- * carries one, else null. The run token deliberately rides in the ordinary
- * key headers (see the module comment) instead of a dedicated header, so the
- * auth path needs this to tell a `wrt_` credential apart from a real key.
- *
- * Resolved per header rather than short-circuiting on the first: if both hold
- * run tokens the admin header wins (it is the slot the runtime shim actually
- * uses), and callers should still use {@link isWorkflowRunToken} per header to
- * suppress the ApiKeySet lookup ONLY for the header that holds a token — a
- * run token in one header must not reject a genuine key in the other.
- */
-export function getWorkflowRunTokenFromHeaders(headers: { secretServerKey: string | null, superSecretAdminKey: string | null }): WorkflowRunTokenRequestCredential | null {
-  if (isWorkflowRunToken(headers.superSecretAdminKey)) return { token: headers.superSecretAdminKey, fromAdminHeader: true };
-  if (isWorkflowRunToken(headers.secretServerKey)) return { token: headers.secretServerKey, fromAdminHeader: false };
-  return null;
-}
-
 /**
  * Rejections reachable by any unauthenticated caller who knows a project id
  * (which is semi-public): purely syntactic failures, forged/expired
@@ -282,12 +289,13 @@ const UNAUTHENTICATED_REACHABLE_REJECTIONS: readonly WorkflowRunTokenRejection[]
 /**
  * The auth-path entry point: fully authenticates a run-token credential
  * (crypto + live run state) and, on rejection, throws the SAME KnownError an
- * invalid real key in that header would produce — the specific rejection
- * reason must never reach the caller, since it would disclose run ids, run
- * state, and lease details to unauthenticated probing.
+ * invalid secret server key would produce — the specific rejection reason must
+ * never reach the caller, since it would disclose run ids, run state, and
+ * lease details to unauthenticated probing.
  */
 export async function authenticateWorkflowRunTokenRequestOrThrow(options: {
-  credential: WorkflowRunTokenRequestCredential,
+  /** Taken from the secret-server-key header; the token is not an admin credential. */
+  token: string,
   projectId: string,
   branchId: string,
   /**
@@ -301,7 +309,7 @@ export async function authenticateWorkflowRunTokenRequestOrThrow(options: {
   const authResult = options.tenancyId == null
     ? Result.error("tenancy-not-found" as const)
     : await authenticateWorkflowRunToken({
-      token: options.credential.token,
+      token: options.token,
       projectId: options.projectId,
       branchId: options.branchId,
       tenancyId: options.tenancyId,
@@ -310,9 +318,7 @@ export async function authenticateWorkflowRunTokenRequestOrThrow(options: {
     if (!UNAUTHENTICATED_REACHABLE_REJECTIONS.includes(authResult.error)) {
       console.log(`[Workflow run token] Rejected an authentic run token for project ${options.projectId}: ${authResult.error}`);
     }
-    throw options.credential.fromAdminHeader
-      ? new KnownErrors.InvalidSuperSecretAdminKey(options.projectId)
-      : new KnownErrors.InvalidSecretServerKey(options.projectId);
+    throw new KnownErrors.InvalidSecretServerKey(options.projectId);
   }
   return authResult.data;
 }

--- a/apps/backend/src/lib/workflows/runtime-env.tsx
+++ b/apps/backend/src/lib/workflows/runtime-env.tsx
@@ -19,7 +19,7 @@ export type WorkflowsRuntimeEnv = {
   stdlibNodeModules: Record<string, string>,
 };
 
-export const WORKFLOWS_CURRENT_RUNTIME_ENV_VERSION = "2026-07-27.1";
+export const WORKFLOWS_CURRENT_RUNTIME_ENV_VERSION = "2026-07-30.1";
 
 const WORKFLOWS_RUNTIME_ENVS = new Map<string, WorkflowsRuntimeEnv>([
   ["2026-07-20.1", {
@@ -44,6 +44,17 @@ const WORKFLOWS_RUNTIME_ENVS = new Map<string, WorkflowsRuntimeEnv>([
       "date-fns": "4.1.0",
     },
   }],
+  ["2026-07-27.1", {
+    runtimeNodeModules: {
+      "@hexclave/js": "1.0.52",
+    },
+    stdlibNodeModules: {
+      "date-fns": "4.1.0",
+    },
+  }],
+  // 2026-07-30.1: the runtime shim's hexclaveApp became a ServerApp
+  // authenticated with a server-scoped run token (was an AdminApp). Same pins;
+  // the bump exists because the shim's behavior changed.
   [WORKFLOWS_CURRENT_RUNTIME_ENV_VERSION, {
     runtimeNodeModules: {
       "@hexclave/js": "1.0.52",

--- a/apps/backend/src/lib/workflows/runtime-source.tsx
+++ b/apps/backend/src/lib/workflows/runtime-source.tsx
@@ -22,7 +22,7 @@
 export const WORKFLOWS_RUNTIME_PACKAGE_SOURCE = `
 // Virtual module "@hexclave/workflows" (workflow runtime, executes in the sandbox).
 
-import { HexclaveAdminApp } from "@hexclave/js";
+import { HexclaveServerApp } from "@hexclave/js";
 
 type SandboxTrigger = { type: "event", eventType: string } | { type: "schedule", cron: string, timezone: string };
 type SandboxStepBagEntry = { kind: "run" | "sleep", stepId: string, result: unknown };
@@ -40,7 +40,7 @@ type SandboxInput = {
   event?: { id: string, type: string, tsMillis: number, data: unknown },
   steps?: Record<string, SandboxStepBagEntry>,
   run?: { id: string, workflowId: string, version: number },
-  credentials?: { apiUrl: string, projectId: string, branchId: string, secretServerKey: string, superSecretAdminKey: string },
+  credentials?: { apiUrl: string, projectId: string, branchId: string, secretServerKey: string },
 };
 
 function getInput(): SandboxInput {
@@ -452,13 +452,16 @@ class StepTimeoutMarker {
 const appCredentials = getInput().credentials;
 
 /**
- * The complete admin SDK, authenticated with a short-lived token minted for
- * this run (it occupies the SDK's key options, but it is a signed run-scoped
- * credential, not an API key — see lib/workflows/run-token.tsx).
+ * The server SDK, authenticated with a short-lived token minted for this run
+ * (it occupies the SDK's secret-server-key option, but it is a signed
+ * run-scoped credential, not an API key — see lib/workflows/run-token.tsx).
+ * Deliberately the ServerApp and not the AdminApp: a workflow reads and writes
+ * project data, it does not administer the project's own configuration, and
+ * the run token is not accepted on admin-type requests.
  * Manifest/run-key/probe imports receive inert credentials;
  * noAutomaticPrefetch guarantees those modes never make a request.
  */
-export const hexclaveApp = new HexclaveAdminApp({
+export const hexclaveApp = new HexclaveServerApp({
   baseUrl: appCredentials?.apiUrl ?? "http://workflow-manifest.invalid",
   // SDK construction validates project IDs before any request is made. The
   // manifest identity must therefore use the one reserved non-UUID project
@@ -467,7 +470,6 @@ export const hexclaveApp = new HexclaveAdminApp({
   projectId: appCredentials?.projectId ?? "internal",
   tokenStore: null,
   secretServerKey: appCredentials?.secretServerKey ?? "ssk_workflow_manifest",
-  superSecretAdminKey: appCredentials?.superSecretAdminKey ?? "sak_workflow_manifest",
   extraRequestHeaders: {
     "x-stack-branch-id": appCredentials?.branchId ?? "main",
   },

--- a/apps/backend/src/route-handlers/smart-request.tsx
+++ b/apps/backend/src/route-handlers/smart-request.tsx
@@ -5,7 +5,7 @@ import { checkApiKeySet, checkApiKeySetQuery } from "@/lib/internal-api-keys";
 import { getProjectQuery, listManagedProjectIds } from "@/lib/projects";
 import { DEFAULT_BRANCH_ID, Tenancy, getSoleTenancyFromProjectBranchQuery } from "@/lib/tenancies";
 import { decodeAccessToken } from "@/lib/tokens";
-import { authenticateWorkflowRunTokenRequestOrThrow, getWorkflowRunTokenFromHeaders, isWorkflowRunToken } from "@/lib/workflows/run-token";
+import { authenticateWorkflowRunTokenRequestOrThrow, getWorkflowRunTokenForRequest } from "@/lib/workflows/run-token";
 import { globalPrismaClient, rawQueryAll } from "@/prisma-client";
 import { KnownErrors } from "@hexclave/shared";
 import { ProjectsCrud } from "@hexclave/shared/dist/interface/crud/projects";
@@ -172,11 +172,6 @@ const parseAuth = withTraceSpan('smart request parseAuth', async (req: NextReque
   const allowAnonymousUser = req.headers.get("x-stack-allow-anonymous-user") === "true";
   const allowRestrictedUser = allowAnonymousUser || req.headers.get("x-stack-allow-restricted-user") === "true";
 
-  // Workflow sandboxes authenticate with a signed, run-scoped token that rides
-  // in the ordinary project-credential headers; the full design (and why it
-  // reuses those slots) lives in lib/workflows/run-token.tsx.
-  const workflowRunToken = getWorkflowRunTokenFromHeaders({ secretServerKey, superSecretAdminKey });
-
   // Ensure header combinations are valid
   const eitherKeyOrToken = !!(publishableClientKey || secretServerKey || superSecretAdminKey || adminAccessToken);
   if (!requestType && eitherKeyOrToken) {
@@ -185,6 +180,12 @@ const parseAuth = withTraceSpan('smart request parseAuth', async (req: NextReque
   if (!requestType) return null;
   if (!typedIncludes(["client", "server", "admin"] as const, requestType)) throw new KnownErrors.InvalidAccessType(requestType);
   if (!projectId) throw new KnownErrors.AccessTypeWithoutProjectId(requestType);
+
+  // Workflow sandboxes authenticate with a signed, run-scoped token that rides
+  // in the ordinary secret-server-key header. It is a server credential, so
+  // this is null on admin-type requests; the full design (and why one shared
+  // predicate decides this) lives in lib/workflows/run-token.tsx.
+  const workflowRunToken = getWorkflowRunTokenForRequest({ requestType, secretServerKey });
 
   const extractUserIdAndRefreshTokenIdFromAccessToken = async (options: { token: string, projectId: string, allowAnonymous: boolean, allowRestricted: boolean }) => {
     const result = await decodeAccessToken(options.token, { allowAnonymous: /* always true as we check for anonymous users later */ true, allowRestricted: /* always true as we check for restricted users later */ true });
@@ -266,11 +267,16 @@ const parseAuth = withTraceSpan('smart request parseAuth', async (req: NextReque
   const bundledQueries = {
     userIfOnGlobalPrismaClient: userId ? getUserIfOnGlobalPrismaClientQuery(projectId, branchId, userId) : undefined,
     isClientKeyValid: publishableClientKey && requestType === "client" ? checkApiKeySetQuery(projectId, { publishableClientKey }) : undefined,
-    // A workflow run token occupies the same header as a project key but is
-    // authenticated below, not by an ApiKeySet lookup; a `wrt_` value can
-    // never match a key row, so skip the lookup for that header only.
-    isServerKeyValid: secretServerKey && requestType === "server" && !isWorkflowRunToken(secretServerKey) ? checkApiKeySetQuery(projectId, { secretServerKey }) : undefined,
-    isAdminKeyValid: superSecretAdminKey && requestType === "admin" && !isWorkflowRunToken(superSecretAdminKey) ? checkApiKeySetQuery(projectId, { superSecretAdminKey }) : undefined,
+    // A workflow run token occupies the same header as a secret server key but
+    // is authenticated below, not by an ApiKeySet lookup; a `wrt_` value can
+    // never match a key row, so skip the lookup when — and only when — the
+    // run-token branch below will actually run. Both conditions read the same
+    // predicate so they cannot drift apart into a dereference of a query that
+    // was never built. The admin header gets no such treatment: a run token
+    // there is not an admin credential, and letting the ordinary lookup fail
+    // is exactly right.
+    isServerKeyValid: secretServerKey && requestType === "server" && workflowRunToken == null ? checkApiKeySetQuery(projectId, { secretServerKey }) : undefined,
+    isAdminKeyValid: superSecretAdminKey && requestType === "admin" ? checkApiKeySetQuery(projectId, { superSecretAdminKey }) : undefined,
     project: getProjectQuery(projectId),
     tenancy: getSoleTenancyFromProjectBranchQuery(projectId, branchId, true),
   };
@@ -290,13 +296,13 @@ const parseAuth = withTraceSpan('smart request parseAuth', async (req: NextReque
     const result = await checkApiKeySet("internal", { superSecretAdminKey: developmentKeyOverride });
     if (result.status === "error") throw new StatusError(401, "Invalid development key override");
   } else if (workflowRunToken != null) {
-    // Like the admin-access-token branch, a valid run token satisfies every
-    // request type: it is a full project-admin credential, so the client/
-    // server/admin key checks below would be strictly weaker. On rejection
-    // this throws the same KnownError an invalid real key would — the
+    // Server-scoped: the predicate that produced this token already excluded
+    // admin-type requests, which take the admin-access-token branch below or
+    // the switch's admin case instead. On rejection this throws the same
+    // KnownError an invalid real secret server key would — the
     // failure/logging policy lives with the token implementation.
     await authenticateWorkflowRunTokenRequestOrThrow({
-      credential: workflowRunToken,
+      token: workflowRunToken,
       projectId,
       branchId,
       tenancyId: tenancy?.id ?? null,

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/workflows/editor-types.ts
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/workflows/editor-types.ts
@@ -1,10 +1,10 @@
 // Type definitions injected into Monaco for workflow authoring. The event
 // catalog mirrors packages/shared/src/interface/workflows.ts, while
-// hexclaveApp is the actual HexclaveAdminApp type from @hexclave/js.
+// hexclaveApp is the actual HexclaveServerApp type from @hexclave/js.
 
 export const WORKFLOWS_EDITOR_DTS = `
 declare module "@hexclave/workflows" {
-  import type { HexclaveAdminApp } from "@hexclave/js";
+  import type { HexclaveServerApp } from "@hexclave/js";
 
   export type UserEventData = {
     id: string,
@@ -118,8 +118,8 @@ declare module "@hexclave/workflows" {
     constructor(message: string);
   }
 
-  /** A real admin SDK instance, authenticated to this workflow's environment. */
-  export const hexclaveApp: HexclaveAdminApp<false>;
+  /** A real server SDK instance, authenticated to this workflow's environment. */
+  export const hexclaveApp: HexclaveServerApp<false>;
 }
 `;
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/workflows/shared.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/workflows/shared.tsx
@@ -544,7 +544,7 @@ export function configureWorkflowsMonaco(monaco: Monaco) {
   monaco.languages.typescript.typescriptDefaults.addExtraLib(WORKFLOWS_EDITOR_DTS, "file:///node_modules/@hexclave/workflows/index.d.ts");
   monaco.languages.typescript.typescriptDefaults.addExtraLib(WORKFLOWS_EDITOR_AMBIENT_DTS, "file:///ambient-workflows-stdlib.d.ts");
   // Use the same generated SDK source bundle as the dashboard's AI editor,
-  // so hexclaveApp exposes the complete HexclaveAdminApp surface rather than
+  // so hexclaveApp exposes the complete HexclaveServerApp surface rather than
   // another hand-maintained subset that will drift.
   for (const file of BUNDLED_TYPE_DEFINITIONS) {
     monaco.languages.typescript.typescriptDefaults.addExtraLib(

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/workflows.test.ts
@@ -765,11 +765,28 @@ export default workflow("${workflowId}", {
     });
   });
 
+  it("does not let a run-token credential authenticate an admin-type request", async ({ expect }) => {
+    // The token is scoped to SERVER access. On an admin-type request it must
+    // be ignored entirely rather than accepted, so the request succeeds or
+    // fails purely on the strength of the real admin credential beside it.
+    // Before the credential was re-scoped, the run-token path ran first and
+    // this returned 401.
+    await inFreshWorkflowsProject(async () => {
+      const response = await niceBackendFetch("/api/v1/users", {
+        method: "GET",
+        accessType: "admin",
+        headers: { "x-stack-secret-server-key": "wrt_eyJhbGciOiJFUzI1NiJ9.eyJzdWIiOiJmb3JnZWQifQ.bm90LWEtc2lnbmF0dXJl" },
+      });
+      expect(response.status).toBe(200);
+    });
+  });
+
   it("rejects a forged run-token credential without leaking why", async ({ expect }) => {
-    // The run token rides in the ordinary project-credential headers, keyed on
-    // the `wrt_` prefix. A forged one must fail closed with the same error a
-    // garbage key produces — never a 500, and never a rejection reason that
-    // discloses run ids, run state or lease details.
+    // The run token rides in the secret-server-key header, keyed on the `wrt_`
+    // prefix; the admin header is covered too because a `wrt_` value there is
+    // just a key that matches no row. A forged one must fail closed with the
+    // same error a garbage key produces — never a 500, and never a rejection
+    // reason that discloses run ids, run state or lease details.
     await inFreshWorkflowsProject(async () => {
       for (const header of ["x-stack-secret-server-key", "x-stack-super-secret-admin-key"] as const) {
         const response = await niceBackendFetch("/api/v1/users", {

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/workflows-skill.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/workflows-skill.ts
@@ -63,7 +63,7 @@ export const workflowsSkillSection = deindent`
 
   Per step: results cap at 1 MiB, logs at 64 KiB, timeout defaults to 2 minutes and cannot exceed 10 minutes. Event payloads cap at 256 KiB. Sleeps under a minute may run inline rather than suspending.
 
-  \`hexclaveApp\` is a real server SDK instance already authenticated to the workflow's own project — use it to read and mutate users, teams, and everything else the server SDK exposes. Its credential is scoped to server access, so admin-only surfaces (project configuration, API keys, workflow management) are not reachable from inside a workflow.
+  \`hexclaveApp\` is a real server SDK instance already authenticated to the workflow's own project — use it to read and mutate users, teams, and everything else the server SDK exposes.
 
   ## Operating
 

--- a/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/workflows-skill.ts
+++ b/packages/shared/src/ai/unified-prompts/skill-site-prompt-parts/workflows-skill.ts
@@ -63,7 +63,7 @@ export const workflowsSkillSection = deindent`
 
   Per step: results cap at 1 MiB, logs at 64 KiB, timeout defaults to 2 minutes and cannot exceed 10 minutes. Event payloads cap at 256 KiB. Sleeps under a minute may run inline rather than suspending.
 
-  \`hexclaveApp\` is a real admin SDK instance already authenticated to the workflow's own project — use it to read and mutate users, teams, and everything else the admin SDK exposes.
+  \`hexclaveApp\` is a real server SDK instance already authenticated to the workflow's own project — use it to read and mutate users, teams, and everything else the server SDK exposes. Its credential is scoped to server access, so admin-only surfaces (project configuration, API keys, workflow management) are not reachable from inside a workflow.
 
   ## Operating
 


### PR DESCRIPTION
## What

The credential a workflow run uses to call back into the public API granted **full project admin**. This re-scopes it to **server access**.

Before: the engine put the run token in *both* the `x-stack-secret-server-key` and `x-stack-super-secret-admin-key` slots, the in-sandbox shim built a `HexclaveAdminApp`, and `parseAuth` accepted the token on every request type — so workflow source could reach project configuration, API keys, and every other admin-only surface. A workflow reads and writes project data; it doesn't need any of that.

## How

- **Engine** — fills only `secretServerKey`. `WorkflowSandboxCredentials` no longer has an admin slot, and the object is now type-annotated so re-adding one is a compile error rather than a silent restoration of admin scope (passed as a variable into the input literal, it would otherwise never get an excess-property check).
- **Sandbox shim** — `hexclaveApp` is a `HexclaveServerApp`.
- **Auth path** — `getWorkflowRunTokenForRequest` is the single authority on whether a request may authenticate with a run token: server- and client-type yes, admin-type never. `parseAuth` uses that one predicate *both* to select the branch and to decide whether to skip the `ApiKeySet` lookup, so the two cannot drift apart into dereferencing a query that was never built. A `wrt_` value in the admin header now falls through to the ordinary admin-key lookup, which cannot match it.
- **Dashboard** — the Monaco typedefs declare `hexclaveApp: HexclaveServerApp<false>`, and the agent-facing workflows skill prompt no longer advertises the admin SDK.

## Notes for review

**No protocol version bump, deliberately.** Dropping a field the engine stops sending is safe: stored runtimes read it as `appCredentials?.superSecretAdminKey ?? <inert placeholder>`, so they degrade to exactly the intended scope. A bump would be strictly worse — stored runtimes compare the version for strict equality, so it would make every already-synced workflow refuse to run. The runtime *env* version is bumped instead, since the shim's behavior changed; the previously-implicit `2026-07-27.1` entry is now explicit so the append-only map keeps no dangling pin.

**Known capability regression.** The admin-only workflow-management verbs — `sendWorkflowEvent`, `listWorkflowRuns`, `cancelWorkflowRuns`, `upgradeWorkflowRuns`, `getWorkflowRun` — are no longer reachable from inside a workflow. They exist only on the admin app and always send admin-type requests, so an already-synced bundle calling `hexclaveApp.sendWorkflowEvent(...)` will now fail. Notably the routes themselves already accept server access *for the sandbox* (`.../internal/workflows/events/route.tsx` comments say as much), so the gap is on the SDK side: closing it needs a published `@hexclave/js` release that exposes these on the server app, since the sandbox installs the pinned published package, not the workspace build. Flagging rather than fixing — say the word if workflow→workflow fan-out should be preserved before this lands.

**Rollout ordering.** The scope reduction only takes effect once the backend is deployed: an old backend pod still routes the token from either header with no request-type condition, so during a rolling deploy old pods will keep honouring a new-engine token on admin-type requests.

## Testing

- `run-token.test.ts` + `compile-scan.test.ts`: 59 pass, including new tests pinning the scope boundary (`admin` → never authenticates) and asserting the shim carries no admin credential.
- Typecheck + lint clean across backend, e2e, and shared. (`apps/backend` and `apps/dashboard` each report stale `.next/types/validator.ts` errors for routes from an unrelated branch — pre-existing build artifacts, not from this change.)
- **Two e2e assertions are unverified locally.** The workflows e2e suite can't run in my environment — the sandbox provider fails to start, identically on pristine `dev` with this change stashed — and the local backend has been up since before this branch existed, so it doesn't serve these edits. The new "does not let a run-token credential authenticate an admin-type request" test returns the *pre-change* answer against that stale server, which is what you'd expect but is not a green run. Relying on CI for those two.

Reviewed by three independent agents (auth-path security, stored-artifact compatibility, tests/docs); their findings are folded in.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Scopes the workflow run token to server access so workflows can no longer authenticate as project admin. Admin-type requests now ignore `wrt_` tokens; only server/client requests use them.

- **Refactors**
  - Engine now fills only `secretServerKey`; removed the admin slot from `WorkflowSandboxCredentials` (typed to prevent re-add).
  - Sandbox `hexclaveApp` is a `HexclaveServerApp` from `@hexclave/js`; compiler/runtime use a server-runtime sentinel.
  - Centralized routing with `getWorkflowRunTokenForRequest`: server/client accept run tokens; admin never. Auth path skips the key lookup only when this predicate applies.
  - Updated dashboard typedefs and trimmed the workflows skill prompt to describe the server SDK.

- **Migration**
  - No protocol bump; stored bundles degrade safely. Runtime env bumped to 2026-07-30.1.
  - Admin-only workflow-management APIs are no longer callable from inside workflows until they’re exposed on the server SDK in `@hexclave/js`.
  - Rollout: scope reduction takes effect after backend deploy; old pods may still accept tokens on admin requests during a rolling deploy.

<sup>Written for commit 464ad55f5088be81a9a3998ae13b6083dbf86dac. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1840?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Security**
  * Workflow runs now use server-scoped credentials, reducing administrative access during execution.
  * Run tokens are ignored for administrative requests and invalid credentials return consistent errors.

* **Bug Fixes**
  * Improved request routing and authentication handling for workflow run tokens.
  * Updated workflow compilation and editor support to use the server SDK consistently.

* **Documentation**
  * Updated workflow guidance and runtime documentation to reflect server-scoped access.

* **Chores**
  * Updated the current workflow runtime environment version.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->