### PR TITLE
Send emails immediately for low-volume tenancies via a bounded burst allowance

### DIFF
--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -1,10 +1,10 @@
 import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
 import { globalPrismaClient } from "@/prisma-client";
-import { afterAll, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
 import { _forTesting } from "./email-queue-step";
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
 
-const { failEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS, updateLastExecutionTime } = _forTesting;
+const { claimEmailsForSending, failEmailsStuckInSending, STUCK_EMAIL_TIMEOUT_MS, updateLastExecutionTime } = _forTesting;
 
 describe.sequential("updateLastExecutionTime", () => {
   const metadataKeys: string[] = [];
@@ -153,5 +153,72 @@ describe.sequential("failEmailsStuckInSending", () => {
     expect(after.nextSendRetryAt).toBeNull();
     expect(after.isQueued).toBe(true); // unchanged: we do not unclaim stuck rows
     expect(after.status).toBe("SERVER_ERROR");
+  });
+});
+
+describe.sequential("claimEmailsForSending burst allowance", () => {
+  const testRunTag = `claim-send-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
+  const testFilter = { tsxSource: `/* ${testRunTag} */` };
+
+  const makeRow = async (startedSendingAt: Date | null) => {
+    const tenancy = await getSoleTenancyFromProjectBranch("internal", DEFAULT_BRANCH_ID);
+    return await globalPrismaClient.emailOutbox.create({
+      data: {
+        tenancyId: tenancy.id,
+        tsxSource: testFilter.tsxSource,
+        themeId: null,
+        isHighPriority: false,
+        to: { type: "custom-emails", emails: ["claim-test@example.com"] },
+        extraRenderVariables: {},
+        shouldSkipDeliverabilityCheck: true,
+        createdWith: EmailOutboxCreatedWith.PROGRAMMATIC_CALL,
+        scheduledAt: new Date(0),
+        isQueued: true,
+        renderedByWorkerId: "00000000-0000-0000-0000-000000000000",
+        startedRenderingAt: new Date(0),
+        finishedRenderingAt: new Date(0),
+        renderedHtml: "<p>claim</p>",
+        renderedText: "claim",
+        renderedSubject: "claim",
+        renderedIsTransactional: false,
+        startedSendingAt,
+      },
+    });
+  };
+
+  afterEach(async () => {
+    await globalPrismaClient.emailOutbox.deleteMany({ where: testFilter });
+  });
+
+  it("claims up to the burst limit when the rate quota is zero", async () => {
+    const rows = await Promise.all(Array.from({ length: 10 }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
+
+    expect(claimed).toHaveLength(10);
+  });
+
+  it("does not claim more after the burst limit has been reached", async () => {
+    const rows = await Promise.all(Array.from({ length: 11 }, () => makeRow(null)));
+    const firstClaim = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
+    const secondClaim = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
+
+    expect(firstClaim).toHaveLength(10);
+    expect(secondClaim).toHaveLength(0);
+  });
+
+  it("does not count claims older than the burst window", async () => {
+    const oldRows = await Promise.all(Array.from({ length: 10 }, () => makeRow(new Date(Date.now() - 11 * 60 * 1000))));
+    const pendingRows = await Promise.all(Array.from({ length: 3 }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(globalPrismaClient, pendingRows[0].tenancyId, 0);
+
+    expect(claimed).toHaveLength(3);
+    expect(oldRows).toHaveLength(10);
+  });
+
+  it("uses the rate quota when it exceeds the burst allowance", async () => {
+    const rows = await Promise.all(Array.from({ length: 12 }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 12);
+
+    expect(claimed).toHaveLength(12);
   });
 });

--- a/apps/backend/src/lib/email-queue-step.test.tsx
+++ b/apps/backend/src/lib/email-queue-step.test.tsx
@@ -1,6 +1,7 @@
-import { EmailOutboxCreatedWith } from "@/generated/prisma/client";
+import { BooleanTrue, EmailOutboxCreatedWith } from "@/generated/prisma/client";
 import { globalPrismaClient } from "@/prisma-client";
-import { afterAll, afterEach, describe, expect, it, vi } from "vitest";
+import { afterAll, afterEach, beforeAll, describe, expect, it, vi } from "vitest";
+import { randomUUID } from "node:crypto";
 import { _forTesting } from "./email-queue-step";
 import { DEFAULT_BRANCH_ID, getSoleTenancyFromProjectBranch } from "./tenancies";
 
@@ -157,14 +158,38 @@ describe.sequential("failEmailsStuckInSending", () => {
 });
 
 describe.sequential("claimEmailsForSending burst allowance", () => {
+  const BURST_SEND_LIMIT = 10;
   const testRunTag = `claim-send-test-${Date.now()}-${Math.random().toString(36).slice(2, 8)}`;
   const testFilter = { tsxSource: `/* ${testRunTag} */` };
+  const testProjectId = randomUUID();
+  let testTenancyId: string;
+
+  beforeAll(async () => {
+    await globalPrismaClient.project.create({
+      data: {
+        id: testProjectId,
+        displayName: "Email queue burst test",
+        isProductionMode: false,
+      },
+    });
+    const tenancy = await globalPrismaClient.tenancy.create({
+      data: {
+        projectId: testProjectId,
+        branchId: DEFAULT_BRANCH_ID,
+        hasNoOrganization: BooleanTrue.TRUE,
+      },
+    });
+    testTenancyId = tenancy.id;
+  });
+
+  afterAll(async () => {
+    await globalPrismaClient.project.delete({ where: { id: testProjectId } });
+  });
 
   const makeRow = async (startedSendingAt: Date | null) => {
-    const tenancy = await getSoleTenancyFromProjectBranch("internal", DEFAULT_BRANCH_ID);
     return await globalPrismaClient.emailOutbox.create({
       data: {
-        tenancyId: tenancy.id,
+        tenancyId: testTenancyId,
         tsxSource: testFilter.tsxSource,
         themeId: null,
         isHighPriority: false,
@@ -191,33 +216,43 @@ describe.sequential("claimEmailsForSending burst allowance", () => {
   });
 
   it("claims up to the burst limit when the rate quota is zero", async () => {
-    const rows = await Promise.all(Array.from({ length: 10 }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
+    await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(testTenancyId, 0);
 
-    expect(claimed).toHaveLength(10);
+    expect(claimed).toHaveLength(BURST_SEND_LIMIT);
   });
 
   it("does not claim more after the burst limit has been reached", async () => {
-    const rows = await Promise.all(Array.from({ length: 11 }, () => makeRow(null)));
-    const firstClaim = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
-    const secondClaim = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 0);
+    await Promise.all(Array.from({ length: BURST_SEND_LIMIT + 1 }, () => makeRow(null)));
+    const firstClaim = await claimEmailsForSending(testTenancyId, 0);
+    const secondClaim = await claimEmailsForSending(testTenancyId, 0);
 
-    expect(firstClaim).toHaveLength(10);
+    expect(firstClaim).toHaveLength(BURST_SEND_LIMIT);
     expect(secondClaim).toHaveLength(0);
   });
 
   it("does not count claims older than the burst window", async () => {
-    const oldRows = await Promise.all(Array.from({ length: 10 }, () => makeRow(new Date(Date.now() - 11 * 60 * 1000))));
-    const pendingRows = await Promise.all(Array.from({ length: 3 }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(globalPrismaClient, pendingRows[0].tenancyId, 0);
+    const oldRows = await Promise.all(Array.from({ length: BURST_SEND_LIMIT }, () => makeRow(new Date(Date.now() - 11 * 60 * 1000))));
+    await Promise.all(Array.from({ length: 3 }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(testTenancyId, 0);
 
     expect(claimed).toHaveLength(3);
-    expect(oldRows).toHaveLength(10);
+    expect(oldRows).toHaveLength(BURST_SEND_LIMIT);
+  });
+
+  it("does not double-consume the burst when workers claim concurrently", async () => {
+    await Promise.all(Array.from({ length: BURST_SEND_LIMIT * 2 }, () => makeRow(null)));
+    const [firstClaim, secondClaim] = await Promise.all([
+      claimEmailsForSending(testTenancyId, 0),
+      claimEmailsForSending(testTenancyId, 0),
+    ]);
+
+    expect(firstClaim.length + secondClaim.length).toBe(BURST_SEND_LIMIT);
   });
 
   it("uses the rate quota when it exceeds the burst allowance", async () => {
-    const rows = await Promise.all(Array.from({ length: 12 }, () => makeRow(null)));
-    const claimed = await claimEmailsForSending(globalPrismaClient, rows[0].tenancyId, 12);
+    await Promise.all(Array.from({ length: 12 }, () => makeRow(null)));
+    const claimed = await claimEmailsForSending(testTenancyId, 12);
 
     expect(claimed).toHaveLength(12);
   });

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -32,6 +32,12 @@ const DELTA_WARNING_THRESHOLD_SECONDS = 30;
 /** Consider an email stuck in rendering/sending if it started more than this many ms ago. */
 const STUCK_EMAIL_TIMEOUT_MS = 20 * 60 * 1000;
 
+/** How many emails a tenancy may send within BURST_SEND_WINDOW_MINUTES regardless of its capacity rate. */
+const BURST_SEND_LIMIT = 10;
+
+/** The sliding window over which BURST_SEND_LIMIT is counted. */
+const BURST_SEND_WINDOW_MINUTES = 10;
+
 const calculateRetryBackoffMs = (attemptCount: number): number => {
   return (Math.random() + 0.5) * SEND_RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptCount);
 };
@@ -204,6 +210,7 @@ async function failEmailsStuckInSending(additionalWhere?: Prisma.EmailOutboxWher
 }
 
 export const _forTesting = {
+  claimEmailsForSending,
   failEmailsStuckInSending,
   STUCK_EMAIL_TIMEOUT_MS,
   updateLastExecutionTime,
@@ -560,7 +567,6 @@ async function prepareSendPlan(deltaSeconds: number): Promise<TenancySendBatch[]
       ]);
       const capacity = calculateCapacityRate(stats, boostExpiresAt);
       const quota = stochasticQuota(capacity.ratePerSecond * deltaSeconds);
-      if (quota <= 0) continue;
       const rows = await claimEmailsForSending(globalPrismaClient, entry.tenancyId, quota);
       if (rows.length === 0) continue;
       plan.push({ tenancyId: entry.tenancyId, rows, capacityRatePerSecond: capacity.ratePerSecond });
@@ -579,7 +585,14 @@ function stochasticQuota(value: number): number {
 }
 
 async function claimEmailsForSending(tx: PrismaClientTransaction, tenancyId: string, limit: number): Promise<EmailOutbox[]> {
-  // Claim queued emails for sending
+  // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
+  // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the
+  // burst, a tenancy at the default capacity of 200 emails/hour would wait ~18s on average before its
+  // first email leaves the queue, which is far too slow for things like sign-in codes; letting small
+  // senders briefly exceed their nominal hourly capacity is a deliberate trade for that latency.
+  // The burst is counted over claims (`startedSendingAt`) rather than completed sends so that a claim
+  // by a concurrent, unsynchronized worker counts against the window as soon as it commits, and it is
+  // computed inside the claiming statement itself so the two cannot drift apart.
   // Note: queueReadyEmails() handles the time-based logic, so we just look for isQueued = TRUE
   return await tx.$queryRaw<EmailOutbox[]>(Prisma.sql`
     WITH selected AS (
@@ -593,7 +606,18 @@ async function claimEmailsForSending(tx: PrismaClientTransaction, tenancyId: str
         AND "startedSendingAt" IS NULL
         AND "isQueued" = TRUE
       ORDER BY "priority" DESC, "scheduledAt" ASC, "createdAt" ASC
-      LIMIT ${limit}
+      LIMIT GREATEST(
+        ${limit}::bigint,
+        GREATEST(
+          0::bigint,
+          ${BURST_SEND_LIMIT}::bigint - (
+            SELECT COUNT(*)
+            FROM "EmailOutbox" AS recent
+            WHERE recent."tenancyId" = ${tenancyId}::uuid
+              AND recent."startedSendingAt" >= NOW() - make_interval(mins => ${BURST_SEND_WINDOW_MINUTES}::int)
+          )
+        )
+      )
       FOR UPDATE SKIP LOCKED
     )
     UPDATE "EmailOutbox" AS e

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -589,11 +589,16 @@ function stochasticQuota(value: number): number {
 
 async function claimEmailsForSending(tenancyId: string, limit: number): Promise<EmailOutbox[]> {
   return await retryTransaction(globalPrismaClient, async (tx) => {
-    // Serialize claims per tenancy so concurrent workers cannot each observe the same pre-claim
-    // burst count. The transaction contains only this claim, so the lock is held briefly.
-    await tx.$executeRaw`
-      SELECT pg_advisory_xact_lock(${EMAIL_QUEUE_CLAIM_LOCK_CLASS}::int, hashtext(${tenancyId}::text))
+    // Avoid waiting on a pooled connection when another worker is claiming this tenancy. The
+    // holder commits before releasing the transaction-scoped lock, so the next step's snapshot
+    // sees its claims and the burst remains exact.
+    const [{ locked }] = await tx.$queryRaw<{ locked: boolean }[]>`
+      SELECT pg_try_advisory_xact_lock(
+        ${EMAIL_QUEUE_CLAIM_LOCK_CLASS}::int,
+        hashtext(${tenancyId}::text)
+      ) AS locked
     `;
+    if (!locked) return [];
 
     // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
     // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the

--- a/apps/backend/src/lib/email-queue-step.tsx
+++ b/apps/backend/src/lib/email-queue-step.tsx
@@ -7,7 +7,7 @@ import { arePlanLimitsEnforced, getBillingTeamId } from "@/lib/plan-entitlements
 import { getHexclaveServerApp } from "@/hexclave";
 import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { getTenancy, Tenancy } from "@/lib/tenancies";
-import { getPrismaClientForTenancy, globalPrismaClient, PrismaClientTransaction } from "@/prisma-client";
+import { getPrismaClientForTenancy, globalPrismaClient, retryTransaction } from "@/prisma-client";
 import { allPromisesAndWaitUntilEach } from "@/utils/background-tasks";
 import { withTraceSpan } from "@/utils/telemetry";
 import { groupBy } from "@hexclave/shared/dist/utils/arrays";
@@ -37,6 +37,9 @@ const BURST_SEND_LIMIT = 10;
 
 /** The sliding window over which BURST_SEND_LIMIT is counted. */
 const BURST_SEND_WINDOW_MINUTES = 10;
+
+/** PostgreSQL advisory-lock namespace for email claims. */
+const EMAIL_QUEUE_CLAIM_LOCK_CLASS = 178554;
 
 const calculateRetryBackoffMs = (attemptCount: number): number => {
   return (Math.random() + 0.5) * SEND_RETRY_BACKOFF_BASE_MS * Math.pow(2, attemptCount);
@@ -567,7 +570,7 @@ async function prepareSendPlan(deltaSeconds: number): Promise<TenancySendBatch[]
       ]);
       const capacity = calculateCapacityRate(stats, boostExpiresAt);
       const quota = stochasticQuota(capacity.ratePerSecond * deltaSeconds);
-      const rows = await claimEmailsForSending(globalPrismaClient, entry.tenancyId, quota);
+      const rows = await claimEmailsForSending(entry.tenancyId, quota);
       if (rows.length === 0) continue;
       plan.push({ tenancyId: entry.tenancyId, rows, capacityRatePerSecond: capacity.ratePerSecond });
     } catch (error) {
@@ -584,17 +587,24 @@ function stochasticQuota(value: number): number {
   return base + (Math.random() < fractional ? 1 : 0);
 }
 
-async function claimEmailsForSending(tx: PrismaClientTransaction, tenancyId: string, limit: number): Promise<EmailOutbox[]> {
-  // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
-  // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the
-  // burst, a tenancy at the default capacity of 200 emails/hour would wait ~18s on average before its
-  // first email leaves the queue, which is far too slow for things like sign-in codes; letting small
-  // senders briefly exceed their nominal hourly capacity is a deliberate trade for that latency.
-  // The burst is counted over claims (`startedSendingAt`) rather than completed sends so that a claim
-  // by a concurrent, unsynchronized worker counts against the window as soon as it commits, and it is
-  // computed inside the claiming statement itself so the two cannot drift apart.
-  // Note: queueReadyEmails() handles the time-based logic, so we just look for isQueued = TRUE
-  return await tx.$queryRaw<EmailOutbox[]>(Prisma.sql`
+async function claimEmailsForSending(tenancyId: string, limit: number): Promise<EmailOutbox[]> {
+  return await retryTransaction(globalPrismaClient, async (tx) => {
+    // Serialize claims per tenancy so concurrent workers cannot each observe the same pre-claim
+    // burst count. The transaction contains only this claim, so the lock is held briefly.
+    await tx.$executeRaw`
+      SELECT pg_advisory_xact_lock(${EMAIL_QUEUE_CLAIM_LOCK_CLASS}::int, hashtext(${tenancyId}::text))
+    `;
+
+    // Claim queued emails for sending, at least `limit` of them (the tenancy's capacity rate for this
+    // step) but always enough to stay at BURST_SEND_LIMIT claims within the burst window. Without the
+    // burst, a tenancy at the default capacity of 200 emails/hour would wait ~18s on average before its
+    // first email leaves the queue, which is far too slow for things like sign-in codes; letting small
+    // senders briefly exceed their nominal hourly capacity is a deliberate trade for that latency.
+    // The burst is counted over claims (`startedSendingAt`) rather than completed sends so that a claim
+    // by a concurrent, unsynchronized worker counts against the window as soon as it commits, and it is
+    // computed inside the claiming statement itself so the two cannot drift apart.
+    // Note: queueReadyEmails() handles the time-based logic, so we just look for isQueued = TRUE
+    return await tx.$queryRaw<EmailOutbox[]>(Prisma.sql`
     WITH selected AS (
       SELECT "tenancyId", "id"
       FROM "EmailOutbox"
@@ -626,7 +636,8 @@ async function claimEmailsForSending(tx: PrismaClientTransaction, tenancyId: str
     FROM selected
     WHERE e."tenancyId" = selected."tenancyId" AND e."id" = selected."id"
     RETURNING e.*;
-  `);
+    `);
+  });
 }
 
 async function processSendPlan(plan: TenancySendBatch[]): Promise<void> {


### PR DESCRIPTION
At the default capacity of 200 emails/hour (~0.055/s) and ~1s queue steps, `prepareSendPlan` produced a per-step quota of `stochasticQuota(0.055)`, so the first email of an idle tenancy waited ~18s on average before leaving the queue.

The claim statement now takes the max of the capacity quota and a burst allowance:

```
LIMIT GREATEST(rateQuota, GREATEST(0, 10 - <claims for this tenancy in the last 10 minutes>))
```

so a tenancy with fewer than 10 claims in the trailing 10 minutes sends right away, deliberately exceeding the nominal hourly capacity by a bounded amount. The `quota <= 0` early skip in `prepareSendPlan` is gone, since the burst has to be able to fire when the capacity quota rounds to 0.

Concurrency: the allowance is counted over `startedSendingAt` (the claim timestamp), not completed sends, and is computed inside the claiming statement itself — a concurrent worker's claim counts against the window as soon as it commits, so unsynchronized workers can only overshoot by what they claim in the same instant, and the existing `EmailOutbox_tenancyId_startedSendingAt_idx` covers the count.

Tests in `email-queue-step.test.tsx` cover the burst firing at zero rate quota, the allowance being exhausted by the previous claim, claims aging out of the window, and a rate quota above the allowance still winning. They fail against the previous behaviour.


Link to Devin session: https://app.devin.ai/sessions/7c390e148a4f41f0a6b2efbbcb03f9df
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Let low-volume tenancies send a few emails immediately via a bounded burst in the claim step, removing the ~18s first-send delay at default capacity. Adds non-blocking per-tenancy claim serialization to keep the burst accurate under concurrency.

- **New Features**
  - Burst: up to 10 emails per tenancy in a 10-minute sliding window, independent of rate.
  - Claim limit: GREATEST(rateQuota, burstRemaining) computed over `startedSendingAt` in one statement.
  - Concurrency: per-tenancy serialization using PostgreSQL advisory locks via `pg_try_advisory_xact_lock` inside `retryTransaction` (non-blocking) to avoid waiting and prevent double-consuming the burst; counts on commit and uses the existing `EmailOutbox_tenancyId_startedSendingAt_idx`.
  - Removed the `quota <= 0` early return so burst can fire at zero rate.
  - Tests for zero-quota burst, burst exhaustion, window aging, concurrency, and when rate quota exceeds burst.

<sup>Written for commit c801d85f2e0b9b07670ca788723ef9c59885c858. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1843?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added burst protection for email sending, allowing up to 10 emails within a rolling 10-minute window.
  * Email sending can now proceed within the burst allowance even when the standard quota is zero.

* **Bug Fixes**
  * Improved enforcement of sending limits by accounting for recent email claims and allowing higher configured quotas when applicable.
  * Prevented concurrent email claims from consuming the same burst allowance twice.
  * Expired older claims are now correctly excluded from burst-limit calculations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->