### PR TITLE
Run external-db-sync queue tests against an isolated schema

### DIFF
--- a/apps/backend/src/lib/external-db-sync-queue.test.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.test.ts
@@ -1,40 +1,99 @@
 import { randomUUID } from "node:crypto";
-import { afterEach, describe, expect, it } from "vitest";
-import { globalPrismaClient } from "@/prisma-client";
+import { PrismaClient } from "@/generated/prisma/client";
+import { PrismaPg } from "@prisma/adapter-pg";
+import { Pool } from "pg";
+import { afterAll, beforeAll, describe, expect, it } from "vitest";
+import { globalPrismaClient, globalPrismaSchema, sqlQuoteIdent } from "@/prisma-client";
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
 import { enqueueExternalDbSync, enqueueExternalDbSyncBatch } from "./external-db-sync-queue";
 
 const DEDUP_PREFIX = "sentinel-sync-key-";
 
-// Track every tenancy ID a test enqueues so we can delete the rows afterwards.
-// These tests run against the shared dev database, and leftover pending rows
-// would be picked up by the poller (which would then fail on the nonexistent
-// tenancies and pollute logs).
-const enqueuedTenancyIds: string[] = [];
+// Use a scratch schema because the real OutgoingRequest table is a live queue
+// consumed by the poller, which can claim or delete rows while these tests run.
+const scratchSchema = `external_db_sync_test_${randomUUID().replaceAll("-", "")}`;
+
+let scratchPool: Pool | undefined;
+let scratchClient: PrismaClient | undefined;
+
+function getScratchClient() {
+  return scratchClient ?? throwErr("Scratch Prisma client has not been initialized");
+}
 
 function freshTenancyIds(count: number): string[] {
-  const ids = Array.from({ length: count }, () => randomUUID());
-  enqueuedTenancyIds.push(...ids);
-  return ids;
+  return Array.from({ length: count }, () => randomUUID());
 }
 
 async function findRowsForTenancies(tenancyIds: string[]) {
-  return await globalPrismaClient.outgoingRequest.findMany({
+  return await getScratchClient().outgoingRequest.findMany({
     where: { deduplicationKey: { in: tenancyIds.map((id) => DEDUP_PREFIX + id) } },
     orderBy: { deduplicationKey: "asc" },
   });
 }
 
-afterEach(async () => {
-  await globalPrismaClient.outgoingRequest.deleteMany({
-    where: { deduplicationKey: { in: enqueuedTenancyIds.splice(0).map((id) => DEDUP_PREFIX + id) } },
+beforeAll(async () => {
+  const databaseConnectionString = getEnvVariable("STACK_DATABASE_CONNECTION_STRING", "") || throwErr("Missing database connection string for external DB sync queue tests");
+  await globalPrismaClient.$executeRaw`CREATE SCHEMA ${sqlQuoteIdent(scratchSchema)}`;
+  await globalPrismaClient.$executeRaw`
+    CREATE TABLE ${sqlQuoteIdent(scratchSchema)}."OutgoingRequest"
+    (LIKE ${sqlQuoteIdent(globalPrismaSchema)}."OutgoingRequest" INCLUDING ALL)
+  `;
+
+  const indexes = await globalPrismaClient.$queryRaw<{ indexname: string, indexdef: string }[]>`
+    SELECT indexname, indexdef
+    FROM pg_indexes
+    WHERE schemaname = ${scratchSchema}
+      AND tablename = 'OutgoingRequest'
+      AND indexdef ILIKE '%UNIQUE%'
+      AND indexdef ILIKE '%startedFulfillingAt%'
+  `;
+  expect(indexes).toHaveLength(1);
+
+  // Pool search_path covers the enqueue's unqualified raw SQL; PrismaPg's schema covers model API queries.
+  scratchPool = new Pool({
+    connectionString: databaseConnectionString,
+    max: 10,
+    options: `-c search_path=${scratchSchema}`,
+  });
+  scratchClient = new PrismaClient({
+    adapter: new PrismaPg(scratchPool, { schema: scratchSchema }),
+  });
+  await scratchClient.$connect();
+
+  const modelApiSentinel = `sentinel-sync-key-model-api-${randomUUID()}`;
+  const client = getScratchClient();
+  // Verify the model API uses the scratch table rather than the live public table.
+  await client.outgoingRequest.create({
+    data: {
+      qstashOptions: { modelApiSentinel },
+      deduplicationKey: modelApiSentinel,
+    },
+  });
+  const scratchRows = await client.outgoingRequest.findMany({
+    where: { deduplicationKey: modelApiSentinel },
+  });
+  const realRows = await globalPrismaClient.outgoingRequest.findMany({
+    where: { deduplicationKey: modelApiSentinel },
+  });
+  expect(scratchRows).toHaveLength(1);
+  expect(realRows).toHaveLength(0);
+  await client.outgoingRequest.deleteMany({
+    where: { deduplicationKey: modelApiSentinel },
   });
 });
 
-describe("enqueueExternalDbSyncBatch (real DB)", () => {
+afterAll(async () => {
+  await globalPrismaClient.$executeRaw`DROP SCHEMA IF EXISTS ${sqlQuoteIdent(scratchSchema)} CASCADE`;
+  if (scratchClient != null) await scratchClient.$disconnect();
+  if (scratchPool != null) await scratchPool.end();
+});
+
+describe("enqueueExternalDbSyncBatch (real DB, isolated schema)", () => {
   it("inserts one pending row per tenancy with the expected qstash options", async ({ expect }) => {
     const [tenancyId] = freshTenancyIds(1);
 
-    await enqueueExternalDbSync(tenancyId);
+    await enqueueExternalDbSync(tenancyId, getScratchClient());
 
     const rows = await findRowsForTenancies([tenancyId]);
     expect(rows).toHaveLength(1);
@@ -52,7 +111,7 @@ describe("enqueueExternalDbSyncBatch (real DB)", () => {
     // Duplicates within one call must collapse to a single row per tenancy.
     const withDuplicates = [...shuffled, ...ids, ids[2]];
 
-    await enqueueExternalDbSyncBatch(withDuplicates);
+    await enqueueExternalDbSyncBatch(withDuplicates, getScratchClient());
 
     const rows = await findRowsForTenancies(ids);
     expect(rows).toHaveLength(ids.length);
@@ -62,8 +121,8 @@ describe("enqueueExternalDbSyncBatch (real DB)", () => {
   it("skips tenancies that already have a pending row, even when re-enqueued in a different order", async ({ expect }) => {
     const ids = freshTenancyIds(4);
 
-    await enqueueExternalDbSyncBatch(ids);
-    await enqueueExternalDbSyncBatch([...ids].reverse());
+    await enqueueExternalDbSyncBatch(ids, getScratchClient());
+    await enqueueExternalDbSyncBatch([...ids].reverse(), getScratchClient());
 
     const rows = await findRowsForTenancies(ids);
     expect(rows).toHaveLength(ids.length);
@@ -72,16 +131,16 @@ describe("enqueueExternalDbSyncBatch (real DB)", () => {
   it("enqueues a new pending row once the previous one has been claimed", async ({ expect }) => {
     const [tenancyId] = freshTenancyIds(1);
 
-    await enqueueExternalDbSync(tenancyId);
+    await enqueueExternalDbSync(tenancyId, getScratchClient());
     // Simulate the poller claiming the row: the partial unique index only
     // covers rows WHERE startedFulfillingAt IS NULL, so a claimed row must not
     // block a fresh sync request for the same tenancy.
-    await globalPrismaClient.outgoingRequest.updateMany({
+    await getScratchClient().outgoingRequest.updateMany({
       where: { deduplicationKey: DEDUP_PREFIX + tenancyId },
       data: { startedFulfillingAt: new Date() },
     });
 
-    await enqueueExternalDbSync(tenancyId);
+    await enqueueExternalDbSync(tenancyId, getScratchClient());
 
     const rows = await findRowsForTenancies([tenancyId]);
     expect(rows).toHaveLength(2);
@@ -89,8 +148,8 @@ describe("enqueueExternalDbSyncBatch (real DB)", () => {
   });
 
   it("rejects non-UUID tenancy IDs", async ({ expect }) => {
-    await expect(enqueueExternalDbSyncBatch(["not-a-uuid"])).rejects.toThrow("tenancyId must be a valid UUID");
-    await expect(enqueueExternalDbSyncBatch([randomUUID(), "'; DROP TABLE \"OutgoingRequest\"; --"])).rejects.toThrow("tenancyId must be a valid UUID");
+    await expect(enqueueExternalDbSyncBatch(["not-a-uuid"], getScratchClient())).rejects.toThrow("tenancyId must be a valid UUID");
+    await expect(enqueueExternalDbSyncBatch([randomUUID(), "'; DROP TABLE \"OutgoingRequest\"; --"], getScratchClient())).rejects.toThrow("tenancyId must be a valid UUID");
   });
 
   // Regression test for a production deadlock (SQLSTATE 40P01): two concurrent
@@ -107,8 +166,8 @@ describe("enqueueExternalDbSyncBatch (real DB)", () => {
     for (let i = 0; i < ITERATIONS; i++) {
       const ids = freshTenancyIds(BATCH_SIZE);
       await Promise.all([
-        enqueueExternalDbSyncBatch(ids),
-        enqueueExternalDbSyncBatch([...ids].reverse()),
+        enqueueExternalDbSyncBatch(ids, getScratchClient()),
+        enqueueExternalDbSyncBatch([...ids].reverse(), getScratchClient()),
       ]);
 
       const rows = await findRowsForTenancies(ids);

--- a/apps/backend/src/lib/external-db-sync-queue.ts
+++ b/apps/backend/src/lib/external-db-sync-queue.ts
@@ -1,4 +1,4 @@
-import { globalPrismaClient } from "@/prisma-client";
+import { globalPrismaClient, type PrismaClientTransaction } from "@/prisma-client";
 import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 
 const UUID_REGEX = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
@@ -10,14 +10,15 @@ function assertUuid(value: unknown, label: string): asserts value is string {
 }
 
 // Queues a sync request for a specific tenant if one isn't already pending.
-export async function enqueueExternalDbSync(tenancyId: string): Promise<void> {
+// The client is injectable so callers can run the insert on their own connection or transaction (e.g. an isolated schema in tests).
+export async function enqueueExternalDbSync(tenancyId: string, client: PrismaClientTransaction = globalPrismaClient): Promise<void> {
   assertUuid(tenancyId, "tenancyId");
-  await enqueueExternalDbSyncBatch([tenancyId]);
+  await enqueueExternalDbSyncBatch([tenancyId], client);
 }
 
 // Queues sync requests for multiple tenants in a single query.
 // Only inserts for tenants that don't already have a pending request.
-export async function enqueueExternalDbSyncBatch(tenancyIds: string[]): Promise<void> {
+export async function enqueueExternalDbSyncBatch(tenancyIds: string[], client: PrismaClientTransaction = globalPrismaClient): Promise<void> {
   if (tenancyIds.length === 0) return;
 
   for (const id of tenancyIds) {
@@ -27,7 +28,7 @@ export async function enqueueExternalDbSyncBatch(tenancyIds: string[]): Promise<
   const sortedTenancyIds = [...new Set(tenancyIds)].sort();
 
   // Use unnest to pass array of UUIDs and insert all in one query
-  await globalPrismaClient.$executeRaw`
+  await client.$executeRaw`
     INSERT INTO "OutgoingRequest" ("id", "createdAt", "qstashOptions", "startedFulfillingAt", "deduplicationKey")
     SELECT
       gen_random_uuid(),


### PR DESCRIPTION
`external-db-sync-queue.test.ts` asserts on the exact contents of `OutgoingRequest`, but that table is a live work queue: whenever the poller cron is running against the same database, it can claim rows (setting `startedFulfillingAt`, which drops them out of the partial unique index so the next enqueue legitimately inserts again → duplicated rows) or drain them entirely (→ missing rows). Both directions were reproducible locally with `pnpm dev` running, and neither is fixable by adjusting assertions.

The tests now create a scratch schema with `CREATE TABLE <scratch>."OutgoingRequest" (LIKE ... INCLUDING ALL)` and talk to it through a dedicated Prisma client/pool whose `search_path` points there, so no poller ever touches those rows. `beforeAll` asserts the partial unique index came along and that writes really land in the scratch table; `afterAll` drops the schema.

To make that possible, the enqueue helpers take an optional Prisma client (defaulting to `globalPrismaClient`); no behaviour change for existing callers, and the SQL is untouched.

Every existing assertion is unchanged, and no sleeps or retries were added.

Verification: 15 consecutive runs of `pnpm test run external-db-sync-queue` green with the poller live (previously ~1 in 3-5 runs failed), plus a parallel loop hammering the claim query against the real table.


Link to Devin session: https://app.devin.ai/sessions/f3d5237ee5104ddaa731752dbc183ab6
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Stabilizes external-db-sync queue tests by running them against an isolated Postgres schema with a dedicated Prisma client/pool, preventing interference from the live poller. Core enqueue logic remains unchanged.

- **Bug Fixes**
  - Tests create a scratch schema and clone "OutgoingRequest" (INCLUDING ALL), then use a pool with `search_path` and a `PrismaPg` adapter scoped to that schema.
  - `beforeAll` verifies the partial unique index and that the model API targets the scratch table; `afterAll` drops the schema and closes the Prisma client and pool.
  - Verified with 15 consecutive green runs while the poller was active; no sleeps or retries added.

- **Refactors**
  - `enqueueExternalDbSync` and `enqueueExternalDbSyncBatch` accept an optional Prisma client/transaction (`PrismaClientTransaction`, defaults to `globalPrismaClient`) to support isolated connections; SQL and behavior are unchanged for existing callers.

<sup>Written for commit 07e40a25cd0550fab76ead24f42ac4a996887aab. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1859?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved external database synchronization reliability by supporting isolated database transactions.
  * Preserved existing enqueue and claimed-row behavior while improving test isolation and validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->