### PR TITLE
Show developer-facing auth setup errors as an in-page error card

### DIFF
--- a/apps/e2e/tests/js/cross-domain-auth.test.ts
+++ b/apps/e2e/tests/js/cross-domain-auth.test.ts
@@ -698,8 +698,8 @@ it("rejects nested cross-domain auth when the source redirect URI is untrusted",
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
     const createCrossDomainAuthRedirectUrlSpy = vi.spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl");
-    // The handler only inspects the OAuth request params once the handoff belongs to the current session, so the source
-    // session has to be the requested one for the trust check to be reached at all.
+    // An untrusted URL only becomes a developer-facing setup error once the handoff is known to belong to the current
+    // session, so the source session has to be the requested one for the trust failure to surface as such.
     vi.spyOn(clientApp as any, "_fetchCurrentRefreshTokenIdIfSignedIn").mockResolvedValue("source-session");
     vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(false);
 

--- a/apps/e2e/tests/js/cross-domain-auth.test.ts
+++ b/apps/e2e/tests/js/cross-domain-auth.test.ts
@@ -1,4 +1,5 @@
 import { StackClientApp } from "@hexclave/js";
+import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
 import { afterEach, vi } from "vitest";
 import { it, localRedirectUrl } from "../helpers";
 
@@ -736,7 +737,14 @@ it("rejects nested cross-domain auth when the callback URL is untrusted", async 
     } as any;
 
     try {
-      await expect((clientApp as any)._maybeHandleNestedCrossDomainAuth()).rejects.toThrowError(/not trusted/);
+      const nestedAuthPromise = (clientApp as any)._maybeHandleNestedCrossDomainAuth();
+      await expect(nestedAuthPromise).rejects.toThrowError(/not trusted/);
+      // An untrusted domain can only be fixed in the project's configuration, so the SDK must throw a setup error with
+      // instructions; that is what makes it render an error card instead of only logging the failure.
+      await expect(nestedAuthPromise).rejects.toSatisfy((error: unknown) => (
+        HexclaveSetupError.isSetupError(error)
+        && error.howToFix.some((step) => step.includes("https://evil.example.test"))
+      ));
     } finally {
       globalThis.window = previousWindow;
       globalThis.document = previousDocument;

--- a/apps/e2e/tests/js/cross-domain-auth.test.ts
+++ b/apps/e2e/tests/js/cross-domain-auth.test.ts
@@ -698,6 +698,9 @@ it("rejects nested cross-domain auth when the source redirect URI is untrusted",
     const previousWindow = globalThis.window;
     const previousDocument = globalThis.document;
     const createCrossDomainAuthRedirectUrlSpy = vi.spyOn(clientApp as any, "_createCrossDomainAuthRedirectUrl");
+    // The handler only inspects the OAuth request params once the handoff belongs to the current session, so the source
+    // session has to be the requested one for the trust check to be reached at all.
+    vi.spyOn(clientApp as any, "_fetchCurrentRefreshTokenIdIfSignedIn").mockResolvedValue("source-session");
     vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(false);
 
     globalThis.document = createMockDocument();

--- a/packages/shared/src/utils/errors.tsx
+++ b/packages/shared/src/utils/errors.tsx
@@ -112,8 +112,8 @@ export class HexclaveSetupError extends Error {
     title: string,
     message: string,
     howToFix: readonly string[],
-    // same shape as HexclaveAssertionError's extraData: freeform diagnostics that only ever reach the error sinks
-    extraData?: Record<string, any> & ErrorOptions,
+    // like HexclaveAssertionError's extraData: freeform diagnostics that only ever reach the error sinks
+    extraData?: Record<string, unknown> & ErrorOptions,
   }) {
     super(options.message, pick(options.extraData ?? {}, ["cause"]));
     this.title = options.title;

--- a/packages/shared/src/utils/errors.tsx
+++ b/packages/shared/src/utils/errors.tsx
@@ -93,6 +93,52 @@ export class HexclaveAssertionError extends Error {
 HexclaveAssertionError.prototype.name = "HexclaveAssertionError";
 
 
+const hexclaveSetupErrorBrand = "hexclave-setup-error-brand-sentinel";
+
+/**
+ * An error caused by an incomplete or incorrect Hexclave setup in the developer's own project — a domain that has not
+ * been added to the project's trusted domains, for example.
+ *
+ * These are neither the end user's fault nor a bug in Hexclave, and they are usually fatal for the flow they occur in (an
+ * auth handoff that can never complete, say). Only logging them would leave the developer with a broken flow and no
+ * visible explanation, so the SDK also renders them on the page; `title` and `howToFix` end up in that card, so write
+ * them as instructions to the developer rather than as internal diagnostics.
+ */
+export class HexclaveSetupError extends Error {
+  public readonly title: string;
+  public readonly howToFix: readonly string[];
+
+  constructor(options: {
+    title: string,
+    message: string,
+    howToFix: readonly string[],
+    // same shape as HexclaveAssertionError's extraData: freeform diagnostics that only ever reach the error sinks
+    extraData?: Record<string, any> & ErrorOptions,
+  }) {
+    super(options.message, pick(options.extraData ?? {}, ["cause"]));
+    this.title = options.title;
+    this.howToFix = options.howToFix;
+
+    Object.defineProperty(this, hexclaveSetupErrorBrand, { value: true, enumerable: false });
+    Object.defineProperty(this, "customCaptureExtraArgs", {
+      get() {
+        return [{ ...options.extraData, howToFix: options.howToFix }];
+      },
+      enumerable: false,
+    });
+  }
+
+  /**
+   * Like `instanceof`, but also true for setup errors thrown by another copy of this package — an app can easily end up
+   * with two of them, and a setup error from either must still show up as one.
+   */
+  public static isSetupError(error: unknown): error is HexclaveSetupError {
+    return typeof error === "object" && error !== null && hexclaveSetupErrorBrand in error;
+  }
+}
+HexclaveSetupError.prototype.name = "HexclaveSetupError";
+
+
 export function errorToNiceString(error: unknown): string {
   if (!(error instanceof Error)) return `${typeof error}<${nicify(error)}>`;
   return nicify(error, { maxDepth: 8 });

--- a/packages/shared/src/utils/errors.tsx
+++ b/packages/shared/src/utils/errors.tsx
@@ -133,7 +133,12 @@ export class HexclaveSetupError extends Error {
    * with two of them, and a setup error from either must still show up as one.
    */
   public static isSetupError(error: unknown): error is HexclaveSetupError {
-    return typeof error === "object" && error !== null && hexclaveSetupErrorBrand in error;
+    if (typeof error !== "object" || error === null) return false;
+    // an own property with the sentinel value, not just the name somewhere on the prototype chain; the brand decides
+    // whether an error is shown to the developer verbatim, so a coincidental key must not be enough
+    if (!Object.prototype.hasOwnProperty.call(error, hexclaveSetupErrorBrand)) return false;
+    if (Reflect.get(error, hexclaveSetupErrorBrand) !== true) return false;
+    return typeof Reflect.get(error, "title") === "string" && Array.isArray(Reflect.get(error, "howToFix"));
   }
 }
 HexclaveSetupError.prototype.name = "HexclaveSetupError";

--- a/packages/template/src/dev-tool/dev-tool-core.ts
+++ b/packages/template/src/dev-tool/dev-tool-core.ts
@@ -6,6 +6,7 @@ import { runAsynchronously, runAsynchronouslyWithAlert } from "@hexclave/shared/
 import { isLocalhost } from "@hexclave/shared/dist/utils/urls";
 import type { StackClientApp } from "../lib/hexclave-app";
 import { getGlobalUiInstance, h, hasAppendChild, setGlobalUiInstance, setHtml, type UiGlobalInstance } from "../in-page-ui/dom";
+import { HEXCLAVE_LOGO_SVG } from "../in-page-ui/logo";
 import { getBaseUrl } from "../lib/hexclave-app/apps/implementations/common";
 import type { HandlerUrlOptions, HandlerUrls, HandlerUrlTarget } from "../lib/hexclave-app/common";
 import { hexclaveAppInternalsSymbol } from "../lib/hexclave-app/common";
@@ -85,10 +86,6 @@ const DEFAULT_STATE: DevToolState = {
   panelHeight: 520,
 };
 
-// Hexclave mark — hexagon outline with three radial bars, monochrome via currentColor
-// so it inherits the trigger logo's color. Sourced from apps/dashboard/public/hexclave-icon.svg
-// (gradient + glow stripped; this is a tiny trigger glyph, not the full brand mark).
-const HEXCLAVE_LOGO_SVG = '<svg width="16" height="16" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="miter"><path d="M 24 4 L 41.32 14 L 41.32 34 L 24 44 L 6.68 34 L 6.68 14 Z"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(120 24 24)"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(240 24 24)"/></svg>';
 
 // ---------------------------------------------------------------------------
 // State management

--- a/packages/template/src/dev-tool/index.ts
+++ b/packages/template/src/dev-tool/index.ts
@@ -3,9 +3,8 @@
 import type { StackClientApp } from "../lib/hexclave-app";
 import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
-import { isLocalhost } from "@hexclave/shared/dist/utils/urls";
+import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
 import { canMountIntoDom } from "../in-page-ui/dom";
-import { envVars } from "../generated/env";
 import type { createDevTool as CreateDevToolFn } from "./dev-tool-core";
 
 // Hexclave rebrand: UI-only local pref — straight rename (one-time reset is harmless)
@@ -35,19 +34,9 @@ function shouldShow(): boolean {
   // consuming app itself was built or hosted as production.
   if (activeProjectIsDevelopmentEnvironment) return true;
 
-  // "auto" behavior (the default):
-  const nodeEnv = envVars.NODE_ENV;
-  if (nodeEnv !== undefined) {
-    // NODE_ENV is available (bundler/process env exists) — only show in development
-    return nodeEnv === "development";
-  }
-
-  // NODE_ENV not found (no process.env/import.meta) — show on localhost or file: protocol
-  try {
-    const url = new URL(window.location.href);
-    if (url.protocol === "file:") return true;
-  } catch {}
-  return isLocalhost(window.location.href);
+  // "auto" behavior (the default): every in-page UI that is only appropriate while developing shares one heuristic, so
+  // the dev tool and the error cards can never disagree about whether this looks like a development environment.
+  return isLikelyDevelopmentEnvironment();
 }
 
 let activeCleanup: (() => void) | null = null;

--- a/packages/template/src/in-page-ui/dev-environment.ts
+++ b/packages/template/src/in-page-ui/dev-environment.ts
@@ -1,0 +1,29 @@
+// Shared "are we in a development-like environment?" check for Hexclave's in-page UIs. Some of them (eg. surfacing an
+// unexpected internal error) are only appropriate while developing, and the SDK cannot ask the server about it because
+// the check has to work synchronously and before the app is authenticated.
+
+import { isLocalhost } from "@hexclave/shared/dist/utils/urls";
+import { envVars } from "../generated/env";
+
+export function isLikelyDevelopmentEnvironment(): boolean {
+  // NODE_ENV is the most reliable signal, but plenty of bundlers (eg. Vite-based ones) don't define it in the browser
+  // bundle at all, so fall back to guessing from the current URL.
+  const nodeEnv = envVars.NODE_ENV;
+  if (nodeEnv !== undefined) {
+    return nodeEnv === "development";
+  }
+
+  if (typeof window === "undefined") {
+    return false;
+  }
+
+  try {
+    const url = new URL(window.location.href);
+    if (url.protocol === "file:") {
+      return true;
+    }
+  } catch {
+    return false;
+  }
+  return isLocalhost(window.location.href);
+}

--- a/packages/template/src/in-page-ui/issue-card.test.ts
+++ b/packages/template/src/in-page-ui/issue-card.test.ts
@@ -1,0 +1,63 @@
+// @vitest-environment jsdom
+
+import { afterEach, describe, expect, it } from "vitest";
+import { renderIssueCard, trapFocusInIssueCard } from "./issue-card";
+
+function mountCard(): HTMLElement {
+  const root = document.body.appendChild(document.createElement("div"));
+  root.appendChild(renderIssueCard({
+    kind: "error",
+    badge: "Config error",
+    title: "Something is misconfigured",
+    bodyText: "Body",
+    messageLabel: "Error message",
+    message: "Message",
+    footerText: "Footer",
+    ariaLabel: "Hexclave config error",
+    aiPrompt: "prompt",
+    onCopyError: () => {},
+    onCopyAiPromptError: () => {},
+    onMinimize: () => {},
+  }));
+  return root;
+}
+
+function pressTab() {
+  document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+}
+
+function cardButtons(root: HTMLElement): HTMLButtonElement[] {
+  return [...root.querySelectorAll<HTMLButtonElement>(".hic-card button")];
+}
+
+describe("issue card focus trap", () => {
+  afterEach(() => {
+    document.body.replaceChildren();
+  });
+
+  it("follows a re-rendered card without moving focus or losing the original focus owner", () => {
+    const pageButton = document.body.appendChild(document.createElement("button"));
+    pageButton.focus();
+
+    const firstRoot = mountCard();
+    const firstTrap = trapFocusInIssueCard(firstRoot);
+    expect(document.activeElement).toBe(firstRoot.querySelector(".hic-card"));
+
+    // What the pushed-config overlay does on every poll: throw the rendered card away and render a fresh one.
+    firstRoot.remove();
+    const secondRoot = mountCard();
+    firstTrap.release({ restoreFocus: false });
+    const secondTrap = trapFocusInIssueCard(secondRoot, {
+      moveFocusIntoCard: false,
+      previouslyFocused: firstTrap.previouslyFocused,
+    });
+    expect(document.activeElement).not.toBe(secondRoot.querySelector(".hic-card"));
+
+    // The trap now belongs to the visible card, so Tab lands inside it instead of inside the detached one.
+    pressTab();
+    expect(document.activeElement).toBe(cardButtons(secondRoot)[0]);
+
+    secondTrap.release();
+    expect(document.activeElement).toBe(pageButton);
+  });
+});

--- a/packages/template/src/in-page-ui/issue-card.ts
+++ b/packages/template/src/in-page-ui/issue-card.ts
@@ -279,7 +279,7 @@ export async function copyTextToClipboard(text: string): Promise<void> {
       opacity: "0",
     },
     readonly: "true",
-  }) as HTMLTextAreaElement;
+  });
   textarea.value = text;
   document.body.appendChild(textarea);
   textarea.select();
@@ -352,7 +352,7 @@ export function renderIssueCard(options: IssueCardOptions): HTMLElement {
   setHtml(logoSpan, HEXCLAVE_LOGO_SVG);
 
   return h("div", { className: "hic-backdrop" },
-    h("div", { className: options.kind === "error" ? "hic-card" : "hic-card hic-card-warning", role: "alertdialog", "aria-modal": "true", "aria-label": options.ariaLabel },
+    h("div", { className: options.kind === "error" ? "hic-card" : "hic-card hic-card-warning", role: "alertdialog", "aria-modal": "true", "aria-label": options.ariaLabel, tabindex: "-1" },
       h("div", { className: "hic-card-inner" },
         h("div", { className: "hic-header" },
           h("div", { className: "hic-title-row" },
@@ -406,6 +406,53 @@ export function renderIssueCard(options: IssueCardOptions): HTMLElement {
       ),
     ),
   );
+}
+
+const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
+
+/**
+ * Keeps keyboard focus inside a mounted card, which claims to be an `aria-modal` alertdialog and therefore has to behave
+ * like one: the flow behind the card is dead until the problem is fixed, so tabbing into it would only let a keyboard
+ * user wander through a page that cannot work while the card stays invisible to them.
+ *
+ * Call right after mounting the card, and call the returned function when the card is minimized or removed — it hands
+ * focus back to wherever it was, so minimizing the card leaves the page as the user found it.
+ */
+export function trapFocusInIssueCard(cardRoot: HTMLElement): () => void {
+  const card = cardRoot.querySelector(".hic-card");
+  if (!(card instanceof HTMLElement)) return () => {};
+  const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+  const onKeyDown = (event: KeyboardEvent) => {
+    if (event.key !== "Tab") return;
+    const focusable = [...card.querySelectorAll(FOCUSABLE_SELECTOR)].filter((element): element is HTMLElement => element instanceof HTMLElement);
+    const first = focusable[0] ?? card;
+    const last = focusable[focusable.length - 1] ?? card;
+    const active = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+
+    let target: HTMLElement | null = null;
+    if (active == null || !card.contains(active)) {
+      // Focus is outside the card (the page moved it, or it never got in): pull it back to the card's near end.
+      target = event.shiftKey ? last : first;
+    } else if (active === last && !event.shiftKey) {
+      target = first;
+    } else if (active === first && event.shiftKey) {
+      target = last;
+    }
+    if (target == null) return;
+    event.preventDefault();
+    target.focus();
+  };
+
+  document.addEventListener("keydown", onKeyDown, true);
+  card.focus();
+
+  return () => {
+    document.removeEventListener("keydown", onKeyDown, true);
+    if (previouslyFocused != null && previouslyFocused.isConnected) {
+      previouslyFocused.focus();
+    }
+  };
 }
 
 export function renderIssuePill(options: {

--- a/packages/template/src/in-page-ui/issue-card.ts
+++ b/packages/template/src/in-page-ui/issue-card.ts
@@ -6,10 +6,10 @@
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { getInPageUiBaseCSS } from "./base-styles";
 import { h, setHtml } from "./dom";
+import { HEXCLAVE_LOGO_SVG } from "./logo";
 
 export type IssueCardKind = "error" | "warning";
 
-export const HEXCLAVE_LOGO_SVG = '<svg width="16" height="16" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="miter"><path d="M 24 4 L 41.32 14 L 41.32 34 L 24 44 L 6.68 34 L 6.68 14 Z"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(120 24 24)"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(240 24 24)"/></svg>';
 const COPY_ICON_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
 
 export function getIssueCardCSS(scopeSelector: string): string {
@@ -410,18 +410,33 @@ export function renderIssueCard(options: IssueCardOptions): HTMLElement {
 
 const FOCUSABLE_SELECTOR = "a[href], button:not([disabled]), input:not([disabled]), select:not([disabled]), textarea:not([disabled]), [tabindex]:not([tabindex='-1'])";
 
+export type IssueCardFocusTrap = {
+  /**
+   * Whatever had focus before the card first appeared. Callers that rebind the trap to a re-rendered card pass it back
+   * in, so focus still returns to where the developer left it once the card is gone for good.
+   */
+  previouslyFocused: HTMLElement | null,
+  release: (releaseOptions?: { restoreFocus?: boolean }) => void,
+};
+
 /**
  * Keeps keyboard focus inside a mounted card, which claims to be an `aria-modal` alertdialog and therefore has to behave
  * like one: the flow behind the card is dead until the problem is fixed, so tabbing into it would only let a keyboard
  * user wander through a page that cannot work while the card stays invisible to them.
  *
- * Call right after mounting the card, and call the returned function when the card is minimized or removed — it hands
- * focus back to wherever it was, so minimizing the card leaves the page as the user found it.
+ * Call right after mounting the card, and release the trap when the card is minimized, replaced or removed. Releasing
+ * hands focus back to `previouslyFocused` unless `restoreFocus: false` is passed, which is what a caller that is about
+ * to rebind the trap to a freshly rendered card wants.
  */
-export function trapFocusInIssueCard(cardRoot: HTMLElement): () => void {
+export function trapFocusInIssueCard(cardRoot: HTMLElement, options: {
+  moveFocusIntoCard?: boolean,
+  previouslyFocused?: HTMLElement | null,
+} = {}): IssueCardFocusTrap {
+  const previouslyFocused = options.previouslyFocused !== undefined
+    ? options.previouslyFocused
+    : document.activeElement instanceof HTMLElement ? document.activeElement : null;
   const card = cardRoot.querySelector(".hic-card");
-  if (!(card instanceof HTMLElement)) return () => {};
-  const previouslyFocused = document.activeElement instanceof HTMLElement ? document.activeElement : null;
+  if (!(card instanceof HTMLElement)) return { previouslyFocused, release: () => {} };
 
   const onKeyDown = (event: KeyboardEvent) => {
     if (event.key !== "Tab") return;
@@ -445,13 +460,19 @@ export function trapFocusInIssueCard(cardRoot: HTMLElement): () => void {
   };
 
   document.addEventListener("keydown", onKeyDown, true);
-  card.focus();
+  if (options.moveFocusIntoCard !== false) {
+    card.focus();
+  }
 
-  return () => {
-    document.removeEventListener("keydown", onKeyDown, true);
-    if (previouslyFocused != null && previouslyFocused.isConnected) {
-      previouslyFocused.focus();
-    }
+  return {
+    previouslyFocused,
+    release: (releaseOptions) => {
+      document.removeEventListener("keydown", onKeyDown, true);
+      if (releaseOptions?.restoreFocus === false) return;
+      if (previouslyFocused != null && previouslyFocused.isConnected) {
+        previouslyFocused.focus();
+      }
+    },
   };
 }
 

--- a/packages/template/src/in-page-ui/issue-card.ts
+++ b/packages/template/src/in-page-ui/issue-card.ts
@@ -1,0 +1,428 @@
+// Shared renderer for Hexclave's in-page issue cards: the modal-style card (plus its minimized pill) that the SDK uses
+// to tell developers about problems it cannot recover from, like a broken pushed config or an untrusted auth domain.
+// Every issue surface renders the same shape, so the markup, styles and clipboard handling live here and each feature
+// only supplies its copy and callbacks.
+
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import { getInPageUiBaseCSS } from "./base-styles";
+import { h, setHtml } from "./dom";
+
+export type IssueCardKind = "error" | "warning";
+
+export const HEXCLAVE_LOGO_SVG = '<svg width="16" height="16" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="miter"><path d="M 24 4 L 41.32 14 L 41.32 34 L 24 44 L 6.68 34 L 6.68 14 Z"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(120 24 24)"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(240 24 24)"/></svg>';
+const COPY_ICON_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
+
+export function getIssueCardCSS(scopeSelector: string): string {
+  return getInPageUiBaseCSS(scopeSelector) + `
+  ${scopeSelector} .hic-backdrop {
+    position: fixed;
+    inset: 0;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    padding: 24px;
+    background: rgba(0, 0, 0, 0.46);
+    backdrop-filter: blur(6px);
+    overflow: auto;
+  }
+
+  ${scopeSelector} .hic-card {
+    --hic-status: var(--sdt-error);
+    width: min(720px, calc(100vw - 32px));
+    max-height: min(640px, calc(100dvh - 48px));
+    border: 1px solid color-mix(in srgb, var(--hic-status) 35%, var(--sdt-border));
+    border-radius: 18px;
+    background: var(--sdt-overlay-bg);
+    box-shadow: var(--sdt-shadow);
+    backdrop-filter: blur(18px);
+    display: flex;
+    overflow: hidden;
+  }
+
+  ${scopeSelector} .hic-card-warning {
+    --hic-status: var(--sdt-warning);
+  }
+
+  ${scopeSelector} .hic-card-inner {
+    padding: 18px;
+    width: 100%;
+    overflow: auto;
+  }
+
+  ${scopeSelector} .hic-header {
+    display: flex;
+    align-items: flex-start;
+    justify-content: space-between;
+    gap: 12px;
+    margin-bottom: 12px;
+  }
+
+  ${scopeSelector} .hic-title-row {
+    display: flex;
+    align-items: flex-start;
+    gap: 10px;
+    min-width: 0;
+  }
+
+  ${scopeSelector} .hic-logo {
+    flex-shrink: 0;
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 34px;
+    height: 34px;
+    border-radius: 10px;
+    background: var(--hic-status);
+    color: white;
+    box-shadow: 0 10px 30px color-mix(in srgb, var(--hic-status) 32%, transparent);
+  }
+
+  ${scopeSelector} .hic-badge {
+    display: inline-flex;
+    flex-shrink: 0;
+    padding: 2px 6px;
+    border-radius: 999px;
+    background: var(--hic-status);
+    color: white;
+    font-size: 10px;
+    font-weight: 700;
+    letter-spacing: 0.06em;
+    text-transform: uppercase;
+  }
+
+  ${scopeSelector} .hic-title {
+    color: var(--sdt-text);
+    margin-top: 4px;
+    font-size: 18px;
+    font-weight: 700;
+    line-height: 1.25;
+  }
+
+  ${scopeSelector} .hic-actions {
+    display: flex;
+    gap: 4px;
+  }
+
+  ${scopeSelector} .hic-icon-btn {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 28px;
+    height: 28px;
+    border: 1px solid var(--sdt-border);
+    border-radius: 8px;
+    background: var(--sdt-bg-elevated);
+    color: var(--sdt-text-secondary);
+    cursor: pointer;
+    font: inherit;
+    line-height: 1;
+    vertical-align: top;
+  }
+
+  ${scopeSelector} .hic-icon-btn svg {
+    display: block;
+    flex-shrink: 0;
+  }
+
+  ${scopeSelector} .hic-text-btn {
+    align-items: center;
+    gap: 6px;
+    min-height: 28px;
+    padding: 0 10px;
+    width: auto;
+    font-size: 12px;
+    line-height: 1;
+  }
+
+  ${scopeSelector} .hic-icon-btn:hover {
+    background: var(--sdt-bg-hover);
+    color: var(--sdt-text);
+  }
+
+  ${scopeSelector} .hic-body {
+    color: var(--sdt-text-secondary);
+    font-size: 14px;
+    line-height: 1.5;
+  }
+
+  ${scopeSelector} .hic-message-header {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 10px;
+    margin-top: 14px;
+    margin-bottom: 8px;
+  }
+
+  ${scopeSelector} .hic-message-label {
+    color: var(--sdt-text);
+    font-size: 12px;
+    font-weight: 650;
+  }
+
+  ${scopeSelector} .hic-message {
+    padding: 12px;
+    max-height: min(260px, max(96px, 30dvh));
+    overflow: auto;
+    border: 1px solid var(--sdt-border-subtle);
+    border-radius: 10px;
+    background: var(--sdt-bg-subtle);
+    color: var(--sdt-text);
+    font-family: var(--sdt-font-mono);
+    font-size: 12px;
+    white-space: pre-wrap;
+    overflow-wrap: anywhere;
+  }
+
+  ${scopeSelector} .hic-fix-list {
+    margin: 8px 0 0;
+    padding-left: 18px;
+    color: var(--sdt-text);
+    font-size: 13px;
+  }
+
+  ${scopeSelector} .hic-fix-list li + li {
+    margin-top: 4px;
+  }
+
+  ${scopeSelector} .hic-footer {
+    margin-top: 10px;
+    color: var(--sdt-text-tertiary);
+    font-size: 12px;
+  }
+
+  ${scopeSelector} .hic-pill {
+    position: fixed;
+    right: 18px;
+    bottom: 18px;
+    z-index: 2147483647;
+    display: flex;
+    align-items: center;
+    gap: 8px;
+    padding: 8px 12px 8px 8px;
+    --hic-status: var(--sdt-error);
+    border: 1px solid color-mix(in srgb, var(--hic-status) 35%, var(--sdt-border));
+    border-radius: 999px;
+    background: var(--sdt-overlay-bg);
+    box-shadow: var(--sdt-trigger-shadow);
+    color: var(--sdt-text);
+    cursor: pointer;
+    font: inherit;
+    backdrop-filter: blur(18px);
+  }
+
+  ${scopeSelector} .hic-pill-warning {
+    --hic-status: var(--sdt-warning);
+  }
+
+  ${scopeSelector} .hic-pill-logo {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    width: 26px;
+    height: 26px;
+    border-radius: 999px;
+    background: var(--hic-status);
+    color: white;
+  }
+
+  @media (max-height: 520px) {
+    ${scopeSelector} .hic-backdrop {
+      align-items: flex-start;
+      padding: 12px;
+    }
+
+    ${scopeSelector} .hic-card {
+      width: min(720px, calc(100vw - 24px));
+      max-height: calc(100dvh - 24px);
+    }
+
+    ${scopeSelector} .hic-card-inner {
+      padding: 12px;
+    }
+
+    ${scopeSelector} .hic-header {
+      margin-bottom: 8px;
+    }
+
+    ${scopeSelector} .hic-title {
+      font-size: 16px;
+    }
+
+    ${scopeSelector} .hic-body {
+      font-size: 13px;
+    }
+
+    ${scopeSelector} .hic-message {
+      max-height: max(80px, 24dvh);
+    }
+  }
+`;
+}
+
+export async function copyTextToClipboard(text: string): Promise<void> {
+  const clipboard: unknown = Reflect.get(navigator, "clipboard");
+  const writeText = clipboard != null && typeof clipboard === "object"
+    ? Reflect.get(clipboard, "writeText")
+    : null;
+  if (typeof writeText === "function") {
+    await writeText.call(clipboard, text);
+    return;
+  }
+
+  const textarea = h("textarea", {
+    style: {
+      position: "fixed",
+      left: "-9999px",
+      top: "0",
+      opacity: "0",
+    },
+    readonly: "true",
+  }) as HTMLTextAreaElement;
+  textarea.value = text;
+  document.body.appendChild(textarea);
+  textarea.select();
+  const copied = document.execCommand("copy");
+  textarea.remove();
+  if (!copied) {
+    throw new Error("Browser refused to copy the message.");
+  }
+}
+
+/**
+ * A button that copies `getText()` and briefly reports the outcome in its own label. Copying can fail for reasons
+ * outside our control (permissions, insecure contexts), so the failure is reported inline instead of being thrown into
+ * a click handler where nothing would show it.
+ */
+function renderCopyButton(options: {
+  variant: "icon" | "text",
+  title: string,
+  ariaLabel: string,
+  getText: () => string,
+  onCopyError: (error: unknown) => void,
+}): HTMLElement {
+  const idleHtml = options.variant === "text" ? `${COPY_ICON_SVG}Copy` : COPY_ICON_SVG;
+  const button = h("button", {
+    className: options.variant === "text" ? "hic-icon-btn hic-text-btn" : "hic-icon-btn",
+    type: "button",
+    title: options.title,
+    "aria-label": options.ariaLabel,
+    onClick: () => {
+      runAsynchronously(async () => {
+        await copyTextToClipboard(options.getText());
+        button.textContent = options.variant === "text" ? "Copied" : "✓";
+        setTimeout(() => setHtml(button, idleHtml), 1500);
+      }, {
+        noErrorLogging: true,
+        onError: (error) => {
+          options.onCopyError(error);
+          button.textContent = options.variant === "text" ? "Copy failed" : "!";
+          setTimeout(() => setHtml(button, idleHtml), 1500);
+        },
+      });
+    },
+  });
+  setHtml(button, idleHtml);
+  return button;
+}
+
+export type IssueCardOptions = {
+  kind: IssueCardKind,
+  /** Short uppercase label in the card's badge, eg. "Config error". */
+  badge: string,
+  title: string,
+  /** One or two sentences on what this means for the running app. */
+  bodyText: string,
+  messageLabel: string,
+  message: string,
+  /** Concrete steps the developer should take; rendered as a list above the footer. */
+  howToFix?: readonly string[],
+  footerText: string,
+  ariaLabel: string,
+  /** Prompt for the "copy AI prompt" button, ie. the message plus enough context for a coding agent to fix it. */
+  aiPrompt: string,
+  onCopyError: (error: unknown) => void,
+  onCopyAiPromptError: (error: unknown) => void,
+  onMinimize: () => void,
+};
+
+export function renderIssueCard(options: IssueCardOptions): HTMLElement {
+  const logoSpan = h("span", { className: "hic-logo" });
+  setHtml(logoSpan, HEXCLAVE_LOGO_SVG);
+
+  return h("div", { className: "hic-backdrop" },
+    h("div", { className: options.kind === "error" ? "hic-card" : "hic-card hic-card-warning", role: "alertdialog", "aria-modal": "true", "aria-label": options.ariaLabel },
+      h("div", { className: "hic-card-inner" },
+        h("div", { className: "hic-header" },
+          h("div", { className: "hic-title-row" },
+            logoSpan,
+            h("div", null,
+              h("span", { className: "hic-badge" }, options.badge),
+              h("div", { className: "hic-title" }, options.title),
+            ),
+          ),
+          h("div", { className: "hic-actions" },
+            renderCopyButton({
+              variant: "icon",
+              title: "Copy AI prompt",
+              ariaLabel: `Copy AI prompt for ${options.ariaLabel}`,
+              getText: () => options.aiPrompt,
+              onCopyError: options.onCopyAiPromptError,
+            }),
+            h("button", {
+              className: "hic-icon-btn",
+              type: "button",
+              title: "Minimize",
+              "aria-label": `Minimize ${options.ariaLabel}`,
+              onClick: options.onMinimize,
+            }, "–"),
+          ),
+        ),
+        h("div", { className: "hic-body" },
+          options.bodyText,
+          h("div", { className: "hic-message-header" },
+            h("div", { className: "hic-message-label" }, options.messageLabel),
+            renderCopyButton({
+              variant: "text",
+              title: `Copy ${options.messageLabel.toLowerCase()}`,
+              ariaLabel: `Copy ${options.ariaLabel} message`,
+              getText: () => options.message,
+              onCopyError: options.onCopyError,
+            }),
+          ),
+          h("div", { className: "hic-message" }, options.message),
+          options.howToFix == null || options.howToFix.length === 0 ? null : h("div", null,
+            h("div", { className: "hic-message-header" },
+              h("div", { className: "hic-message-label" }, "How to fix"),
+            ),
+            h("ul",
+              { className: "hic-fix-list" },
+              ...options.howToFix.map((step) => h("li", null, step)),
+            ),
+          ),
+          h("div", { className: "hic-footer" }, options.footerText),
+        ),
+      ),
+    ),
+  );
+}
+
+export function renderIssuePill(options: {
+  kind: IssueCardKind,
+  label: string,
+  ariaLabel: string,
+  onClick: () => void,
+}): HTMLElement {
+  const logoSpan = h("span", { className: "hic-pill-logo" });
+  setHtml(logoSpan, HEXCLAVE_LOGO_SVG);
+  return h("button", {
+    className: options.kind === "error" ? "hic-pill" : "hic-pill hic-pill-warning",
+    type: "button",
+    "aria-label": options.ariaLabel,
+    onClick: options.onClick,
+  },
+    logoSpan,
+    h("span", null, options.label),
+  );
+}

--- a/packages/template/src/in-page-ui/logo.ts
+++ b/packages/template/src/in-page-ui/logo.ts
@@ -1,0 +1,4 @@
+// Hexclave mark — hexagon outline with three radial bars, monochrome via currentColor so it inherits the surrounding
+// text color. Sourced from apps/dashboard/public/hexclave-icon.svg (gradient + glow stripped; this is a tiny glyph, not
+// the full brand mark). Shared by every in-page UI so the mark cannot drift between them.
+export const HEXCLAVE_LOGO_SVG = '<svg width="16" height="16" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="miter"><path d="M 24 4 L 41.32 14 L 41.32 34 L 24 44 L 6.68 34 L 6.68 14 Z"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(120 24 24)"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(240 24 24)"/></svg>';

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from "vitest";
 import { AccessToken } from "@hexclave/shared/dist/sessions";
+import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
 import { Store } from "@hexclave/shared/dist/utils/stores";
 import { hexclaveAppInternalsSymbol } from "../../common";
 import { StackClientApp } from "../interfaces/client-app";
@@ -489,6 +490,58 @@ describe("StackClientApp cross-domain auth", () => {
       // The live-URL guard must also stand down on its own when code+state are still present.
       (globalThis.window as any).location.href = urlAtConstructionTime.toString();
       await expect((clientApp as any)._maybeHandleNestedCrossDomainAuth()).resolves.toBe(false);
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it("reports malformed nested cross-domain auth URLs as setup errors", async () => {
+    const projectId = "00000000-0000-4000-8000-000000000012";
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    globalThis.document = createMockDocument();
+
+    // A URL the flow cannot even parse is as fatal as an untrusted one, so it has to reach the developer the same way
+    // instead of escaping as a bare TypeError from `new URL()`, which the overlay only shows during development.
+    const malformedCases = [
+      { description: "redirect URI", params: { redirect_uri: "not-a-url", state: "nested-state", code_challenge: "nested-code-challenge" } },
+      {
+        description: "after-callback redirect URL",
+        params: {
+          redirect_uri: "https://source.example.test/handler/account-settings",
+          state: "nested-state",
+          code_challenge: "nested-code-challenge",
+          after_callback_redirect_url: "http://[",
+        },
+      },
+      { description: "callback URL", params: { stack_nested_cross_domain_auth_callback_url: "http://[" } },
+    ];
+
+    try {
+      for (const malformedCase of malformedCases) {
+        const currentUrl = new URL("https://target.example.test/nested-provider");
+        currentUrl.searchParams.set("stack_nested_cross_domain_auth_refresh_token_id", "source-refresh-token-id");
+        for (const [key, value] of Object.entries(malformedCase.params)) {
+          currentUrl.searchParams.set(key, value);
+        }
+        globalThis.window = { location: { href: currentUrl.toString() } } as any;
+
+        const clientApp = new StackClientApp({
+          baseUrl: "http://localhost:12345",
+          projectId,
+          publishableClientKey: "stack-pk-test",
+          tokenStore: "memory",
+          redirectMethod: "window",
+          noAutomaticPrefetch: true,
+        });
+        vi.spyOn(clientApp as any, "_fetchCurrentRefreshTokenIdIfSignedIn").mockResolvedValue(null);
+        vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(true);
+
+        const nestedAuthPromise = (clientApp as any)._maybeHandleNestedCrossDomainAuth();
+        await expect(nestedAuthPromise).rejects.toThrowError(new RegExp(`${malformedCase.description} .* is not a valid absolute URL`));
+        await expect(nestedAuthPromise).rejects.toSatisfy((error: unknown) => HexclaveSetupError.isSetupError(error));
+      }
     } finally {
       globalThis.window = previousWindow;
       globalThis.document = previousDocument;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -6,6 +6,10 @@ import { hexclaveAppInternalsSymbol } from "../../common";
 import { StackClientApp } from "../interfaces/client-app";
 import { planRedirectToHandler } from "./redirect-page-urls";
 
+// Every app in this file is constructed with `devTool: false`. The tests install a mock window and document, which makes
+// the SDK believe it is in a browser, and mounting the dev tool kicks off a background `getProject()` against a backend
+// that does not exist here. That fetch never settles, and because it runs inside the global store lock, it blocks every
+// later `withWriteLock` caller (`_signOut`, most visibly) for the rest of the test file.
 function createAccessTokenString(refreshTokenId: string): string {
   const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
   const nowSeconds = Math.floor(Date.now() / 1000);
@@ -164,6 +168,7 @@ describe("StackClientApp cross-domain auth", () => {
           signIn: "/handler/sign-in",
         },
         noAutomaticPrefetch: true,
+        devTool: false,
       });
 
       const redirectUrl = await clientApp[hexclaveAppInternalsSymbol].getRedirectToHandlerUrl("signIn");
@@ -192,6 +197,7 @@ describe("StackClientApp cross-domain auth", () => {
       },
       redirectMethod: "none",
       noAutomaticPrefetch: true,
+      devTool: false,
     });
 
     const clientInterface = Reflect.get(clientApp, "_interface");
@@ -272,6 +278,7 @@ describe("StackClientApp cross-domain auth", () => {
         default: { type: "hosted" },
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const outerState = "outer-cross-domain-state";
     const outerCodeChallenge = "abcdefghijklmnopqrstuvwxyzABCDEFG_0123456789-._~";
@@ -333,6 +340,7 @@ describe("StackClientApp cross-domain auth", () => {
         default: { type: "hosted" },
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const tokenStore = Reflect.get(clientApp, "_memoryTokenStore");
     if (!(tokenStore instanceof Store)) {
@@ -411,6 +419,7 @@ describe("StackClientApp cross-domain auth", () => {
       tokenStore: "cookie",
       redirectMethod: "none",
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const clientInterface = Reflect.get(clientApp, "_interface");
     const originalFetchNewAccessToken = Reflect.get(clientInterface, "fetchNewAccessToken");
@@ -485,6 +494,7 @@ describe("StackClientApp cross-domain auth", () => {
       tokenStore: "memory",
       redirectMethod: "window",
       noAutomaticPrefetch: true,
+      devTool: false,
     });
 
     globalThis.document = createMockDocument();
@@ -526,9 +536,9 @@ describe("StackClientApp cross-domain auth", () => {
 
     // A URL the flow cannot even parse is as fatal as an untrusted one, so it has to reach the developer the same way
     // instead of escaping as a bare TypeError from `new URL()`, which the overlay only shows during development.
-    // The two branches of the handler want opposite session states: the provider side (a.com) only looks at the OAuth
-    // request params once the handoff belongs to the current session, while the requesting side (b.com) only bounces
-    // when the current session is *not* the one that was asked for.
+    // The two branches of the handler want opposite session states: on the provider side (a.com) a query-derived failure
+    // only becomes a setup error when the handoff belongs to the current session, while the requesting side (b.com) only
+    // bounces when the current session is *not* the one that was asked for.
     const malformedCases = [
       {
         description: "redirect URI",
@@ -559,8 +569,10 @@ describe("StackClientApp cross-domain auth", () => {
         for (const [key, value] of Object.entries(malformedCase.params)) {
           currentUrl.searchParams.set(key, value);
         }
-        setMockWindow({ location: { href: currentUrl.toString() } });
-
+        // Each app is constructed with the mock window uninstalled: the constructor's automatic side effects expect a
+        // real window, and a construction-time nested-auth URL would also schedule a second, unawaited run of the
+        // handler that keeps failing in the background and leaks into whichever test runs next.
+        globalThis.window = previousWindow;
         const clientApp = new StackClientApp({
           baseUrl: "http://localhost:12345",
           projectId,
@@ -568,13 +580,63 @@ describe("StackClientApp cross-domain auth", () => {
           tokenStore: "memory",
           redirectMethod: "window",
           noAutomaticPrefetch: true,
+          devTool: false,
         });
+        setMockWindow({ location: { href: currentUrl.toString() } });
         Reflect.set(clientApp, "_fetchCurrentRefreshTokenIdIfSignedIn", async () => malformedCase.currentRefreshTokenId);
         Reflect.set(clientApp, "_isTrusted", async () => true);
 
         const nestedAuthPromise = callProtectedMethod(clientApp, "_maybeHandleNestedCrossDomainAuth");
         await expect(nestedAuthPromise).rejects.toThrowError(new RegExp(`${malformedCase.description} .* is not a valid absolute URL`));
         await expect(nestedAuthPromise).rejects.toSatisfy((error: unknown) => HexclaveSetupError.isSetupError(error));
+      }
+    } finally {
+      globalThis.window = previousWindow;
+      globalThis.document = previousDocument;
+    }
+  });
+
+  it("keeps nested cross-domain auth failures off the page for a handoff that does not own the session", async () => {
+    const projectId = "00000000-0000-4000-8000-000000000013";
+    const previousWindow = globalThis.window;
+    const previousDocument = globalThis.document;
+    globalThis.document = createMockDocument();
+
+    // Setup errors are shown in production, so a link anybody can craft must not be able to put a card on a healthy
+    // app's page: with a refresh-token ID that is not the current session's, every failure below stays an ordinary error
+    // that only captureError sees, even though the same URL from the right session would render a card.
+    const craftedRedirectUris = [
+      "https://evil.example.test/handler/account-settings", // untrusted
+      "not-a-url", // malformed
+    ];
+
+    try {
+      for (const craftedRedirectUri of craftedRedirectUris) {
+        const currentUrl = new URL("https://target.example.test/nested-provider");
+        currentUrl.searchParams.set("stack_nested_cross_domain_auth_refresh_token_id", "attacker-chosen-refresh-token-id");
+        currentUrl.searchParams.set("redirect_uri", craftedRedirectUri);
+        currentUrl.searchParams.set("state", "nested-state");
+        currentUrl.searchParams.set("code_challenge", "nested-code-challenge");
+
+        globalThis.window = previousWindow;
+        const clientApp = new StackClientApp({
+          baseUrl: "http://localhost:12345",
+          projectId,
+          publishableClientKey: "stack-pk-test",
+          tokenStore: "memory",
+          redirectMethod: "window",
+          noAutomaticPrefetch: true,
+          devTool: false,
+        });
+        setMockWindow({ location: { href: currentUrl.toString() } });
+        Reflect.set(clientApp, "_fetchCurrentRefreshTokenIdIfSignedIn", async () => "this-apps-refresh-token-id");
+        Reflect.set(clientApp, "_isTrusted", async () => false);
+
+        const nestedAuthPromise = callProtectedMethod(clientApp, "_maybeHandleNestedCrossDomainAuth");
+        await expect(nestedAuthPromise).rejects.toThrowError(/does not match the requested refresh token ID/);
+        await expect(nestedAuthPromise).rejects.toSatisfy(
+          (error: unknown) => !HexclaveSetupError.isSetupError(error),
+        );
       }
     } finally {
       globalThis.window = previousWindow;
@@ -612,6 +674,7 @@ describe("StackClientApp cross-domain auth", () => {
         tokenStore: "memory",
         redirectMethod: "window",
         noAutomaticPrefetch: true,
+        devTool: false,
       });
 
       // Simulate consumeOAuthCallbackQueryParams stripping code+state before microtasks run.
@@ -680,6 +743,7 @@ describe("StackClientApp cross-domain auth", () => {
           default: { type: "hosted" },
         },
         noAutomaticPrefetch: true,
+        devTool: false,
       });
 
       await new Promise((resolve) => setTimeout(resolve, 0));
@@ -712,6 +776,7 @@ describe("StackClientApp cross-domain auth", () => {
         signOut: { type: "hosted" },
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const signOutSpy = vi.spyOn(clientApp, "signOut").mockRejectedValue(new Error("INTENTIONAL_TEST_ABORT"));
 
@@ -734,6 +799,7 @@ describe("StackClientApp cross-domain auth", () => {
         default: { type: "hosted" },
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
 
     expect(() => clientApp.urls.signIn).toThrowError(/app\.urls\.signIn cannot be used when this app is configured to use hosted components.*Use app\.redirectToSignIn\(\) instead/s);
@@ -752,6 +818,7 @@ describe("StackClientApp cross-domain auth", () => {
         handler: "/custom-handler",
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
 
     expect(clientApp.urls.signIn).toBe("/custom-handler/sign-in");
@@ -768,6 +835,7 @@ describe("StackClientApp cross-domain auth", () => {
         default: { type: "hosted" },
       },
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const currentHref = "https://demo.stack-auth.com/settings?tab=profile";
 
@@ -837,6 +905,7 @@ describe("StackClientApp cross-domain auth", () => {
         tokenStore: "memory",
         redirectMethod: "window",
         noAutomaticPrefetch: true,
+        devTool: false,
       });
 
       // Intermediate hops (MFA, magic link, OAuth round-trips, ...) dropped the query params.
@@ -905,6 +974,7 @@ describe("StackClientApp cross-domain auth", () => {
         tokenStore: "memory",
         redirectMethod: "window",
         noAutomaticPrefetch: true,
+        devTool: false,
       });
       const crossDomainAuthorizeRedirect = "https://demo.example.test/handler/oauth-callback?code=minted-code&state=mirror-handoff-state";
       const createCrossDomainAuthRedirectUrlSpy = vi
@@ -941,6 +1011,7 @@ describe("StackClientApp cross-domain auth", () => {
       tokenStore: "memory",
       redirectMethod: "none",
       noAutomaticPrefetch: true,
+      devTool: false,
     });
     const oldAccessToken = createAccessTokenString("old-refresh-token-id");
     const refreshedOldAccessToken = createAccessTokenString("refreshed-old-refresh-token-id");

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.cross-domain.test.ts
@@ -51,6 +51,28 @@ function createMockDocument(): Document {
   } as any;
 }
 
+/**
+ * Installs a stand-in for `window` with only the parts the code under test touches. `globalThis.window` is typed as a
+ * full `Window`, which a hand-written stub can never be, so the assignment goes through `Reflect.set` — the stub's own
+ * shape stays checked, unlike with a cast on the object literal.
+ */
+function setMockWindow(mockWindow: {
+  location: { href: string, replace?: (url: string) => void },
+}): void {
+  Reflect.set(globalThis, "window", mockWindow);
+}
+
+/**
+ * Calls one of the app's `protected` methods, which are part of the flows under test but not of the public SDK surface.
+ */
+function callProtectedMethod(app: StackClientApp<true>, methodName: string, ...args: unknown[]): Promise<unknown> {
+  const method = Reflect.get(app, methodName);
+  if (typeof method !== "function") {
+    throw new Error(`Expected StackClientApp to have a ${methodName} method in tests.`);
+  }
+  return method.apply(app, args);
+}
+
 describe("StackClientApp cross-domain auth", () => {
   it("keeps noRedirectBack same-domain redirects free of redirect-back state", async () => {
     const redirectPlan = await planRedirectToHandler({
@@ -504,10 +526,18 @@ describe("StackClientApp cross-domain auth", () => {
 
     // A URL the flow cannot even parse is as fatal as an untrusted one, so it has to reach the developer the same way
     // instead of escaping as a bare TypeError from `new URL()`, which the overlay only shows during development.
+    // The two branches of the handler want opposite session states: the provider side (a.com) only looks at the OAuth
+    // request params once the handoff belongs to the current session, while the requesting side (b.com) only bounces
+    // when the current session is *not* the one that was asked for.
     const malformedCases = [
-      { description: "redirect URI", params: { redirect_uri: "not-a-url", state: "nested-state", code_challenge: "nested-code-challenge" } },
+      {
+        description: "redirect URI",
+        currentRefreshTokenId: "source-refresh-token-id",
+        params: { redirect_uri: "not-a-url", state: "nested-state", code_challenge: "nested-code-challenge" },
+      },
       {
         description: "after-callback redirect URL",
+        currentRefreshTokenId: "source-refresh-token-id",
         params: {
           redirect_uri: "https://source.example.test/handler/account-settings",
           state: "nested-state",
@@ -515,7 +545,11 @@ describe("StackClientApp cross-domain auth", () => {
           after_callback_redirect_url: "http://[",
         },
       },
-      { description: "callback URL", params: { stack_nested_cross_domain_auth_callback_url: "http://[" } },
+      {
+        description: "callback URL",
+        currentRefreshTokenId: null,
+        params: { stack_nested_cross_domain_auth_callback_url: "http://[" },
+      },
     ];
 
     try {
@@ -525,7 +559,7 @@ describe("StackClientApp cross-domain auth", () => {
         for (const [key, value] of Object.entries(malformedCase.params)) {
           currentUrl.searchParams.set(key, value);
         }
-        globalThis.window = { location: { href: currentUrl.toString() } } as any;
+        setMockWindow({ location: { href: currentUrl.toString() } });
 
         const clientApp = new StackClientApp({
           baseUrl: "http://localhost:12345",
@@ -535,10 +569,10 @@ describe("StackClientApp cross-domain auth", () => {
           redirectMethod: "window",
           noAutomaticPrefetch: true,
         });
-        vi.spyOn(clientApp as any, "_fetchCurrentRefreshTokenIdIfSignedIn").mockResolvedValue(null);
-        vi.spyOn(clientApp as any, "_isTrusted").mockResolvedValue(true);
+        Reflect.set(clientApp, "_fetchCurrentRefreshTokenIdIfSignedIn", async () => malformedCase.currentRefreshTokenId);
+        Reflect.set(clientApp, "_isTrusted", async () => true);
 
-        const nestedAuthPromise = (clientApp as any)._maybeHandleNestedCrossDomainAuth();
+        const nestedAuthPromise = callProtectedMethod(clientApp, "_maybeHandleNestedCrossDomainAuth");
         await expect(nestedAuthPromise).rejects.toThrowError(new RegExp(`${malformedCase.description} .* is not a valid absolute URL`));
         await expect(nestedAuthPromise).rejects.toSatisfy((error: unknown) => HexclaveSetupError.isSetupError(error));
       }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1111,6 +1111,12 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       if ((currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.codeChallengeMethod) ?? "S256") !== "S256") {
         throw new HexclaveAssertionError("Nested cross-domain auth only supports S256 PKCE");
       }
+      // Checked before anything derived from the query params can throw a developer-facing setup error: those errors are
+      // rendered as a card, so only a handoff that actually belongs to this session gets to put one on the page.
+      const currentRefreshTokenId = await this._fetchCurrentRefreshTokenIdIfSignedIn({ awaitPendingAuthResolutions: false });
+      if (currentRefreshTokenId !== refreshTokenId) {
+        throw new Error("Nested cross-domain auth source session does not match the requested refresh token ID.");
+      }
       const redirectUriUrl = isRelative(redirectUri) ? null : createUrlIfValid(redirectUri);
       if (redirectUriUrl == null) {
         throw createMalformedNestedCrossDomainUrlError({
@@ -1141,10 +1147,6 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
           url: afterCallbackRedirectUrlString ?? afterCallbackRedirectUrl.toString(),
           projectId: this.projectId,
         });
-      }
-      const currentRefreshTokenId = await this._fetchCurrentRefreshTokenIdIfSignedIn({ awaitPendingAuthResolutions: false });
-      if (currentRefreshTokenId !== refreshTokenId) {
-        throw new Error("Nested cross-domain auth source session does not match the requested refresh token ID.");
       }
       await this._redirectTo({
         url: await this._createCrossDomainAuthRedirectUrl({

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -1111,43 +1111,52 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       if ((currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.codeChallengeMethod) ?? "S256") !== "S256") {
         throw new HexclaveAssertionError("Nested cross-domain auth only supports S256 PKCE");
       }
-      // Checked before anything derived from the query params can throw a developer-facing setup error: those errors are
-      // rendered as a card, so only a handoff that actually belongs to this session gets to put one on the page.
-      const currentRefreshTokenId = await this._fetchCurrentRefreshTokenIdIfSignedIn({ awaitPendingAuthResolutions: false });
-      if (currentRefreshTokenId !== refreshTokenId) {
-        throw new Error("Nested cross-domain auth source session does not match the requested refresh token ID.");
-      }
+      const validateHandoffOwnership = async (): Promise<void> => {
+        const currentRefreshTokenId = await this._fetchCurrentRefreshTokenIdIfSignedIn({ awaitPendingAuthResolutions: false });
+        if (currentRefreshTokenId !== refreshTokenId) {
+          throw new Error("Nested cross-domain auth source session does not match the requested refresh token ID.");
+        }
+      };
+      // Everything derived from these query params is attacker-controllable, and setup errors are rendered as a card on
+      // the page, so a failure may only become a displayable setup error once the handoff is known to belong to this
+      // session. The check runs on the failure paths rather than up front so the happy path keeps making exactly the
+      // requests it made before, and so an unowned handoff never costs the session lookup twice.
+      const setupErrorIfHandoffIsOwned = async (setupError: HexclaveSetupError): Promise<HexclaveSetupError> => {
+        await validateHandoffOwnership();
+        return setupError;
+      };
       const redirectUriUrl = isRelative(redirectUri) ? null : createUrlIfValid(redirectUri);
       if (redirectUriUrl == null) {
-        throw createMalformedNestedCrossDomainUrlError({
+        throw await setupErrorIfHandoffIsOwned(createMalformedNestedCrossDomainUrlError({
           urlDescription: "redirect URI",
           url: redirectUri,
-        });
+        }));
       }
       if (!await this._isTrusted(redirectUriUrl.toString())) {
-        throw createUntrustedNestedCrossDomainUrlError({
+        throw await setupErrorIfHandoffIsOwned(createUntrustedNestedCrossDomainUrlError({
           urlDescription: "redirect URI",
           url: redirectUri,
           projectId: this.projectId,
-        });
+        }));
       }
       const afterCallbackRedirectUrlString = currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.afterCallbackRedirectUrl);
       const afterCallbackRedirectUrl = afterCallbackRedirectUrlString == null
         ? redirectUriUrl
         : createUrlIfValid(afterCallbackRedirectUrlString, redirectUriUrl);
       if (afterCallbackRedirectUrl == null) {
-        throw createMalformedNestedCrossDomainUrlError({
+        throw await setupErrorIfHandoffIsOwned(createMalformedNestedCrossDomainUrlError({
           urlDescription: "after-callback redirect URL",
           url: afterCallbackRedirectUrlString ?? "",
-        });
+        }));
       }
       if (!await this._isTrusted(afterCallbackRedirectUrl.toString())) {
-        throw createUntrustedNestedCrossDomainUrlError({
+        throw await setupErrorIfHandoffIsOwned(createUntrustedNestedCrossDomainUrlError({
           urlDescription: "after-callback redirect URL",
           url: afterCallbackRedirectUrlString ?? afterCallbackRedirectUrl.toString(),
           projectId: this.projectId,
-        });
+        }));
       }
+      await validateHandoffOwnership();
       await this._redirectTo({
         url: await this._createCrossDomainAuthRedirectUrl({
           redirectUri: redirectUriUrl.toString(),

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -142,6 +142,28 @@ function createUntrustedNestedCrossDomainUrlError(options: {
   });
 }
 
+/**
+ * A URL that the auth flow cannot even parse is just as fatal as an untrusted one, and just as much a configuration
+ * problem: something in the developer's setup put a relative or malformed value where an absolute URL belongs.
+ */
+function createMalformedNestedCrossDomainUrlError(options: {
+  urlDescription: string,
+  url: string,
+}): HexclaveSetupError {
+  return new HexclaveSetupError({
+    title: "A URL in your authentication flow is not a valid absolute URL",
+    message: `Nested cross-domain auth ${options.urlDescription} ${options.url} is not a valid absolute URL.`,
+    howToFix: [
+      "Handler URLs and after-auth redirect URLs must be absolute, including their protocol, like https://example.com/handler/oauth-callback.",
+      "Check the handler URLs configured for your project and the redirect URLs you pass to Hexclave's sign-in and sign-up methods.",
+      "If none of those look wrong, check whether a proxy or rewrite in front of your app is rewriting the authentication flow's query parameters.",
+    ],
+    extraData: {
+      url: options.url,
+    },
+  });
+}
+
 function getRedirectHelperInstruction(handlerName: string): string {
   if (handlerName === "handler") {
     return "Use a page-specific redirect helper such as app.redirectToSignIn() instead.";
@@ -1089,10 +1111,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       if ((currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.codeChallengeMethod) ?? "S256") !== "S256") {
         throw new HexclaveAssertionError("Nested cross-domain auth only supports S256 PKCE");
       }
-      if (isRelative(redirectUri)) {
-        throw new Error("Nested cross-domain auth redirect URI must be absolute.");
+      const redirectUriUrl = isRelative(redirectUri) ? null : createUrlIfValid(redirectUri);
+      if (redirectUriUrl == null) {
+        throw createMalformedNestedCrossDomainUrlError({
+          urlDescription: "redirect URI",
+          url: redirectUri,
+        });
       }
-      const redirectUriUrl = new URL(redirectUri);
       if (!await this._isTrusted(redirectUriUrl.toString())) {
         throw createUntrustedNestedCrossDomainUrlError({
           urlDescription: "redirect URI",
@@ -1103,7 +1128,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       const afterCallbackRedirectUrlString = currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.afterCallbackRedirectUrl);
       const afterCallbackRedirectUrl = afterCallbackRedirectUrlString == null
         ? redirectUriUrl
-        : new URL(afterCallbackRedirectUrlString, redirectUriUrl);
+        : createUrlIfValid(afterCallbackRedirectUrlString, redirectUriUrl);
+      if (afterCallbackRedirectUrl == null) {
+        throw createMalformedNestedCrossDomainUrlError({
+          urlDescription: "after-callback redirect URL",
+          url: afterCallbackRedirectUrlString ?? "",
+        });
+      }
       if (!await this._isTrusted(afterCallbackRedirectUrl.toString())) {
         throw createUntrustedNestedCrossDomainUrlError({
           urlDescription: "after-callback redirect URL",
@@ -1140,10 +1171,13 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     if (callbackUrlString == null) {
       throw new HexclaveAssertionError("Nested cross-domain auth URL is missing callback URL");
     }
-    if (isRelative(callbackUrlString)) {
-      throw new Error("Nested cross-domain auth callback URL must be absolute.");
+    const callbackUrl = isRelative(callbackUrlString) ? null : createUrlIfValid(callbackUrlString);
+    if (callbackUrl == null) {
+      throw createMalformedNestedCrossDomainUrlError({
+        urlDescription: "callback URL",
+        url: callbackUrlString,
+      });
     }
-    const callbackUrl = new URL(callbackUrlString);
     const isTrusted = await this._isTrusted(callbackUrl.toString());
     if (!isTrusted) {
       throw createUntrustedNestedCrossDomainUrlError({

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -21,7 +21,7 @@ import { InternalSession } from "@hexclave/shared/dist/sessions";
 import { decodeBase32, decodeBase64, encodeBase32, encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
 import { scrambleDuringCompileTime } from "@hexclave/shared/dist/utils/compile-time";
 import { isBrowserLike } from "@hexclave/shared/dist/utils/env";
-import { HexclaveAssertionError, captureError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { HexclaveAssertionError, HexclaveSetupError, captureError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { parseJson } from "@hexclave/shared/dist/utils/json";
 import { DependenciesMap } from "@hexclave/shared/dist/utils/maps";
 import { ProviderType } from "@hexclave/shared/dist/utils/oauth";
@@ -77,6 +77,7 @@ import { useAsyncCache } from "./common";
 import { mountClickmapOverlay } from "../../../../clickmap";
 import { mountDevTool } from "../../../../dev-tool";
 import { mountPushedConfigErrorOverlay } from "../../../../pushed-config-error-overlay";
+import { showSetupErrorOverlay } from "../../../../setup-error-overlay";
 // END_PLATFORM
 
 let isReactServer = false;
@@ -101,6 +102,45 @@ const nestedCrossDomainAuthQueryParams = {
   codeChallengeMethod: "code_challenge_method",
   afterCallbackRedirectUrl: oauthAfterCallbackRedirectUrlQueryParam,
 } as const;
+
+/**
+ * An auth flow can only ever send the user to a URL that the project trusts, so an untrusted one means the flow is dead
+ * until someone changes the project's configuration. Describe the problem in terms of that configuration rather than in
+ * terms of the flow's internals, which nobody outside this file knows about.
+ */
+function createUntrustedUrlError(options: {
+  /** Kept verbatim from the throw site, so the message stays greppable for whoever already has it in their logs. */
+  message: string,
+  url: string,
+  projectId: string,
+}): HexclaveSetupError {
+  const origin = createUrlIfValid(options.url)?.origin ?? options.url;
+  return new HexclaveSetupError({
+    title: "A domain in your authentication flow is not one of your project's trusted domains",
+    message: options.message,
+    howToFix: [
+      `If ${origin} is yours, add it to your project's trusted domains in the Hexclave dashboard, under Domains.`,
+      "Protocol, domain and port must all match a trusted domain exactly; a wildcard like https://*.example.com matches only one subdomain level.",
+      `If ${origin} is not yours, do not add it \u2014 somebody may be trying to redirect your users' credentials to it.`,
+    ],
+    extraData: {
+      url: options.url,
+      projectId: options.projectId,
+    },
+  });
+}
+
+function createUntrustedNestedCrossDomainUrlError(options: {
+  urlDescription: string,
+  url: string,
+  projectId: string,
+}): HexclaveSetupError {
+  return createUntrustedUrlError({
+    message: `Nested cross-domain auth ${options.urlDescription} ${options.url} is not trusted.`,
+    url: options.url,
+    projectId: options.projectId,
+  });
+}
 
 function getRedirectHelperInstruction(handlerName: string): string {
   if (handlerName === "handler") {
@@ -818,6 +858,9 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
         // Startup auth transitions gate session finality, but malformed nested-auth URLs should
         // not make every app-level session consumer fail while the tracker is cleaning up.
         captureError("pending-auth-resolution-failed", error);
+        // Swallowing the error here means the flow just stops, with no sign of it on the page; setup errors
+        // (untrusted domains, most commonly) would otherwise be invisible to whoever has to fix them.
+        showSetupErrorOverlay(error); // THIS_LINE_PLATFORM js-like
       }
     })();
     this._pendingAuthResolutionPromises.push(promise);
@@ -1051,14 +1094,22 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       }
       const redirectUriUrl = new URL(redirectUri);
       if (!await this._isTrusted(redirectUriUrl.toString())) {
-        throw new Error(`Nested cross-domain auth redirect URI ${redirectUri} is not trusted.`);
+        throw createUntrustedNestedCrossDomainUrlError({
+          urlDescription: "redirect URI",
+          url: redirectUri,
+          projectId: this.projectId,
+        });
       }
       const afterCallbackRedirectUrlString = currentUrl.searchParams.get(nestedCrossDomainAuthQueryParams.afterCallbackRedirectUrl);
       const afterCallbackRedirectUrl = afterCallbackRedirectUrlString == null
         ? redirectUriUrl
         : new URL(afterCallbackRedirectUrlString, redirectUriUrl);
       if (!await this._isTrusted(afterCallbackRedirectUrl.toString())) {
-        throw new Error(`Nested cross-domain auth after-callback redirect URL ${afterCallbackRedirectUrlString} is not trusted.`);
+        throw createUntrustedNestedCrossDomainUrlError({
+          urlDescription: "after-callback redirect URL",
+          url: afterCallbackRedirectUrlString ?? afterCallbackRedirectUrl.toString(),
+          projectId: this.projectId,
+        });
       }
       const currentRefreshTokenId = await this._fetchCurrentRefreshTokenIdIfSignedIn({ awaitPendingAuthResolutions: false });
       if (currentRefreshTokenId !== refreshTokenId) {
@@ -1095,7 +1146,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     const callbackUrl = new URL(callbackUrlString);
     const isTrusted = await this._isTrusted(callbackUrl.toString());
     if (!isTrusted) {
-      throw new Error(`Nested cross-domain auth callback URL ${callbackUrlString} is not trusted.`);
+      throw createUntrustedNestedCrossDomainUrlError({
+        urlDescription: "callback URL",
+        url: callbackUrlString,
+        projectId: this.projectId,
+      });
     }
 
     const afterCallbackRedirectUrl = new URL(currentUrl);
@@ -3138,7 +3193,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   // END_PLATFORM
   protected async _redirectIfTrusted(url: string, options?: RedirectToOptions) {
     if (!await this._isTrusted(url)) {
-      throw new Error(`Redirect URL ${url} is not trusted; should be relative.`);
+      throw createUntrustedUrlError({
+        message: `Redirect URL ${url} is not trusted; should be relative.`,
+        url,
+        projectId: this.projectId,
+      });
     }
     return await this._redirectTo({ url, ...options });
   }
@@ -3219,7 +3278,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       })
       : plan.url;
     if (!await this._isTrusted(redirectUrl)) {
-      throw new Error(`Redirect URL ${redirectUrl} is not trusted; should be relative.`);
+      throw createUntrustedUrlError({
+        message: `Redirect URL ${redirectUrl} is not trusted; should be relative.`,
+        url: redirectUrl,
+        projectId: this.projectId,
+      });
     }
     return redirectUrl;
   }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/redirect-page-urls.test.ts
@@ -13,6 +13,7 @@ async function plan(options: {
     ...options,
     noRedirectBack: options.noRedirectBack === true,
     localOAuthCallbackUrl,
+    rawHomeUrl: "/",
     getCrossDomainHandoffParams: async () => {
       throw new Error("Continuation-only redirects must not mint a new cross-domain handoff");
     },

--- a/packages/template/src/pushed-config-error-overlay/index.ts
+++ b/packages/template/src/pushed-config-error-overlay/index.ts
@@ -2,258 +2,21 @@
 
 import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
-import { isLocalhost } from "@hexclave/shared/dist/utils/urls";
-import { envVars } from "../generated/env";
-import { getInPageUiBaseCSS } from "../in-page-ui/base-styles";
-import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance, setHtml } from "../in-page-ui/dom";
+import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
+import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill } from "../in-page-ui/issue-card";
 import type { StackClientApp } from "../lib/hexclave-app";
 
 const GLOBAL_INSTANCE_KEY = "__hexclave-pushed-config-error-overlay";
 const MINIMIZED_STORAGE_KEY = "hexclave-pushed-config-error-minimized-key";
 const REFRESH_INTERVAL_MS = 5_000;
-const HEXCLAVE_LOGO_SVG = '<svg width="16" height="16" viewBox="0 0 48 48" fill="none" stroke="currentColor" stroke-width="3" stroke-linejoin="miter"><path d="M 24 4 L 41.32 14 L 41.32 34 L 24 44 L 6.68 34 L 6.68 14 Z"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(120 24 24)"/><path d="M 11 16.87 L 14 15.13 L 14 32.87 L 11 31.13 Z" fill="currentColor" stroke="none" transform="rotate(240 24 24)"/></svg>';
-const COPY_ICON_SVG = '<svg width="12" height="12" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.25" stroke-linecap="round" stroke-linejoin="round"><rect x="9" y="9" width="13" height="13" rx="2"/><path d="M5 15H4a2 2 0 0 1-2-2V4a2 2 0 0 1 2-2h9a2 2 0 0 1 2 2v1"/></svg>';
 
 type ConfigIssue = {
   kind: "error" | "warning",
   messages: string[],
 };
 
-const css = getInPageUiBaseCSS(".hexclave-config-error-overlay") + `
-  .hexclave-config-error-overlay .hce-backdrop {
-    position: fixed;
-    inset: 0;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    padding: 24px;
-    background: rgba(0, 0, 0, 0.46);
-    backdrop-filter: blur(6px);
-    overflow: auto;
-  }
-
-  .hexclave-config-error-overlay .hce-card {
-    --hce-status: var(--sdt-error);
-    width: min(720px, calc(100vw - 32px));
-    max-height: min(640px, calc(100dvh - 48px));
-    border: 1px solid color-mix(in srgb, var(--hce-status) 35%, var(--sdt-border));
-    border-radius: 18px;
-    background: var(--sdt-overlay-bg);
-    box-shadow: var(--sdt-shadow);
-    backdrop-filter: blur(18px);
-    display: flex;
-    overflow: hidden;
-  }
-
-  .hexclave-config-error-overlay .hce-card-warning {
-    --hce-status: var(--sdt-warning);
-  }
-
-  .hexclave-config-error-overlay .hce-card-inner {
-    padding: 18px;
-    width: 100%;
-    overflow: auto;
-  }
-
-  .hexclave-config-error-overlay .hce-header {
-    display: flex;
-    align-items: flex-start;
-    justify-content: space-between;
-    gap: 12px;
-    margin-bottom: 12px;
-  }
-
-  .hexclave-config-error-overlay .hce-title-row {
-    display: flex;
-    align-items: flex-start;
-    gap: 10px;
-    min-width: 0;
-  }
-
-  .hexclave-config-error-overlay .hce-logo {
-    flex-shrink: 0;
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 34px;
-    height: 34px;
-    border-radius: 10px;
-    background: var(--hce-status);
-    color: white;
-    box-shadow: 0 10px 30px color-mix(in srgb, var(--hce-status) 32%, transparent);
-  }
-
-  .hexclave-config-error-overlay .hce-badge {
-    display: inline-flex;
-    flex-shrink: 0;
-    padding: 2px 6px;
-    border-radius: 999px;
-    background: var(--hce-status);
-    color: white;
-    font-size: 10px;
-    font-weight: 700;
-    letter-spacing: 0.06em;
-    text-transform: uppercase;
-  }
-
-  .hexclave-config-error-overlay .hce-title {
-    color: var(--sdt-text);
-    margin-top: 4px;
-    font-size: 18px;
-    font-weight: 700;
-    line-height: 1.25;
-  }
-
-  .hexclave-config-error-overlay .hce-actions {
-    display: flex;
-    gap: 4px;
-  }
-
-  .hexclave-config-error-overlay .hce-icon-btn {
-    display: inline-flex;
-    align-items: center;
-    justify-content: center;
-    width: 28px;
-    height: 28px;
-    border: 1px solid var(--sdt-border);
-    border-radius: 8px;
-    background: var(--sdt-bg-elevated);
-    color: var(--sdt-text-secondary);
-    cursor: pointer;
-    font: inherit;
-    line-height: 1;
-    vertical-align: top;
-  }
-
-  .hexclave-config-error-overlay .hce-icon-btn svg {
-    display: block;
-    flex-shrink: 0;
-  }
-
-  .hexclave-config-error-overlay .hce-text-btn {
-    align-items: center;
-    gap: 6px;
-    min-height: 28px;
-    padding: 0 10px;
-    width: auto;
-    font-size: 12px;
-    line-height: 1;
-  }
-
-  .hexclave-config-error-overlay .hce-icon-btn:hover {
-    background: var(--sdt-bg-hover);
-    color: var(--sdt-text);
-  }
-
-  .hexclave-config-error-overlay .hce-body {
-    color: var(--sdt-text-secondary);
-    font-size: 14px;
-    line-height: 1.5;
-  }
-
-  .hexclave-config-error-overlay .hce-message-header {
-    display: flex;
-    align-items: center;
-    justify-content: space-between;
-    gap: 10px;
-    margin-top: 14px;
-    margin-bottom: 8px;
-  }
-
-  .hexclave-config-error-overlay .hce-message-label {
-    color: var(--sdt-text);
-    font-size: 12px;
-    font-weight: 650;
-  }
-
-  .hexclave-config-error-overlay .hce-message {
-    padding: 12px;
-    max-height: min(260px, max(96px, 30dvh));
-    overflow: auto;
-    border: 1px solid var(--sdt-border-subtle);
-    border-radius: 10px;
-    background: var(--sdt-bg-subtle);
-    color: var(--sdt-text);
-    font-family: var(--sdt-font-mono);
-    font-size: 12px;
-    white-space: pre-wrap;
-    overflow-wrap: anywhere;
-  }
-
-  .hexclave-config-error-overlay .hce-footer {
-    margin-top: 10px;
-    color: var(--sdt-text-tertiary);
-    font-size: 12px;
-  }
-
-  .hexclave-config-error-overlay .hce-pill {
-    position: fixed;
-    right: 18px;
-    bottom: 18px;
-    z-index: 2147483647;
-    display: flex;
-    align-items: center;
-    gap: 8px;
-    padding: 8px 12px 8px 8px;
-    --hce-status: var(--sdt-error);
-    border: 1px solid color-mix(in srgb, var(--hce-status) 35%, var(--sdt-border));
-    border-radius: 999px;
-    background: var(--sdt-overlay-bg);
-    box-shadow: var(--sdt-trigger-shadow);
-    color: var(--sdt-text);
-    cursor: pointer;
-    font: inherit;
-    backdrop-filter: blur(18px);
-  }
-
-  .hexclave-config-error-overlay .hce-pill-warning {
-    --hce-status: var(--sdt-warning);
-  }
-
-  .hexclave-config-error-overlay .hce-pill-logo {
-    display: flex;
-    align-items: center;
-    justify-content: center;
-    width: 26px;
-    height: 26px;
-    border-radius: 999px;
-    background: var(--hce-status);
-    color: white;
-  }
-
-  @media (max-height: 520px) {
-    .hexclave-config-error-overlay .hce-backdrop {
-      align-items: flex-start;
-      padding: 12px;
-    }
-
-    .hexclave-config-error-overlay .hce-card {
-      width: min(720px, calc(100vw - 24px));
-      max-height: calc(100dvh - 24px);
-    }
-
-    .hexclave-config-error-overlay .hce-card-inner {
-      padding: 12px;
-    }
-
-    .hexclave-config-error-overlay .hce-header {
-      margin-bottom: 8px;
-    }
-
-    .hexclave-config-error-overlay .hce-title {
-      font-size: 16px;
-    }
-
-    .hexclave-config-error-overlay .hce-body {
-      font-size: 13px;
-    }
-
-    .hexclave-config-error-overlay .hce-message {
-      max-height: max(80px, 24dvh);
-    }
-  }
-`;
+const css = getIssueCardCSS(".hexclave-config-error-overlay");
 
 function storageGet(key: string): string | null {
   try {
@@ -280,53 +43,7 @@ function storageRemove(key: string): void {
 }
 
 function shouldMount(): boolean {
-  if (!canMountIntoDom()) {
-    return false;
-  }
-
-  const nodeEnv = envVars.NODE_ENV;
-  if (nodeEnv !== undefined) {
-    return nodeEnv === "development";
-  }
-
-  try {
-    const url = new URL(window.location.href);
-    if (url.protocol === "file:") {
-      return true;
-    }
-  } catch {
-    return false;
-  }
-  return isLocalhost(window.location.href);
-}
-
-async function copyTextToClipboard(text: string): Promise<void> {
-  const clipboard: unknown = Reflect.get(navigator, "clipboard");
-  const writeText = clipboard != null && typeof clipboard === "object"
-    ? Reflect.get(clipboard, "writeText")
-    : null;
-  if (typeof writeText === "function") {
-    await writeText.call(clipboard, text);
-    return;
-  }
-
-  const textarea = h("textarea", {
-    style: {
-      position: "fixed",
-      left: "-9999px",
-      top: "0",
-      opacity: "0",
-    },
-    readonly: "true",
-  }) as HTMLTextAreaElement;
-  textarea.value = text;
-  document.body.appendChild(textarea);
-  textarea.select();
-  const copied = document.execCommand("copy");
-  textarea.remove();
-  if (!copied) {
-    throw new Error("Browser refused to copy the config error message.");
-  }
+  return canMountIntoDom() && isLikelyDevelopmentEnvironment();
 }
 
 function buildConfigIssueAiPrompt(issue: ConfigIssue): string {
@@ -397,113 +114,37 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
     }
 
     if (minimized) {
-      const logoSpan = h("span", { className: "hce-pill-logo" });
-      setHtml(logoSpan, HEXCLAVE_LOGO_SVG);
-      root.appendChild(h("button", {
-        className: issue.kind === "error" ? "hce-pill" : "hce-pill hce-pill-warning",
-        type: "button",
+      root.appendChild(renderIssuePill({
+        kind: issue.kind,
+        label: issue.kind === "error" ? "Config error" : "Config warning",
+        ariaLabel: `Show Hexclave config ${issueLabel}`,
         onClick: () => {
           minimized = false;
           storageRemove(MINIMIZED_STORAGE_KEY);
           render(issue);
         },
-      },
-      logoSpan,
-      h("span", null, issue.kind === "error" ? "Config error" : "Config warning")));
+      }));
       return;
     }
 
-    const logoSpan = h("span", { className: "hce-logo" });
-    setHtml(logoSpan, HEXCLAVE_LOGO_SVG);
-    const copyButton = h("button", {
-      className: "hce-icon-btn hce-text-btn",
-      type: "button",
-      title: issue.kind === "error" ? "Copy error message" : "Copy warning message",
-      "aria-label": issue.kind === "error" ? "Copy config error message" : "Copy config warning message",
-      onClick: () => {
-        runAsynchronously(async () => {
-          await copyTextToClipboard(issueMessage);
-          copyButton.textContent = "Copied";
-          setTimeout(() => {
-            setHtml(copyButton, `${COPY_ICON_SVG}Copy`);
-          }, 1500);
-        }, {
-          noErrorLogging: true,
-          onError: (copyError) => {
-            captureError("pushed-config-error-overlay-copy", copyError);
-            copyButton.textContent = "Copy failed";
-            setTimeout(() => {
-              setHtml(copyButton, `${COPY_ICON_SVG}Copy`);
-            }, 1500);
-          },
-        });
+    root.appendChild(renderIssueCard({
+      kind: issue.kind,
+      badge: `Config ${issueLabel}`,
+      title: issueTitle,
+      bodyText,
+      messageLabel: issue.kind === "error" ? "Error message" : "Warning message",
+      message: issueMessage,
+      footerText,
+      ariaLabel: `Hexclave config ${issueLabel}`,
+      aiPrompt: buildConfigIssueAiPrompt(issue),
+      onCopyError: (copyError) => captureError("pushed-config-error-overlay-copy", copyError),
+      onCopyAiPromptError: (copyError) => captureError("pushed-config-error-overlay-copy-ai-prompt", copyError),
+      onMinimize: () => {
+        minimized = true;
+        storageSet(MINIMIZED_STORAGE_KEY, issueKey);
+        render(issue);
       },
-    });
-    setHtml(copyButton, `${COPY_ICON_SVG}Copy`);
-
-    const aiPromptCopyButton = h("button", {
-      className: "hce-icon-btn",
-      type: "button",
-      title: "Copy AI prompt",
-      "aria-label": issue.kind === "error" ? "Copy AI prompt for config error" : "Copy AI prompt for config warning",
-      onClick: () => {
-        runAsynchronously(async () => {
-          await copyTextToClipboard(buildConfigIssueAiPrompt(issue));
-          aiPromptCopyButton.textContent = "✓";
-          setTimeout(() => {
-            setHtml(aiPromptCopyButton, COPY_ICON_SVG);
-          }, 1500);
-        }, {
-          noErrorLogging: true,
-          onError: (copyError) => {
-            captureError("pushed-config-error-overlay-copy-ai-prompt", copyError);
-            aiPromptCopyButton.textContent = "!";
-            setTimeout(() => {
-              setHtml(aiPromptCopyButton, COPY_ICON_SVG);
-            }, 1500);
-          },
-        });
-      },
-    });
-    setHtml(aiPromptCopyButton, COPY_ICON_SVG);
-
-    root.appendChild(h("div", { className: "hce-backdrop" },
-      h("div", { className: issue.kind === "error" ? "hce-card" : "hce-card hce-card-warning", role: "alertdialog", "aria-modal": "true", "aria-label": `Hexclave config ${issueLabel}` },
-      h("div", { className: "hce-card-inner" },
-        h("div", { className: "hce-header" },
-          h("div", { className: "hce-title-row" },
-            logoSpan,
-            h("div", null,
-              h("span", { className: "hce-badge" }, `Config ${issueLabel}`),
-              h("div", { className: "hce-title" }, issueTitle),
-            ),
-          ),
-          h("div", { className: "hce-actions" },
-            aiPromptCopyButton,
-            h("button", {
-              className: "hce-icon-btn",
-              type: "button",
-              title: "Minimize",
-              "aria-label": issue.kind === "error" ? "Minimize config error" : "Minimize config warning",
-              onClick: () => {
-                minimized = true;
-                storageSet(MINIMIZED_STORAGE_KEY, issueKey);
-                render(issue);
-              },
-            }, "–"),
-          ),
-        ),
-        h("div", { className: "hce-body" },
-          bodyText,
-          h("div", { className: "hce-message-header" },
-            h("div", { className: "hce-message-label" }, issue.kind === "error" ? "Error message" : "Warning message"),
-            copyButton,
-          ),
-          h("div", { className: "hce-message" }, issueMessage),
-          h("div", { className: "hce-footer" }, footerText),
-        ),
-      ),
-    )));
+    }));
   };
 
   const refresh = () => {

--- a/packages/template/src/pushed-config-error-overlay/index.ts
+++ b/packages/template/src/pushed-config-error-overlay/index.ts
@@ -4,7 +4,7 @@ import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
 import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
-import { getIssueCardCSS, renderIssueCard, renderIssuePill } from "../in-page-ui/issue-card";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard } from "../in-page-ui/issue-card";
 import type { StackClientApp } from "../lib/hexclave-app";
 
 const GLOBAL_INSTANCE_KEY = "__hexclave-pushed-config-error-overlay";
@@ -77,12 +77,22 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
   let lastErrorKey: string | null = null;
   let lastConsoleErrorKey: string | null = null;
   let minimized = false;
+  // The card is re-rendered on every poll, so focus is only claimed when a card first appears for an issue; doing it on
+  // every render would yank focus out of whatever the developer is doing every few seconds.
+  let focusedIssueKey: string | null = null;
+  let releaseFocus: (() => void) | null = null;
+  const releaseFocusIfHeld = () => {
+    releaseFocus?.();
+    releaseFocus = null;
+    focusedIssueKey = null;
+  };
 
   const render = (issue: ConfigIssue | null) => {
     root.replaceChildren(style);
     if (issue == null) {
       lastErrorKey = null;
       minimized = false;
+      releaseFocusIfHeld();
       return;
     }
 
@@ -114,6 +124,7 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
     }
 
     if (minimized) {
+      releaseFocusIfHeld();
       root.appendChild(renderIssuePill({
         kind: issue.kind,
         label: issue.kind === "error" ? "Config error" : "Config warning",
@@ -145,6 +156,11 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
         render(issue);
       },
     }));
+    if (focusedIssueKey !== issueKey) {
+      releaseFocusIfHeld();
+      focusedIssueKey = issueKey;
+      releaseFocus = trapFocusInIssueCard(root);
+    }
   };
 
   const refresh = () => {
@@ -178,6 +194,7 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
   const cleanup = () => {
     disposed = true;
     clearInterval(interval);
+    releaseFocusIfHeld();
     root.remove();
     if (getGlobalUiInstance(GLOBAL_INSTANCE_KEY)?.cleanup === cleanup) {
       setGlobalUiInstance(GLOBAL_INSTANCE_KEY, null);

--- a/packages/template/src/pushed-config-error-overlay/index.ts
+++ b/packages/template/src/pushed-config-error-overlay/index.ts
@@ -4,7 +4,7 @@ import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
 import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
-import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard } from "../in-page-ui/issue-card";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard, type IssueCardFocusTrap } from "../in-page-ui/issue-card";
 import type { StackClientApp } from "../lib/hexclave-app";
 
 const GLOBAL_INSTANCE_KEY = "__hexclave-pushed-config-error-overlay";
@@ -77,13 +77,14 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
   let lastErrorKey: string | null = null;
   let lastConsoleErrorKey: string | null = null;
   let minimized = false;
-  // The card is re-rendered on every poll, so focus is only claimed when a card first appears for an issue; doing it on
-  // every render would yank focus out of whatever the developer is doing every few seconds.
+  // The card element is replaced on every poll, so the trap has to be rebound to the new one each time or it would keep
+  // trapping Tab inside the detached card. Focus is only *moved* into the card when a card first appears for an issue;
+  // doing it on every render would yank focus out of whatever the developer is doing every few seconds.
   let focusedIssueKey: string | null = null;
-  let releaseFocus: (() => void) | null = null;
+  let focusTrap: IssueCardFocusTrap | null = null;
   const releaseFocusIfHeld = () => {
-    releaseFocus?.();
-    releaseFocus = null;
+    focusTrap?.release();
+    focusTrap = null;
     focusedIssueKey = null;
   };
 
@@ -156,11 +157,11 @@ export function mountPushedConfigErrorOverlay(app: StackClientApp<true>): () => 
         render(issue);
       },
     }));
-    if (focusedIssueKey !== issueKey) {
-      releaseFocusIfHeld();
-      focusedIssueKey = issueKey;
-      releaseFocus = trapFocusInIssueCard(root);
-    }
+    const isNewIssue = focusedIssueKey !== issueKey;
+    const previouslyFocused = isNewIssue ? undefined : focusTrap?.previouslyFocused ?? null;
+    focusTrap?.release({ restoreFocus: isNewIssue });
+    focusedIssueKey = issueKey;
+    focusTrap = trapFocusInIssueCard(root, { moveFocusIntoCard: isNewIssue, previouslyFocused });
   };
 
   const refresh = () => {

--- a/packages/template/src/setup-error-overlay/index.test.ts
+++ b/packages/template/src/setup-error-overlay/index.test.ts
@@ -2,7 +2,7 @@
 
 import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
 import { afterEach, describe, expect, it, vi } from "vitest";
-import { showSetupErrorOverlay } from ".";
+import { SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY, showSetupErrorOverlay } from ".";
 
 function createSetupError() {
   return new HexclaveSetupError({
@@ -22,7 +22,7 @@ describe("setup error overlay", () => {
     for (const root of overlayRoots()) {
       root.remove();
     }
-    Reflect.deleteProperty(window, "__hexclave-setup-error-overlay");
+    Reflect.deleteProperty(window, SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY);
   });
 
   it("renders setup errors with their fix instructions, even outside development", () => {
@@ -60,6 +60,36 @@ describe("setup error overlay", () => {
     } finally {
       cleanup();
     }
+  });
+
+  it("keeps keyboard focus inside the card and gives it back afterwards", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const pageButton = document.body.appendChild(document.createElement("button"));
+    pageButton.focus();
+
+    const cleanup = showSetupErrorOverlay(createSetupError());
+    try {
+      const card = document.querySelector<HTMLElement>("[role='alertdialog']");
+      expect(document.activeElement).toBe(card);
+
+      const cardButtons = [...(card?.querySelectorAll("button") ?? [])];
+      expect(cardButtons.length).toBeGreaterThan(1);
+      cardButtons[cardButtons.length - 1].focus();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+      expect(document.activeElement).toBe(cardButtons[0]);
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true, shiftKey: true }));
+      expect(document.activeElement).toBe(cardButtons[cardButtons.length - 1]);
+
+      // Tabbing away from the card is what the trap exists to prevent, even when the page itself moves focus.
+      pageButton.focus();
+      document.dispatchEvent(new KeyboardEvent("keydown", { key: "Tab", bubbles: true, cancelable: true }));
+      expect(document.activeElement).toBe(cardButtons[0]);
+    } finally {
+      cleanup();
+    }
+
+    expect(document.activeElement).toBe(pageButton);
+    pageButton.remove();
   });
 
   it("keeps the first card instead of stacking later errors on top of it", () => {

--- a/packages/template/src/setup-error-overlay/index.test.ts
+++ b/packages/template/src/setup-error-overlay/index.test.ts
@@ -1,0 +1,99 @@
+// @vitest-environment jsdom
+
+import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
+import { afterEach, describe, expect, it, vi } from "vitest";
+import { showSetupErrorOverlay } from ".";
+
+function createSetupError() {
+  return new HexclaveSetupError({
+    title: "A domain in your authentication flow is not one of your project's trusted domains",
+    message: "Nested cross-domain auth callback URL https://demo.example.test/ is not trusted.",
+    howToFix: ["Add https://demo.example.test to your project's trusted domains."],
+  });
+}
+
+function overlayRoots() {
+  return document.querySelectorAll(".hexclave-setup-error-overlay");
+}
+
+describe("setup error overlay", () => {
+  afterEach(() => {
+    vi.unstubAllEnvs();
+    for (const root of overlayRoots()) {
+      root.remove();
+    }
+    Reflect.deleteProperty(window, "__hexclave-setup-error-overlay");
+  });
+
+  it("renders setup errors with their fix instructions, even outside development", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const error = createSetupError();
+
+    const cleanup = showSetupErrorOverlay(error);
+    try {
+      expect(overlayRoots()).toHaveLength(1);
+      const text = document.body.textContent;
+      expect(text).toContain(error.title);
+      expect(text).toContain(error.message);
+      expect(text).toContain(error.howToFix[0]);
+      expect(document.querySelector("[role='alertdialog']")).not.toBeNull();
+    } finally {
+      cleanup();
+    }
+
+    expect(overlayRoots()).toHaveLength(0);
+  });
+
+  it("minimizes into a pill and back", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const cleanup = showSetupErrorOverlay(createSetupError());
+    try {
+      const minimizeButton = document.querySelector<HTMLButtonElement>("[aria-label='Minimize Hexclave setup error']");
+      expect(minimizeButton).not.toBeNull();
+      minimizeButton?.click();
+      expect(document.querySelector("[role='alertdialog']")).toBeNull();
+
+      const pill = document.querySelector<HTMLButtonElement>("[aria-label='Show Hexclave setup error']");
+      expect(pill).not.toBeNull();
+      pill?.click();
+      expect(document.querySelector("[role='alertdialog']")).not.toBeNull();
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("keeps the first card instead of stacking later errors on top of it", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    const firstError = createSetupError();
+    const cleanup = showSetupErrorOverlay(firstError);
+    try {
+      const secondCleanup = showSetupErrorOverlay(new HexclaveSetupError({
+        title: "Another setup error",
+        message: "Another setup error happened.",
+        howToFix: ["Fix the other thing."],
+      }));
+      secondCleanup();
+
+      expect(overlayRoots()).toHaveLength(1);
+      expect(document.body.textContent).toContain(firstError.message);
+      expect(document.body.textContent).not.toContain("Another setup error happened.");
+    } finally {
+      cleanup();
+    }
+  });
+
+  it("only shows errors that are not setup errors while developing", () => {
+    vi.stubEnv("NODE_ENV", "production");
+    showSetupErrorOverlay(new Error("Some internal failure."))();
+    expect(overlayRoots()).toHaveLength(0);
+
+    vi.stubEnv("NODE_ENV", "development");
+    const cleanup = showSetupErrorOverlay(new Error("Some internal failure."));
+    try {
+      expect(overlayRoots()).toHaveLength(1);
+      expect(document.body.textContent).toContain("Some internal failure.");
+    } finally {
+      cleanup();
+    }
+  });
+});

--- a/packages/template/src/setup-error-overlay/index.ts
+++ b/packages/template/src/setup-error-overlay/index.ts
@@ -9,7 +9,7 @@
 import { HexclaveSetupError, captureError, errorToNiceString } from "@hexclave/shared/dist/utils/errors";
 import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
 import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
-import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard } from "../in-page-ui/issue-card";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard, type IssueCardFocusTrap } from "../in-page-ui/issue-card";
 
 /** Exported so tests can drop the singleton; every other consumer should go through `showSetupErrorOverlay`. */
 export const SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY = "__hexclave-setup-error-overlay";
@@ -26,6 +26,9 @@ type SetupIssue = {
   title: string,
   message: string,
   howToFix: readonly string[],
+  // Setup errors are known to be fatal for their flow, so the card says so. Anything else may well be transient (a
+  // network blip while resolving a session, say), and claiming that nobody can sign in anymore would be misleading.
+  isFatal: boolean,
 };
 
 function toSetupIssue(error: unknown): SetupIssue {
@@ -34,12 +37,14 @@ function toSetupIssue(error: unknown): SetupIssue {
       title: error.title,
       message: error.message,
       howToFix: error.howToFix,
+      isFatal: true,
     };
   }
   return {
     title: "Hexclave could not finish an authentication flow",
     message: errorToNiceString(error),
     howToFix: unexpectedErrorHowToFix,
+    isFatal: false,
   };
 }
 
@@ -91,10 +96,10 @@ export function showSetupErrorOverlay(error: unknown): () => void {
   root.appendChild(style);
   document.body.appendChild(root);
 
-  let releaseFocus: (() => void) | null = null;
+  let focusTrap: IssueCardFocusTrap | null = null;
   const render = (minimized: boolean) => {
-    releaseFocus?.();
-    releaseFocus = null;
+    focusTrap?.release();
+    focusTrap = null;
     root.replaceChildren(style);
     if (minimized) {
       root.appendChild(renderIssuePill({
@@ -109,24 +114,28 @@ export function showSetupErrorOverlay(error: unknown): () => void {
       kind: "error",
       badge: "Setup error",
       title: issue.title,
-      bodyText: "Hexclave stopped the authentication flow that ran into this error, so nobody can sign in through it until it is fixed.",
+      bodyText: issue.isFatal
+        ? "Hexclave stopped the authentication flow that ran into this error, so nobody can sign in through it until it is fixed."
+        : "Hexclave aborted the authentication flow that ran into this error. Errors like this one may also be transient, in which case retrying the flow works.",
       messageLabel: "Error message",
       message: issue.message,
       howToFix: issue.howToFix,
-      footerText: "This card is shown by the Hexclave SDK. Fix the problem above and reload the page to try the flow again.",
+      footerText: issue.isFatal
+        ? "This card is shown by the Hexclave SDK. Fix the problem above and reload the page to try the flow again."
+        : "This card is shown by the Hexclave SDK while developing, and never in production.",
       ariaLabel: "Hexclave setup error",
       aiPrompt: buildAiPrompt(issue),
       onCopyError: (copyError) => captureError("setup-error-overlay-copy", copyError),
       onCopyAiPromptError: (copyError) => captureError("setup-error-overlay-copy-ai-prompt", copyError),
       onMinimize: () => render(true),
     }));
-    releaseFocus = trapFocusInIssueCard(root);
+    focusTrap = trapFocusInIssueCard(root);
   };
   render(false);
 
   const cleanup = () => {
-    releaseFocus?.();
-    releaseFocus = null;
+    focusTrap?.release();
+    focusTrap = null;
     root.remove();
     if (getGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY)?.cleanup === cleanup) {
       setGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY, null);

--- a/packages/template/src/setup-error-overlay/index.ts
+++ b/packages/template/src/setup-error-overlay/index.ts
@@ -9,9 +9,10 @@
 import { HexclaveSetupError, captureError, errorToNiceString } from "@hexclave/shared/dist/utils/errors";
 import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
 import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
-import { getIssueCardCSS, renderIssueCard, renderIssuePill } from "../in-page-ui/issue-card";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill, trapFocusInIssueCard } from "../in-page-ui/issue-card";
 
-const GLOBAL_INSTANCE_KEY = "__hexclave-setup-error-overlay";
+/** Exported so tests can drop the singleton; every other consumer should go through `showSetupErrorOverlay`. */
+export const SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY = "__hexclave-setup-error-overlay";
 
 const css = getIssueCardCSS(".hexclave-setup-error-overlay");
 
@@ -77,7 +78,7 @@ export function showSetupErrorOverlay(error: unknown): () => void {
   }
 
   const issue = toSetupIssue(error);
-  const existingInstance = getGlobalUiInstance(GLOBAL_INSTANCE_KEY);
+  const existingInstance = getGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY);
   if (existingInstance != null) {
     // A single broken setup usually throws the same error on every page load and sometimes from several flows at once.
     // Stacking cards on top of each other would only hide the first (and most relevant) one, so later errors keep to
@@ -90,7 +91,10 @@ export function showSetupErrorOverlay(error: unknown): () => void {
   root.appendChild(style);
   document.body.appendChild(root);
 
+  let releaseFocus: (() => void) | null = null;
   const render = (minimized: boolean) => {
+    releaseFocus?.();
+    releaseFocus = null;
     root.replaceChildren(style);
     if (minimized) {
       root.appendChild(renderIssuePill({
@@ -116,16 +120,19 @@ export function showSetupErrorOverlay(error: unknown): () => void {
       onCopyAiPromptError: (copyError) => captureError("setup-error-overlay-copy-ai-prompt", copyError),
       onMinimize: () => render(true),
     }));
+    releaseFocus = trapFocusInIssueCard(root);
   };
   render(false);
 
   const cleanup = () => {
+    releaseFocus?.();
+    releaseFocus = null;
     root.remove();
-    if (getGlobalUiInstance(GLOBAL_INSTANCE_KEY)?.cleanup === cleanup) {
-      setGlobalUiInstance(GLOBAL_INSTANCE_KEY, null);
+    if (getGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY)?.cleanup === cleanup) {
+      setGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY, null);
     }
   };
-  setGlobalUiInstance(GLOBAL_INSTANCE_KEY, { cleanup });
+  setGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY, { cleanup });
   return cleanup;
 }
 

--- a/packages/template/src/setup-error-overlay/index.ts
+++ b/packages/template/src/setup-error-overlay/index.ts
@@ -1,0 +1,132 @@
+// IF_PLATFORM js-like
+
+// Renders an error card on the page when an auth flow dies because of a setup problem in the developer's project (a
+// domain missing from the trusted domains, for example). Those failures used to be logged with captureError only, which
+// meant the flow just quietly stopped: the developer saw a page that never signed anybody in, with the explanation
+// buried in the console or in Sentry. Setup errors are always the developer's to fix and never recoverable at runtime,
+// so they get the same treatment as a broken pushed config: a card that is impossible to miss.
+
+import { HexclaveSetupError, captureError, errorToNiceString } from "@hexclave/shared/dist/utils/errors";
+import { isLikelyDevelopmentEnvironment } from "../in-page-ui/dev-environment";
+import { canMountIntoDom, getGlobalUiInstance, h, setGlobalUiInstance } from "../in-page-ui/dom";
+import { getIssueCardCSS, renderIssueCard, renderIssuePill } from "../in-page-ui/issue-card";
+
+const GLOBAL_INSTANCE_KEY = "__hexclave-setup-error-overlay";
+
+const css = getIssueCardCSS(".hexclave-setup-error-overlay");
+
+const unexpectedErrorHowToFix = [
+  "Check the browser console and your Hexclave dashboard's logs for the full error.",
+  "Make sure your Hexclave SDK packages are up to date.",
+  "If the error looks like a bug in Hexclave, report it at https://github.com/hexclave/hexclave/issues.",
+] as const;
+
+type SetupIssue = {
+  title: string,
+  message: string,
+  howToFix: readonly string[],
+};
+
+function toSetupIssue(error: unknown): SetupIssue {
+  if (HexclaveSetupError.isSetupError(error)) {
+    return {
+      title: error.title,
+      message: error.message,
+      howToFix: error.howToFix,
+    };
+  }
+  return {
+    title: "Hexclave could not finish an authentication flow",
+    message: errorToNiceString(error),
+    howToFix: unexpectedErrorHowToFix,
+  };
+}
+
+function buildAiPrompt(issue: SetupIssue): string {
+  return [
+    "Help me fix this Hexclave setup error.",
+    "",
+    "Hexclave reminder:",
+    "This error was thrown by the Hexclave SDK in the browser while it was resolving an authentication flow, and the flow was aborted because of it. It is a problem with how my project is set up, not something my users can work around. Use your web fetch tool to read https://skill.hexclave.com to learn more about Hexclave.",
+    "",
+    "Error message:",
+    issue.message,
+    "",
+    "Hexclave suggests:",
+    ...issue.howToFix.map((step) => `- ${step}`),
+    "",
+    "Please explain the likely cause and suggest the smallest safe fix.",
+  ].join("\n");
+}
+
+/**
+ * Shows `error` as an error card on the current page.
+ *
+ * Setup errors are always shown, because the flow they aborted cannot complete no matter what the end user does, and
+ * their messages are written for exactly this purpose. Any other error is only shown while developing — those messages
+ * are internal diagnostics, so in production they stay in captureError's hands.
+ *
+ * Returns a cleanup function that removes the card again.
+ */
+export function showSetupErrorOverlay(error: unknown): () => void {
+  if (!canMountIntoDom()) {
+    return () => {};
+  }
+  if (!HexclaveSetupError.isSetupError(error) && !isLikelyDevelopmentEnvironment()) {
+    return () => {};
+  }
+
+  const issue = toSetupIssue(error);
+  const existingInstance = getGlobalUiInstance(GLOBAL_INSTANCE_KEY);
+  if (existingInstance != null) {
+    // A single broken setup usually throws the same error on every page load and sometimes from several flows at once.
+    // Stacking cards on top of each other would only hide the first (and most relevant) one, so later errors keep to
+    // captureError and leave the card that is already up alone.
+    return () => {};
+  }
+
+  const root = h("div", { className: "hexclave-setup-error-overlay" });
+  const style = h("style", null, css);
+  root.appendChild(style);
+  document.body.appendChild(root);
+
+  const render = (minimized: boolean) => {
+    root.replaceChildren(style);
+    if (minimized) {
+      root.appendChild(renderIssuePill({
+        kind: "error",
+        label: "Setup error",
+        ariaLabel: "Show Hexclave setup error",
+        onClick: () => render(false),
+      }));
+      return;
+    }
+    root.appendChild(renderIssueCard({
+      kind: "error",
+      badge: "Setup error",
+      title: issue.title,
+      bodyText: "Hexclave stopped the authentication flow that ran into this error, so nobody can sign in through it until it is fixed.",
+      messageLabel: "Error message",
+      message: issue.message,
+      howToFix: issue.howToFix,
+      footerText: "This card is shown by the Hexclave SDK. Fix the problem above and reload the page to try the flow again.",
+      ariaLabel: "Hexclave setup error",
+      aiPrompt: buildAiPrompt(issue),
+      onCopyError: (copyError) => captureError("setup-error-overlay-copy", copyError),
+      onCopyAiPromptError: (copyError) => captureError("setup-error-overlay-copy-ai-prompt", copyError),
+      onMinimize: () => render(true),
+    }));
+  };
+  render(false);
+
+  const cleanup = () => {
+    root.remove();
+    if (getGlobalUiInstance(GLOBAL_INSTANCE_KEY)?.cleanup === cleanup) {
+      setGlobalUiInstance(GLOBAL_INSTANCE_KEY, null);
+    }
+  };
+  setGlobalUiInstance(GLOBAL_INSTANCE_KEY, { cleanup });
+  return cleanup;
+}
+
+// END_PLATFORM


### PR DESCRIPTION
Startup auth failures (nested cross-domain handoffs, most notably an untrusted callback URL) were only `captureError`'d, so the flow just stopped with nothing on the page.

- New `HexclaveSetupError` in `packages/shared`: carries a developer-facing `title` + `howToFix` steps; diagnostics go to the error sinks only.
- Untrusted URL checks in the client app (nested cross-domain callback URL / redirect URI / after-callback redirect URL, and the `_redirectIfTrusted` / handler-redirect checks) now throw it, keeping their existing messages so logs stay greppable.
- `_trackPendingAuthResolution` still captures the error, and additionally renders it via a new setup-error overlay. Structured setup errors render always; anything else only while developing.
- Card/pill rendering extracted into `in-page-ui/issue-card`, which the pushed-config error overlay now uses too (that overlay's markup and copy are unchanged).

Untracked drive-by: `redirect-page-urls.test.ts` was missing `rawHomeUrl`, which broke `pnpm typecheck` on `dev`.

![setup error card](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGwzT2d1STVWMXBYcTUwUCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19obDNPZ3VJNVYxcFhxNTBQL2NhNDQyZTE0LWY4MzQtNDE4Mi05OGIwLTBlZTlkZGZmMDk3ZCIsImlhdCI6MTc4NTc5NTUxMiwiZXhwIjoxNzg2NDAwMzEyLCJmaWxlbmFtZSI6InNzX2ZkMTk3OTc4LnBuZyJ9.iRq4h_MyNWoBnnntpOmhR_nOUehBEYJTxwQFa5CYKA0)
![minimized](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGwzT2d1STVWMXBYcTUwUCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19obDNPZ3VJNVYxcFhxNTBQLzIwMWU4NzUyLWIwZmMtNDA3MC05NzJkLTg5YzBlMGU4ZmIwMSIsImlhdCI6MTc4NTc5NTUxMiwiZXhwIjoxNzg2NDAwMzEyLCJmaWxlbmFtZSI6InNzXzdiMThlZWU0LnBuZyJ9.PboCEwiIItyHwj9cXnsTGHfzOGRxcHjnQedJBRPioXI)


Link to Devin session: https://app.devin.ai/sessions/65c77ab6130142b982b8afbea488ebf3
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Show developer-facing auth setup errors as an in-page error card so startup auth failures aren’t silent; addresses Linear 1785795500. Adds `HexclaveSetupError`, surfaces untrusted or malformed auth URLs, unifies overlay UI with a focus‑trapped card, and only shows nested‑auth setup errors when the handoff owns the current session.

- **New Features**
  - Added `HexclaveSetupError` in `@hexclave/shared` with `title`/`howToFix` and a strict cross-bundle brand check via `HexclaveSetupError.isSetupError`.
  - New setup-error overlay (`showSetupErrorOverlay`) renders a focus‑trapped card (always for setup errors, dev‑only for others) with minimize pill, copy buttons, and AI prompt; global instance key exported.
  - Untrusted or malformed nested-auth redirect/callback URLs and `_redirectIfTrusted` now throw it; `_trackPendingAuthResolution` surfaces a setup‑error card.

- **Refactors**
  - Hardened nested cross‑domain auth: only show setup cards when the handoff owns the current session; checks run on failure paths to keep the happy path unchanged.
  - Introduced shared issue‑card UI and Hexclave logo; pushed‑config overlay migrated and now rebinds its focus trap on re‑render; dev‑environment detection centralized in `isLikelyDevelopmentEnvironment`.
  - Tests cover malformed URL and ownership cases, focus/minimize, and singleton behavior; e2e uses a matching source session; `rawHomeUrl` added.

<sup>Written for commit de58cbe873c278005aea4ae07a7e82e98d68089a. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1851?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a browser overlay for authentication setup errors with clear explanations and remediation steps.
  * Added options to minimize, dismiss, copy error details, and generate troubleshooting prompts.
  * Added accessible error and warning cards with responsive layouts and keyboard focus support.
  * Added safeguards for malformed or untrusted redirect and cross-domain authentication URLs.

* **Bug Fixes**
  * Improved reporting of authentication failures during application startup.
  * Improved environment-specific display of development errors.

* **Tests**
  * Added coverage for setup-error display, cleanup, minimization, focus behavior, and malformed URLs.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->