### PR TITLE
Show the setup error card when the server rejects a cross-domain redirect URL

### DIFF
--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.ts
@@ -113,6 +113,7 @@ function createUntrustedUrlError(options: {
   message: string,
   url: string,
   projectId: string,
+  cause?: unknown,
 }): HexclaveSetupError {
   const origin = createUrlIfValid(options.url)?.origin ?? options.url;
   return new HexclaveSetupError({
@@ -126,6 +127,7 @@ function createUntrustedUrlError(options: {
     extraData: {
       url: options.url,
       projectId: options.projectId,
+      ...options.cause === undefined ? {} : { cause: options.cause },
     },
   });
 }
@@ -162,6 +164,18 @@ function createMalformedNestedCrossDomainUrlError(options: {
       url: options.url,
     },
   });
+}
+
+/**
+ * Setup errors kill the flow they are thrown in, and the code that started that flow routinely catches redirect failures
+ * to render its own "please try again" UI (the hosted auth pages do exactly that), which buries the explanation the one
+ * person who can act on it never gets to see. Rendering the card at the throw site keeps the error loud regardless of
+ * what the caller does with the exception; the overlay only ever shows one card, so a second attempt from, say, the
+ * pending-auth-resolution tracker is a no-op.
+ */
+function throwSetupError(error: HexclaveSetupError): never {
+  showSetupErrorOverlay(error); // THIS_LINE_PLATFORM js-like
+  throw error;
 }
 
 function getRedirectHelperInstruction(handlerName: string): string {
@@ -3134,23 +3148,47 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
     // be minted from the refresh token we are about to send, instead of reusing
     // a still-valid cached token from a pre-handoff session snapshot.
     await session.fetchNewTokens();
-    const response = await this._interface.sendClientRequest(
-      "/auth/oauth/cross-domain/authorize",
-      {
-        method: "POST",
-        headers: {
-          "Content-Type": "application/json",
+    let response;
+    try {
+      response = await this._interface.sendClientRequest(
+        "/auth/oauth/cross-domain/authorize",
+        {
+          method: "POST",
+          headers: {
+            "Content-Type": "application/json",
+          },
+          body: JSON.stringify({
+            redirect_uri: options.redirectUri,
+            state: options.state,
+            code_challenge: options.codeChallenge,
+            code_challenge_method: "S256",
+            after_callback_redirect_url: options.afterCallbackRedirectUrl,
+          }),
         },
-        body: JSON.stringify({
-          redirect_uri: options.redirectUri,
-          state: options.state,
-          code_challenge: options.codeChallenge,
-          code_challenge_method: "S256",
-          after_callback_redirect_url: options.afterCallbackRedirectUrl,
-        }),
-      },
-      session,
-    );
+        session,
+      );
+    } catch (error) {
+      // The server runs the trusted-domain check again on both URLs, and for a cross-domain handoff it is usually the
+      // first place the check happens at all (the SDK only sees that the target is on another domain, which is the
+      // entire point of the flow). Its rejection is the same developer-owned problem as a client-side trust failure, so
+      // it gets the same card instead of a bare known error that whoever started the redirect turns into "please try
+      // again" — the domain is untrusted, and retrying will fail forever.
+      if (KnownErrors.RedirectUrlNotWhitelisted.isInstance(error)) {
+        const untrustedUrl = error.constructorArgs[0] ?? options.redirectUri;
+        // The URL the server rejected carries the entire handoff (state, code challenge, return URL) in its query, none
+        // of which has anything to do with why it was rejected, so the message shows only the part that is checked. The
+        // full URL still goes to the error tracker through `extraData`.
+        const untrustedUrlObject = createUrlIfValid(untrustedUrl);
+        const displayedUrl = untrustedUrlObject == null ? untrustedUrl : `${untrustedUrlObject.origin}${untrustedUrlObject.pathname}`;
+        throwSetupError(createUntrustedUrlError({
+          message: `Cross-domain auth redirect URL ${displayedUrl} is not trusted.`,
+          url: untrustedUrl,
+          projectId: this.projectId,
+          cause: error,
+        }));
+      }
+      throw error;
+    }
     if (!response.ok) {
       const responseBody = await response.text();
       throw new HexclaveAssertionError(`Cross-domain authorization endpoint failed: ${response.status} ${responseBody}`);
@@ -3238,11 +3276,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
   // END_PLATFORM
   protected async _redirectIfTrusted(url: string, options?: RedirectToOptions) {
     if (!await this._isTrusted(url)) {
-      throw createUntrustedUrlError({
+      throwSetupError(createUntrustedUrlError({
         message: `Redirect URL ${url} is not trusted; should be relative.`,
         url,
         projectId: this.projectId,
-      });
+      }));
     }
     return await this._redirectTo({ url, ...options });
   }
@@ -3323,11 +3361,11 @@ export class _HexclaveClientAppImplIncomplete<HasTokenStore extends boolean, Pro
       })
       : plan.url;
     if (!await this._isTrusted(redirectUrl)) {
-      throw createUntrustedUrlError({
+      throwSetupError(createUntrustedUrlError({
         message: `Redirect URL ${redirectUrl} is not trusted; should be relative.`,
         url: redirectUrl,
         projectId: this.projectId,
-      });
+      }));
     }
     return redirectUrl;
   }

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.untrusted-redirect-card.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.untrusted-redirect-card.test.ts
@@ -4,6 +4,7 @@ import { KnownErrors } from "@hexclave/shared";
 import { AccessToken } from "@hexclave/shared/dist/sessions";
 import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
 import { afterEach, describe, expect, it } from "vitest";
+import { getGlobalUiInstance, setGlobalUiInstance } from "../../../../in-page-ui/dom";
 import { SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY } from "../../../../setup-error-overlay";
 import { StackClientApp } from "../interfaces/client-app";
 
@@ -83,10 +84,12 @@ function createCrossDomainAuthRedirectUrl(app: StackClientApp<true>, redirectUri
 
 describe("cross-domain handoff rejected by the server", () => {
   afterEach(() => {
+    // The card's own cleanup, so that the focus trap it installed is released too and does not follow the next test.
+    getGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY)?.cleanup();
+    setGlobalUiInstance(SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY, null);
     for (const root of overlayRoots()) {
       root.remove();
     }
-    Reflect.deleteProperty(window, SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY);
   });
 
   it("shows a setup error card even when the caller swallows the redirect failure", async () => {
@@ -108,13 +111,14 @@ describe("cross-domain handoff rejected by the server", () => {
       caught = error;
     }
 
-    expect(HexclaveSetupError.isSetupError(caught)).toBe(true);
-    expect(caught).toBeInstanceOf(Error);
+    if (!HexclaveSetupError.isSetupError(caught)) {
+      throw new Error(`Expected the rejected handoff to throw a setup error, got: ${caught}`);
+    }
     // The handoff query parameters have nothing to do with the rejection, so the message keeps only the checked part.
-    expect((caught as Error).message).toBe("Cross-domain auth redirect URL https://demo.example.test/ is not trusted.");
+    expect(caught.message).toBe("Cross-domain auth redirect URL https://demo.example.test/ is not trusted.");
     // The full URL is still handed to the error sinks, which is where `customCaptureExtraArgs` ends up.
-    expect(Reflect.get(caught as object, "customCaptureExtraArgs")).toMatchObject([{ url: untrustedUrl }]);
-    expect((caught as Error).cause).toBeInstanceOf(KnownErrors.RedirectUrlNotWhitelisted);
+    expect(Reflect.get(caught, "customCaptureExtraArgs")).toMatchObject([{ url: untrustedUrl }]);
+    expect(caught.cause).toBeInstanceOf(KnownErrors.RedirectUrlNotWhitelisted);
 
     expect(overlayRoots()).toHaveLength(1);
     const cardText = document.body.textContent;

--- a/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.untrusted-redirect-card.test.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/client-app-impl.untrusted-redirect-card.test.ts
@@ -1,0 +1,138 @@
+// @vitest-environment jsdom
+
+import { KnownErrors } from "@hexclave/shared";
+import { AccessToken } from "@hexclave/shared/dist/sessions";
+import { HexclaveSetupError } from "@hexclave/shared/dist/utils/errors";
+import { afterEach, describe, expect, it } from "vitest";
+import { SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY } from "../../../../setup-error-overlay";
+import { StackClientApp } from "../interfaces/client-app";
+
+function createAccessTokenString(refreshTokenId: string): string {
+  const encode = (value: unknown) => Buffer.from(JSON.stringify(value)).toString("base64url");
+  const nowSeconds = Math.floor(Date.now() / 1000);
+  return [
+    encode({ alg: "none", typ: "JWT" }),
+    encode({
+      sub: "user-id",
+      exp: nowSeconds + 60,
+      iat: nowSeconds,
+      iss: "https://api.example.test",
+      aud: "project-id",
+      project_id: "project-id",
+      branch_id: "main",
+      refresh_token_id: refreshTokenId,
+      role: "authenticated",
+      name: null,
+      email: null,
+      email_verified: false,
+      selected_team_id: null,
+      signed_up_at: nowSeconds,
+      is_anonymous: false,
+      is_restricted: false,
+      restricted_reason: null,
+      requires_totp_mfa: false,
+    }),
+    "",
+  ].join(".");
+}
+
+function overlayRoots(): NodeListOf<Element> {
+  return document.querySelectorAll(".hexclave-setup-error-overlay");
+}
+
+function createAppWithFailingHandoff(options: {
+  projectId: string,
+  sendClientRequest: () => Promise<never>,
+}): StackClientApp<true> {
+  const app = new StackClientApp({
+    baseUrl: "http://localhost:12345",
+    projectId: options.projectId,
+    publishableClientKey: "stack-pk-test",
+    tokenStore: "memory",
+    redirectMethod: "none",
+    noAutomaticPrefetch: true,
+    devTool: false,
+  });
+  const accessToken = createAccessTokenString("source-refresh-token-id");
+  const clientInterface = Reflect.get(app, "_interface");
+  Reflect.set(clientInterface, "fetchNewAccessToken", async () => {
+    return AccessToken.createIfValid(accessToken) ?? (() => {
+      throw new Error("Expected the test access token to be valid.");
+    })();
+  });
+  Reflect.set(clientInterface, "sendClientRequest", options.sendClientRequest);
+  return app;
+}
+
+function createCrossDomainAuthRedirectUrl(app: StackClientApp<true>, redirectUri: string): Promise<unknown> {
+  const method = Reflect.get(app, "_createCrossDomainAuthRedirectUrl");
+  if (typeof method !== "function") {
+    throw new Error("Expected StackClientApp to expose _createCrossDomainAuthRedirectUrl in tests.");
+  }
+  return method.call(app, {
+    redirectUri,
+    state: "handoff-state",
+    codeChallenge: "abcdefghijklmnopqrstuvwxyzABCDEFG_0123456789-._~",
+    afterCallbackRedirectUrl: redirectUri,
+    overrideTokenStoreInit: {
+      accessToken: createAccessTokenString("source-refresh-token-id"),
+      refreshToken: "source-refresh-token",
+    },
+  });
+}
+
+describe("cross-domain handoff rejected by the server", () => {
+  afterEach(() => {
+    for (const root of overlayRoots()) {
+      root.remove();
+    }
+    Reflect.deleteProperty(window, SETUP_ERROR_OVERLAY_GLOBAL_INSTANCE_KEY);
+  });
+
+  it("shows a setup error card even when the caller swallows the redirect failure", async () => {
+    const untrustedUrl = "https://demo.example.test/?hexclave_cross_domain_auth=1";
+    const app = createAppWithFailingHandoff({
+      projectId: "00000000-0000-4000-8000-000000000101",
+      sendClientRequest: async () => {
+        throw new KnownErrors.RedirectUrlNotWhitelisted(untrustedUrl);
+      },
+    });
+
+    // The hosted auth pages catch a failing post-auth redirect and render their own "we could not continue
+    // automatically, please try again" screen, which is exactly how this error used to disappear: nothing on the page
+    // said that the flow is dead until a domain is added to the project's trusted domains.
+    let caught: unknown = null;
+    try {
+      await createCrossDomainAuthRedirectUrl(app, untrustedUrl);
+    } catch (error) {
+      caught = error;
+    }
+
+    expect(HexclaveSetupError.isSetupError(caught)).toBe(true);
+    expect(caught).toBeInstanceOf(Error);
+    // The handoff query parameters have nothing to do with the rejection, so the message keeps only the checked part.
+    expect((caught as Error).message).toBe("Cross-domain auth redirect URL https://demo.example.test/ is not trusted.");
+    // The full URL is still handed to the error sinks, which is where `customCaptureExtraArgs` ends up.
+    expect(Reflect.get(caught as object, "customCaptureExtraArgs")).toMatchObject([{ url: untrustedUrl }]);
+    expect((caught as Error).cause).toBeInstanceOf(KnownErrors.RedirectUrlNotWhitelisted);
+
+    expect(overlayRoots()).toHaveLength(1);
+    const cardText = document.body.textContent;
+    expect(cardText).toContain("A domain in your authentication flow is not one of your project's trusted domains");
+    expect(cardText).toContain("add it to your project's trusted domains in the Hexclave dashboard, under Domains.");
+  });
+
+  it("leaves other handoff failures to captureError", async () => {
+    const app = createAppWithFailingHandoff({
+      projectId: "00000000-0000-4000-8000-000000000102",
+      sendClientRequest: async () => {
+        throw new KnownErrors.UserAuthenticationRequired();
+      },
+    });
+
+    await expect(createCrossDomainAuthRedirectUrl(app, "https://demo.example.test/")).rejects.toSatisfy(
+      (error: unknown) => KnownErrors.UserAuthenticationRequired.isInstance(error),
+    );
+    expect(overlayRoots()).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
#1851 only made the SDK's own trusted-domain checks loud. In a cross-domain handoff the SDK can't do that check (the target being on another domain is the point of the flow), so the rejection comes from `/auth/oauth/cross-domain/authorize` as a plain `RedirectUrlNotWhitelisted`, and the caller's own error UI swallowed it:

```
redirectToAfterSignIn() → _createCrossDomainAuthRedirectUrl() → KnownError<REDIRECT_URL_NOT_WHITELISTED>
  → hosted auth page catch → "Unable to redirect / We could not continue automatically. Please try again."
```

Two changes:

- that rejection becomes the same `HexclaveSetupError` as a client-side trust failure, keeping the rejected URL in `extraData` for the error sinks while the message shows only the checked part of the URL (the handoff query string is noise);
- setup errors render the card at the throw site (`throwSetupError`), so a caller that catches redirect failures can no longer hide them. The overlay is a singleton, so the later `showSetupErrorOverlay` from the pending-auth tracker stays a no-op.

The new test drives `_createCrossDomainAuthRedirectUrl` against an interface that rejects the way the server does, swallows the error like the hosted page does, and asserts the card is on the page anyway; it fails without the fix.

![setup error card for a rejected cross-domain redirect](https://app.devin.ai/api/presigned_proxy?token=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJvcmdfaWQiOiJvcmdfaGwzT2d1STVWMXBYcTUwUCIsInVzZXJfaWQiOm51bGwsImJ1Y2tldF9uYW1lIjoiZGV2aW5hdHRhY2htZW50cyIsImJ1Y2tldF9rZXkiOiJhdHRhY2htZW50c19wcml2YXRlL29yZ19obDNPZ3VJNVYxcFhxNTBQLzYzZjg1YTg4LTAyNzctNDBkYi1iNzkxLTk2N2RlMzg2ZmU4MiIsImlhdCI6MTc4NTgwOTE4NywiZXhwIjoxNzg2NDEzOTg3LCJmaWxlbmFtZSI6InNldHVwLWVycm9yLWNhcmQtY3Jvc3MtZG9tYWluLnBuZyJ9.u6lhR2rPn5wnmJx-Bt8c1D8F6sLJ3HPPQojgbff94ng)


Link to Devin session: https://app.devin.ai/sessions/65c77ab6130142b982b8afbea488ebf3
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Shows the setup error card when a cross-domain redirect URL is rejected by the server, making untrusted-domain failures loud and actionable. Prevents hosted pages and callers from swallowing the error behind a generic “please try again” message.

- **Bug Fixes**
  - Map `KnownErrors.RedirectUrlNotWhitelisted` from `/auth/oauth/cross-domain/authorize` to a `HexclaveSetupError` with `cause`; message shows only origin+path, full URL kept in `extraData`.
  - Render the setup error overlay at the throw site via `throwSetupError`, so callers that catch redirect failures can’t hide it; overlay remains a singleton.
  - Apply the same handling to client-side trust checks in `_redirectIfTrusted` and related paths; tests assert the card appears, unrelated errors pass through, and release the card’s focus trap to avoid leaks between tests.

<sup>Written for commit 510565e6978e1ad32e2ba7500a773dab7f17d697. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1856?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved setup error handling during authentication and redirect flows.
  - Untrusted redirect failures now display a clear setup-error overlay before being reported.
  - Preserved underlying error details to support troubleshooting.
  - Other authentication failures continue to be handled without being incorrectly shown as setup errors.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->