### PR TITLE
Don't let the example.com Emailable shortcut override the no-API-key dev/test path

### DIFF
--- a/apps/backend/src/lib/emailable.tsx
+++ b/apps/backend/src/lib/emailable.tsx
@@ -163,6 +163,7 @@ import.meta.vitest?.describe("checkEmailWithEmailable(...)", () => {
     "user@stack-generated.example.com",
   ])("treats reserved example address %s as deliverable without an API key", async (email) => {
     vi.stubEnv("STACK_EMAILABLE_API_KEY", "");
+    vi.stubEnv("NODE_ENV", "test");
     const result = await checkEmailWithEmailable(email);
     expect(result).toEqual({ status: "deliverable", emailableScore: null });
   });

--- a/apps/backend/src/lib/emailable.tsx
+++ b/apps/backend/src/lib/emailable.tsx
@@ -82,9 +82,7 @@ export async function checkEmailWithEmailable(
     const rawApiKey = getEnvVariable("STACK_EMAILABLE_API_KEY", "");
     const emailDomain = email.split("@")[1]?.toLowerCase() ?? "";
 
-    // example.com and its subdomains are reserved for documentation and can never receive email, so avoid spending an
-    // Emailable request on them in every environment. This also covers EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN.
-    if (isReservedExampleDomain(emailDomain)) {
+    if (emailDomain === EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN) {
       const testResponse = buildTestUndeliverableResponse(email);
       return { status: "not-deliverable", emailableResponse: testResponse, emailableScore: testResponse.score };
     }
@@ -99,6 +97,12 @@ export async function checkEmailWithEmailable(
     const apiKey = rawApiKey === "disable_email_validation" ? "" : rawApiKey;
     if (!apiKey) {
       return { status: "deliverable", emailableScore: null };
+    }
+
+    // Avoid spending Emailable requests on reserved example domains without overriding the no-key dev/test behavior.
+    if (isReservedExampleDomain(emailDomain)) {
+      const testResponse = buildTestUndeliverableResponse(email);
+      return { status: "not-deliverable", emailableResponse: testResponse, emailableScore: testResponse.score };
     }
 
     const clientFactory = options?._clientFactory ?? createEmailableClient;
@@ -152,6 +156,15 @@ import.meta.vitest?.describe("checkEmailWithEmailable(...)", () => {
     vi.stubEnv("STACK_EMAILABLE_API_KEY", "");
     await expect(checkEmailWithEmailable(`user@${EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN}`))
       .resolves.toMatchObject({ status: "not-deliverable", emailableResponse: { state: "undeliverable", reason: "test_domain_rejection" } });
+  });
+
+  test.each([
+    "user@example.com",
+    "user@stack-generated.example.com",
+  ])("treats reserved example address %s as deliverable without an API key", async (email) => {
+    vi.stubEnv("STACK_EMAILABLE_API_KEY", "");
+    const result = await checkEmailWithEmailable(email);
+    expect(result).toEqual({ status: "deliverable", emailableScore: null });
   });
 
   test.each([


### PR DESCRIPTION
`checkEmailWithEmailable` rejected every `example.com` / `*.example.com` address as undeliverable before it ever looked at the API key. E2E mailboxes are `…@stack-generated.example.com`, so any email whose send path runs the deliverability check was marked `skippedReason = LIKELY_NOT_DELIVERABLE` and never delivered to Inbucket.

That only bites password sign-up, since `shouldSkipDeliverabilityCheck` is `true` for OTP, password reset, contact-channel verification and invitations, and `false` for password sign-up — which is exactly the email `Auth.Password.signUpWithEmail` waits for.

The reserved-domain shortcut exists to avoid spending Emailable requests, so it now runs after the API-key branches instead of ahead of them:

```
if (domain === EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN) return notDeliverable  // unchanged: tests rely on this with no key
if (!rawApiKey) { dev/test => deliverable; else throw }
if (apiKey === "") return deliverable                                        // disable_email_validation
+ if (isReservedExampleDomain(domain)) return notDeliverable                 // moved here
… call Emailable
```

`EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN` deliberately stays above the key checks: `risk-scores.test.ts`, `internal/sign-up-rules-test.test.ts` and `emails/deliverability-gating.test.ts` need that domain to be undeliverable against a backend with no Emailable key.

Verified with the pre-fix version of this change: the five tests reported as flaky (`projects.test.ts` userCount, and four `users.test.ts` "with server access" cases) went from 0/10 to 10/10 in isolation, and the outbox row went from `SKIPPED / LIKELY_NOT_DELIVERABLE` to `SENT`. They were not flaky — they failed in 7/7 of the last dev CI runs, and 0/10 locally in isolation and 0/3 under load.


Link to Devin session: https://app.devin.ai/sessions/117e9304e11743008973e4aec076e5bd
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fix the Emailable check so the `example.com` shortcut no longer overrides the no-API-key dev/test path. Password sign-up emails to `…@stack-generated.example.com` now deliver to Inbucket; tests now make the test environment explicit.

- **Bug Fixes**
  - Reordered `checkEmailWithEmailable` so API-key branches run before the reserved `example.com` rule.
  - Kept `EMAILABLE_NOT_DELIVERABLE_TEST_DOMAIN` as an early exit to preserve no-key test behavior.
  - Added tests that stub `STACK_EMAILABLE_API_KEY=""` and `NODE_ENV="test"` to confirm `user@example.com` and `user@stack-generated.example.com` are deliverable.

<sup>Written for commit a41b003026a0802d1ab7db0417bb8fc8c1539a7d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1850?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved email validation behavior for reserved example domains.
  * Dedicated test domains are consistently rejected, regardless of configuration.
  * Other reserved example domains now return appropriate deliverability results in development and test environments.
  * Avoided unnecessary external validation requests when validation is disabled or no API key is configured.
  * Added coverage for behavior across domains, environments, and API-key configurations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->