### PR TITLE
Tabbed Apple OAuth credential modes in the dashboard

### DIFF
--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -6,6 +6,7 @@ import { ActionDialog, BrandIcons, FormControl, FormField, FormItem, FormLabel, 
 import {
   DesignAlert,
   DesignBadge,
+  DesignCategoryTabs,
   DesignCardTint,
   DesignInput,
   DesignPillToggle,
@@ -78,20 +79,37 @@ export function createProviderFormSchema(providerId: string) {
     appleTeamId: yupString().optional(),
     appleKeyId: yupString().optional(),
     applePrivateKey: yupString().optional(),
+    appleCredentialMode: yupString().oneOf(["private-key", "client-secret"]).defined().default("private-key"),
     facebookConfigId: yupString().optional(),
     microsoftTenantId: yupString().optional(),
     appleBundleIds: yup.array(yupString().defined()).optional(),
   }).test(
     "apple-credentials",
-    "Apple requires either a client secret or all Team ID, Key ID, and private key fields.",
     function (values) {
       if (providerId !== "apple" || values.shared) return true;
-      const keyCredentials = [values.appleTeamId, values.appleKeyId, values.applePrivateKey];
-      const hasClientSecret = values.clientSecret != null && values.clientSecret !== "";
-      const hasAllAppleKeyCredentials = keyCredentials.every(value => value != null && value !== "");
-      const hasAnyAppleKeyCredential = keyCredentials.some(value => value != null && value !== "");
-      return (hasClientSecret || hasAllAppleKeyCredentials) && (!hasAnyAppleKeyCredential || hasAllAppleKeyCredentials)
-        || this.createError({ path: "applePrivateKey" });
+      if (values.appleCredentialMode === "client-secret") {
+        return values.clientSecret != null && values.clientSecret !== ""
+          || this.createError({
+            path: "clientSecret",
+            message: "Client secret is required when using the legacy client secret.",
+          });
+      }
+
+      const keyCredentials = [
+        ["appleTeamId", values.appleTeamId],
+        ["appleKeyId", values.appleKeyId],
+        ["applePrivateKey", values.applePrivateKey],
+      ] as const;
+      const missingKeyField = keyCredentials.find(([_, value]) => {
+        return value == null || value === "";
+      })?.[0];
+      if (missingKeyField == null) return true;
+      const messages = {
+        appleTeamId: "Apple Team ID is required.",
+        appleKeyId: "Apple Key ID is required.",
+        applePrivateKey: "Apple private key is required.",
+      } as const;
+      return this.createError({ path: missingKeyField, message: messages[missingKeyField] });
     },
   );
 }
@@ -170,6 +188,7 @@ function RedirectInline({ providerId }: { providerId: string }) {
 
 function CredentialFields({ form, providerId }: { form: UseFormReturn<ProviderFormValues>, providerId: string }) {
   const [showApplePrivateKey, setShowApplePrivateKey] = useState(false);
+  const appleCredentialMode = useWatch({ control: form.control, name: "appleCredentialMode" });
 
   const clientIdLabel = providerId === 'apple' ? "Service ID (Client ID)" : "Client ID";
   return (
@@ -187,19 +206,21 @@ function CredentialFields({ form, providerId }: { form: UseFormReturn<ProviderFo
           </FormItem>
         )}
       />
-      <FormField
-        control={form.control}
-        name="clientSecret"
-        render={({ field }) => (
-          <FormItem className="space-y-1.5">
-            <FormLabel className="text-xs font-medium text-muted-foreground">Client Secret</FormLabel>
-            <FormControl>
-              <DesignInput {...field} value={field.value ?? ""} type="password" placeholder="Client Secret" size="sm" autoComplete="off" />
-            </FormControl>
-            <FormMessage />
-          </FormItem>
-        )}
-      />
+      {providerId !== "apple" && (
+        <FormField
+          control={form.control}
+          name="clientSecret"
+          render={({ field }) => (
+            <FormItem className="space-y-1.5">
+              <FormLabel className="text-xs font-medium text-muted-foreground">Client Secret</FormLabel>
+              <FormControl>
+                <DesignInput {...field} value={field.value ?? ""} type="password" placeholder="Client Secret" size="sm" autoComplete="off" />
+              </FormControl>
+              <FormMessage />
+            </FormItem>
+          )}
+        />
+      )}
       {providerId === 'facebook' && (
         <FormField
           control={form.control}
@@ -232,58 +253,97 @@ function CredentialFields({ form, providerId }: { form: UseFormReturn<ProviderFo
       )}
       {providerId === 'apple' && (
         <>
-          <FormField
-            control={form.control}
-            name="appleTeamId"
-            render={({ field }) => (
-              <FormItem className="space-y-1.5">
-                <FormLabel className="text-xs font-medium text-muted-foreground">Apple Team ID</FormLabel>
-                <FormControl><DesignInput {...field} value={field.value ?? ""} placeholder="Team ID" size="sm" autoComplete="off" /></FormControl>
-                <FormMessage />
-              </FormItem>
+          <DesignCategoryTabs
+            categories={[
+              { id: "private-key", label: "Private key (Recommended)" },
+              { id: "client-secret", label: "Client secret (Legacy)" },
+            ]}
+            selectedCategory={appleCredentialMode}
+            onSelect={(id) => form.setValue(
+              "appleCredentialMode",
+              id === "client-secret" ? "client-secret" : "private-key",
+              { shouldDirty: true, shouldValidate: form.formState.isSubmitted },
             )}
+            showBadge={false}
+            size="sm"
+            glassmorphic
+            gradient="default"
           />
-          <FormField
-            control={form.control}
-            name="appleKeyId"
-            render={({ field }) => (
-              <FormItem className="space-y-1.5">
-                <FormLabel className="text-xs font-medium text-muted-foreground">Apple Key ID</FormLabel>
-                <FormControl><DesignInput {...field} value={field.value ?? ""} placeholder="Key ID" size="sm" autoComplete="off" /></FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
-          <FormField
-            control={form.control}
-            name="applePrivateKey"
-            render={({ field }) => (
-              <FormItem className="space-y-1.5">
-                <FormLabel className="text-xs font-medium text-muted-foreground">Apple private key (.p8)</FormLabel>
-                <FormControl>
-                  <div className="relative">
-                    <textarea
-                      {...field}
-                      value={field.value ?? ""}
-                      placeholder="-----BEGIN PRIVATE KEY-----"
-                      autoComplete="off"
-                      rows={6}
-                      className={`w-full rounded-md border border-input bg-background px-3 py-2 pr-10 font-mono text-xs ${showApplePrivateKey ? "" : "[-webkit-text-security:disc]"}`}
-                    />
-                    <button
-                      type="button"
-                      onClick={() => setShowApplePrivateKey(value => !value)}
-                      aria-label={showApplePrivateKey ? "Hide Apple private key" : "Show Apple private key"}
-                      className="absolute right-2 top-2 rounded p-1 text-muted-foreground hover:text-foreground"
-                    >
-                      {showApplePrivateKey ? <EyeSlashIcon size={16} /> : <EyeIcon size={16} />}
-                    </button>
-                  </div>
-                </FormControl>
-                <FormMessage />
-              </FormItem>
-            )}
-          />
+          <NoteInline>
+            {appleCredentialMode === "client-secret"
+              ? "Static client secrets expire within 6 months and must be rotated manually."
+              : "Hexclave mints short-lived client secrets from your private key, so no manual rotation is needed."}
+          </NoteInline>
+          {appleCredentialMode === "client-secret" ? (
+            <FormField
+              control={form.control}
+              name="clientSecret"
+              render={({ field }) => (
+                <FormItem className="space-y-1.5">
+                  <FormLabel className="text-xs font-medium text-muted-foreground">Client Secret</FormLabel>
+                  <FormControl>
+                    <DesignInput {...field} value={field.value ?? ""} type="password" placeholder="Client Secret" size="sm" autoComplete="off" />
+                  </FormControl>
+                  <FormMessage />
+                </FormItem>
+              )}
+            />
+          ) : (
+            <>
+              <FormField
+                control={form.control}
+                name="appleTeamId"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel className="text-xs font-medium text-muted-foreground">Apple Team ID</FormLabel>
+                    <FormControl><DesignInput {...field} value={field.value ?? ""} placeholder="Team ID" size="sm" autoComplete="off" /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="appleKeyId"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel className="text-xs font-medium text-muted-foreground">Apple Key ID</FormLabel>
+                    <FormControl><DesignInput {...field} value={field.value ?? ""} placeholder="Key ID" size="sm" autoComplete="off" /></FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+              <FormField
+                control={form.control}
+                name="applePrivateKey"
+                render={({ field }) => (
+                  <FormItem className="space-y-1.5">
+                    <FormLabel className="text-xs font-medium text-muted-foreground">Apple private key (.p8)</FormLabel>
+                    <FormControl>
+                      <div className="relative">
+                        <textarea
+                          {...field}
+                          value={field.value ?? ""}
+                          placeholder="-----BEGIN PRIVATE KEY-----"
+                          autoComplete="off"
+                          rows={6}
+                          className={`w-full rounded-md border border-input bg-background px-3 py-2 pr-10 font-mono text-xs ${showApplePrivateKey ? "" : "[-webkit-text-security:disc]"}`}
+                        />
+                        <button
+                          type="button"
+                          onClick={() => setShowApplePrivateKey(value => !value)}
+                          aria-label={showApplePrivateKey ? "Hide Apple private key" : "Show Apple private key"}
+                          className="absolute right-2 top-2 rounded p-1 text-muted-foreground hover:text-foreground"
+                        >
+                          {showApplePrivateKey ? <EyeSlashIcon size={16} /> : <EyeIcon size={16} />}
+                        </button>
+                      </div>
+                    </FormControl>
+                    <FormMessage />
+                  </FormItem>
+                )}
+              />
+            </>
+          )}
           <ChipsInputField
             control={form.control}
             name="appleBundleIds"
@@ -368,6 +428,16 @@ function OAuthProviderSettingsForm(props: {
 export function ProviderSettingDialog(props: Props & { open: boolean, onClose: () => void }) {
   const hasSharedKeys = sharedProviders.includes(props.id as any);
   const bundleIdsArray = (props.provider as any)?.appleBundleIds ?? [];
+  // Existing Apple providers with only a client secret are legacy integrations;
+  // providers with any key credentials should open on the key-based path.
+  const isNonEmpty = (value: unknown) => typeof value === "string" && value !== "";
+  const initialAppleCredentialMode: ProviderFormValues["appleCredentialMode"] =
+    isNonEmpty((props.provider as any)?.clientSecret)
+      && !isNonEmpty((props.provider as any)?.appleTeamId)
+      && !isNonEmpty((props.provider as any)?.appleKeyId)
+      && !isNonEmpty((props.provider as any)?.applePrivateKey)
+      ? "client-secret"
+      : "private-key";
 
   const defaultValues = {
     shared: props.provider ? (props.provider.type === 'shared') : hasSharedKeys,
@@ -376,6 +446,7 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
     appleTeamId: (props.provider as any)?.appleTeamId ?? "",
     appleKeyId: (props.provider as any)?.appleKeyId ?? "",
     applePrivateKey: (props.provider as any)?.applePrivateKey ?? "",
+    appleCredentialMode: initialAppleCredentialMode,
     facebookConfigId: (props.provider as any)?.facebookConfigId ?? "",
     microsoftTenantId: (props.provider as any)?.microsoftTenantId ?? "",
     appleBundleIds: Array.isArray(bundleIdsArray) ? bundleIdsArray : [],
@@ -385,18 +456,29 @@ export function ProviderSettingDialog(props: Props & { open: boolean, onClose: (
     if (values.shared) {
       await props.updateProvider({ id: props.id, type: 'shared' });
     } else {
-      await props.updateProvider({
+      const provider = {
         id: props.id,
         type: 'standard',
         clientId: values.clientId || "",
-        clientSecret: values.clientSecret || undefined,
-        appleTeamId: values.appleTeamId || undefined,
-        appleKeyId: values.appleKeyId || undefined,
-        applePrivateKey: values.applePrivateKey || undefined,
         facebookConfigId: values.facebookConfigId,
         microsoftTenantId: values.microsoftTenantId,
         appleBundleIds: values.appleBundleIds ?? [],
-      });
+      } as const;
+      await props.updateProvider(props.id === "apple"
+        ? {
+          ...provider,
+          clientSecret: values.appleCredentialMode === "client-secret" ? values.clientSecret || undefined : undefined,
+          appleTeamId: values.appleCredentialMode === "private-key" ? values.appleTeamId || undefined : undefined,
+          appleKeyId: values.appleCredentialMode === "private-key" ? values.appleKeyId || undefined : undefined,
+          applePrivateKey: values.appleCredentialMode === "private-key" ? values.applePrivateKey || undefined : undefined,
+        }
+        : {
+          ...provider,
+          clientSecret: values.clientSecret || undefined,
+          appleTeamId: values.appleTeamId || undefined,
+          appleKeyId: values.appleKeyId || undefined,
+          applePrivateKey: values.applePrivateKey || undefined,
+        });
     }
   };
 

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/auth-methods/providers.tsx
@@ -255,7 +255,7 @@ function CredentialFields({ form, providerId }: { form: UseFormReturn<ProviderFo
         <>
           <DesignCategoryTabs
             categories={[
-              { id: "private-key", label: "Private key (Recommended)" },
+              { id: "private-key", label: "Automatic (Recommended)" },
               { id: "client-secret", label: "Client secret (Legacy)" },
             ]}
             selectedCategory={appleCredentialMode}

--- a/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
@@ -51,7 +51,7 @@ This guide explains how to set up Apple as an authentication provider with Hexcl
   <Step>
     ### Configure Key-Based Credentials (Recommended)
 
-    In the Apple provider dialog, choose the **Private key (Recommended)** tab. Hexclave mints a short-lived client secret at token-exchange time from your Apple credentials. Enter:
+    In the Apple provider dialog, choose the **Automatic (Recommended)** tab. Hexclave mints a short-lived client secret at token-exchange time from your Apple credentials. Enter:
 
     * **Team ID**: Your Apple Developer account ID found at the top-right of the portal
     * **Key ID**: The ID of the private key you just created
@@ -65,7 +65,7 @@ This guide explains how to set up Apple as an authentication provider with Hexcl
 
     1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Apple** as the provider.
-    3. Set the **Service ID (Client ID)** to your Services ID identifier, then choose the **Private key (Recommended)** tab and enter the Team ID, Key ID, and `.p8` private key contents.
+    3. Set the **Service ID (Client ID)** to your Services ID identifier, then choose the **Automatic (Recommended)** tab and enter the Team ID, Key ID, and `.p8` private key contents.
   </Step>
 
   <Step>

--- a/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
+++ b/docs-mintlify/guides/apps/authentication/auth-providers/apple.mdx
@@ -51,7 +51,7 @@ This guide explains how to set up Apple as an authentication provider with Hexcl
   <Step>
     ### Configure Key-Based Credentials (Recommended)
 
-    Hexclave mints a short-lived client secret at token-exchange time from your Apple credentials. In the dashboard, enter:
+    In the Apple provider dialog, choose the **Private key (Recommended)** tab. Hexclave mints a short-lived client secret at token-exchange time from your Apple credentials. Enter:
 
     * **Team ID**: Your Apple Developer account ID found at the top-right of the portal
     * **Key ID**: The ID of the private key you just created
@@ -65,15 +65,15 @@ This guide explains how to set up Apple as an authentication provider with Hexcl
 
     1. On the Hexclave dashboard, select **Auth Methods** in the left sidebar.
     2. Click **Add SSO Providers** and select **Apple** as the provider.
-    3. Set the **Client ID** to your Services ID identifier, then enter the Team ID, Key ID, and `.p8` private key contents.
+    3. Set the **Service ID (Client ID)** to your Services ID identifier, then choose the **Private key (Recommended)** tab and enter the Team ID, Key ID, and `.p8` private key contents.
   </Step>
 
   <Step>
     ### Legacy: Static Client Secret
 
-    Apple also supports a manually generated client-secret JWT. This is retained for existing integrations, but is less convenient because it expires (Apple allows a maximum lifetime of six months). Enter it in **Client Secret** instead of the key-based credentials.
+    Apple also supports a manually generated client-secret JWT. In the Apple provider dialog, choose the **Client secret (Legacy)** tab. This is retained for existing integrations, but is less convenient because it expires (Apple allows a maximum lifetime of six months) and must be rotated manually. Enter it in **Client Secret** instead of the key-based credentials.
 
-    If you use a static secret, leave the Team ID, Key ID, and private key fields empty.
+    Saving on this tab clears any stored Team ID, Key ID, and private key.
   </Step>
 </Steps>
 


### PR DESCRIPTION
Apple's provider dialog listed the client secret and the Team ID / Key ID / `.p8` key as one flat list, so it wasn't clear that the key-based path is the one almost everyone should use, or which fields were actually required.

The dialog now has two tabs, defaulting to `Private key (Recommended)`, with `Client secret (Legacy)` for existing static-JWT integrations. Service ID and Bundle IDs stay outside the tabs since they apply to both. Only Apple gets tabs; other providers keep the flat form.

- Validation follows the selected mode and points at the visible missing field (`Apple Team ID is required.` rather than one combined message).
- Saving submits only the active mode's credentials and omits the other's, so switching modes clears the stale credentials server-side.
- Reopening an existing provider picks the tab from what's stored: client-secret only → legacy tab, otherwise the key tab.

Docs updated to match the new labels.


Link to Devin session: https://app.devin.ai/sessions/ff747db5e23748848070428513d27307
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Make Apple OAuth setup clearer by splitting credentials into two tabs and defaulting to Automatic (Recommended). Validation and saving now follow the selected mode, and the docs match the new labels.

- **New Features**
  - Two tabs: Automatic (Recommended) and Client secret (Legacy). Service ID and Bundle IDs apply to both.
  - Mode-specific validation with field-level errors (e.g., “Apple Team ID is required.” or “Client secret is required when using the legacy client secret.”).
  - Save only the active mode’s credentials; switching modes clears the other mode server-side.
  - Reopening selects the tab based on stored credentials (client-secret-only → Legacy; otherwise → Automatic).
  - Other providers remain unchanged.

<sup>Written for commit 5a496e95f0f26d6116f4790dabb0cc0005ce51c5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1847?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Apple authentication setup supports recommended private-key credentials and legacy client-secret credentials.
  * Configuration fields and validation adapt to the selected credential mode.
  * Existing Apple provider settings automatically select the appropriate mode.

* **Documentation**
  * Updated Apple authentication guidance for private-key and legacy client-secret setup.
  * Clarified credential expiration, rotation, and storage behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->