### PR TITLE
Fix MEMORY_LIMIT_EXCEEDED in platform-analytics verified-user queries

### DIFF
--- a/apps/backend/src/app/api/latest/internal/platform-analytics/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/platform-analytics/route.tsx
@@ -256,11 +256,20 @@ export const GET = createSmartRouteHandler({
       analyticsByProject: CountRow[],
     };
     try {
+      // FINAL normally merges every partition before evaluating the IN set;
+      // hashing the key is a deliberate accuracy-for-memory tradeoff: a
+      // 64-bit collision is negligible at these row counts for this internal
+      // KPI. Limiting FINAL read parallelism also avoids buffering one large
+      // block per reader on object-backed storage.
       const verifiedSubquery = `
-        (project_id, id) IN (
-          SELECT project_id, user_id FROM analytics_internal.contact_channels FINAL
-          WHERE branch_id = {branchId:String} AND sync_is_deleted = 0 AND type = 'EMAIL' AND is_verified = 1
+        cityHash64(project_id, id) IN (
+          SELECT cityHash64(project_id, user_id)
+          FROM analytics_internal.contact_channels FINAL
+          WHERE branch_id = {branchId:String} AND sync_is_deleted = 0
+            AND type = 'EMAIL' AND is_verified = 1
+          SETTINGS do_not_merge_across_partitions_select_final = 1
         )`;
+      const verifiedQuerySettings = "SETTINGS max_threads = 1, max_final_threads = 1, max_block_size = 1024";
       const [
         dauSeries, pvSeries, signupSeries, mauProjects, userCounts, country, deadClicks, split,
         totalsByProject, verifiedByProject, signupsByProject, activeByProject, sparkByProject,
@@ -316,6 +325,7 @@ export const GET = createSmartRouteHandler({
             countIf(is_anonymous = 1) AS anonymous
           FROM analytics_internal.users FINAL
           WHERE ${customerUserScope}
+          ${verifiedQuerySettings}
         `, { branchId, internalProjectId, mid: midParam }),
         // Users by country (for the globe) over the window.
         chQuery<{ country_code: string, c: string | number }>(`
@@ -379,6 +389,7 @@ export const GET = createSmartRouteHandler({
           SELECT project_id AS projectId, count() AS c
           FROM analytics_internal.users FINAL
           WHERE ${customerUserScope} AND is_anonymous = 0 AND ${verifiedSubquery} GROUP BY project_id
+          ${verifiedQuerySettings}
         `, baseParams),
         // Per-project signups, current vs prior window.
         chQuery<{ projectId: string, cur: string | number, prev: string | number }>(`


### PR DESCRIPTION
The two platform-analytics queries that resolve verified users (`userCounts`, `verifiedByProject`) hit the 512 MB per-query ClickHouse cap once `contact_channels` grows past a few million rows, so the endpoint 500s.

Two causes, both addressed:
- the `IN` set held a `(String project_id, UUID user_id)` tuple per verified email channel — now hashed to a single `UInt64` (`cityHash64(project_id, id) IN (SELECT cityHash64(project_id, user_id) ...)`), ~5x smaller. Deliberate accuracy-for-memory trade; 64-bit collisions are negligible at these row counts for an internal KPI.
- unbounded `FINAL` read parallelism buffered one large block per reader — the two queries now run with `max_threads = 1, max_final_threads = 1, max_block_size = 1024`, and the subquery adds `do_not_merge_across_partitions_select_final = 1` (safe: `contact_channels` is a ReplacingMergeTree partitioned by a month derived from the immutable `created_at`, so replacements never cross partitions).

Measured with a local harness seeding 3M users / 2.1M verified channels across 13 and 24 monthly partitions, at the production 488.28 MiB cap; results were compared byte-for-byte against the current query run with a temporarily raised limit.

| variant | userCounts | verifiedByProject |
| --- | --- | --- |
| current | OOM (492.6 MiB) | OOM (492.4 MiB) |
| hashed IN, 4 threads | 471.2 MiB / 466 ms | 476.0 MiB / 890 ms |
| hashed IN, 2 threads | 318.1 MiB / 685 ms | 323.8 MiB / 1262 ms |
| **this PR** (1 thread, small blocks) | **227.8 MiB / 1022 ms** | **220.5 MiB / 1053 ms** |

Parallelism is capped at 1 rather than 2–4 because the benchmark runs on local disk and understates read-buffer memory on the object-backed storage production uses; the ~2x latency cost is worth the headroom.


Link to Devin session: https://app.devin.ai/sessions/0c109cefd9504fbfb9bf3ee91c6b8542
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Prevents ClickHouse MEMORY_LIMIT_EXCEEDED errors in verified-user analytics by shrinking the IN set and capping FINAL read parallelism. Endpoints no longer 500, with lower memory use and acceptable latency.

- **Bug Fixes**
  - Hash `(project_id, user_id)` to `cityHash64` in the IN set to cut memory; negligible 64-bit collision risk for this internal KPI.
  - Add `SETTINGS max_threads = 1, max_final_threads = 1, max_block_size = 1024` and `do_not_merge_across_partitions_select_final = 1` to avoid large per-reader buffers; safe with monthly-partitioned ReplacingMergeTree.

- **Performance**
  - Memory drops from ~492 MiB (OOM) to ~221–228 MiB; latency increases to ~1.0–1.1s due to single-threaded FINAL.

<sup>Written for commit 545a69858a485bc6696aff8f9c713bf67be5e31b. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1845?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved verified-user analytics filtering for more accurate results.
  * Enhanced verified contact-channel data handling.
  * Optimized platform-wide and per-project verified-user count queries for more efficient reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->