### PR TITLE
Reconcile item grants when a subscription's product snapshot is rewritten

### DIFF
--- a/apps/backend/src/lib/payments.test.tsx
+++ b/apps/backend/src/lib/payments.test.tsx
@@ -89,7 +89,7 @@ describe.sequential('validatePurchaseSession - purchase guards (real DB)', () =>
       stripeSubscriptionId: `stripe-${id}`, status: 'active',
       currentPeriodStart: now, currentPeriodEnd: periodEnd,
       cancelAtPeriodEnd: false, canceledAt: null, endedAt: null, refundedAt: null, productRevokedAt: null,
-      creationSource: 'TEST_MODE', createdAt: now,
+      creationSource: 'TEST_MODE', createdAt: now, updatedAt: now,
     });
   };
 

--- a/apps/backend/src/lib/payments/bulldozer-dual-write.ts
+++ b/apps/backend/src/lib/payments/bulldozer-dual-write.ts
@@ -38,6 +38,7 @@ export function subscriptionToStoredRow(sub: {
   productRevokedAt: Date | null,
   creationSource: string,
   createdAt: Date,
+  updatedAt: Date,
 }): Record<string, unknown> {
   return {
     id: sub.id,
@@ -59,6 +60,11 @@ export function subscriptionToStoredRow(sub: {
     productRevokedAtMillis: dateToMillis(sub.productRevokedAt),
     creationSource: sub.creationSource,
     createdAtMillis: dateToMillis(sub.createdAt),
+    // Bulldozer needs the rewrite time, not just the creation time: when a
+    // rewritten row carries a different product snapshot, the subscription fold
+    // reconciles the customer's item grants to it and stamps that adjustment at
+    // this instant.
+    updatedAtMillis: dateToMillis(sub.updatedAt),
   };
 }
 

--- a/apps/backend/src/lib/payments/ensure-free-plan.test.ts
+++ b/apps/backend/src/lib/payments/ensure-free-plan.test.ts
@@ -67,6 +67,7 @@ describe.sequential("ensureFreePlanForBillingTeam (real DB)", () => {
       productRevokedAt: null,
       creationSource: "PURCHASE_PAGE",
       createdAt: now,
+      updatedAt: now,
     });
   }
 
@@ -179,6 +180,7 @@ describe.sequential("ensureFreePlanForBillingTeam (real DB)", () => {
       productRevokedAt: null,
       creationSource: "PURCHASE_PAGE",
       createdAt: yesterday,
+      updatedAt: yesterday,
     });
 
     // Precondition: the team has exactly one sub on record, and it is the

--- a/apps/backend/src/lib/payments/schema/types.ts
+++ b/apps/backend/src/lib/payments/schema/types.ts
@@ -101,6 +101,12 @@ export type SubscriptionRow = {
   productRevokedAtMillis: number | null,
   creationSource: PurchaseCreationSource,
   createdAtMillis: number,
+  /**
+   * When the writer last rewrote this row. Bulldozer uses it as the effective
+   * time of the item-grant reconciliation that a rewritten product snapshot
+   * triggers. Null for rows written before the field existed.
+   */
+  updatedAtMillis: number | null,
 };
 
 export type SubscriptionInvoiceRow = {

--- a/apps/backend/src/lib/plan-usage.test.ts
+++ b/apps/backend/src/lib/plan-usage.test.ts
@@ -29,6 +29,7 @@ function createSubscriptionPeriod(startMillis: number, endMillis: number): Subsc
     productRevokedAtMillis: null,
     creationSource: "TEST_MODE",
     createdAtMillis: startMillis,
+    updatedAtMillis: null,
   };
 }
 

--- a/apps/bulldozer-js/src/payments/schema/index.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.ts
@@ -61,6 +61,14 @@ type SubscriptionFoldState = {
   itemRepeatSchedule: RepeatSchedule,
   outstandingGrants: OutstandingGrant[],
   repeatCount: number,
+  /**
+   * Effective time of the last item-grant reconciliation emitted for a rewritten
+   * product snapshot, or null/absent if none was ever emitted (states persisted
+   * before this field existed read as `undefined`). Reconciliations reuse the
+   * `igr:<subscriptionId>:<millis>` transaction ids, so each one must be stamped
+   * strictly later than the previous one to keep those ids unique.
+   */
+  lastReconcileMillis?: number | null,
 };
 type OtpFoldState = {
   purchaseId: string,
@@ -418,6 +426,107 @@ function subscriptionRepeatStep(state: SubscriptionFoldState, currentMillis: num
     }),
   };
 }
+
+// The item grants the fold currently holds live for `itemId`, i.e. the ones a reconciliation has to
+// retire before re-granting at a new quantity.
+const liveGrantsByItem = (grants: OutstandingGrant[]): Map<string, OutstandingGrant[]> => {
+  const byItem = new Map<string, OutstandingGrant[]>();
+  for (const grant of grants) {
+    byItem.set(grant.itemId, [...byItem.get(grant.itemId) ?? [], grant]);
+  }
+  return byItem;
+};
+
+// Bring the customer's item grants in line with a rewritten product snapshot, at `currentMillis`.
+//
+// Emitted transactions are immutable facts, so we cannot rewrite the subscription-start grants when
+// the stored snapshot changes (a plan whose quotas were raised, or the internal regen script
+// pushing the latest product config onto existing subscriptions). Instead we emit one more
+// item-grant-repeat transaction that retires the grants whose configured quantity/expiry changed
+// and re-grants them at the new numbers — the same shape the periodic repeat step emits, so
+// everything downstream (ledger, subscription-end expiry, refunds) treats it identically.
+//
+// Without this, `mergeRepeatSchedule` only ever picked up a changed item at its *next* reset, and
+// items configured with `repeat: "never"` were never re-granted at all.
+function subscriptionReconcileStep(state: SubscriptionFoldState, currentMillis: number): { state: SubscriptionFoldState, event: PiledriverObject } | null {
+  const live = liveGrantsByItem(state.outstandingGrants);
+  const itemIds = [...new Set([...live.keys(), ...Object.keys(state.product.includedItems)])];
+  const previousGrantsToExpire: ReturnType<typeof grantRefsToExpire> = [];
+  const newGrants: ItemGrant[] = [];
+  const keptGrants: OutstandingGrant[] = [];
+  const txnId = `igr:${state.subscriptionId}:${currentMillis}`;
+  // Only called for items the (merged) schedule knows about, i.e. items present in the new snapshot.
+  const grantNow = (itemId: string, quantity: number, expiresWhen: ItemGrant["expiresWhen"]) => newGrants.push({
+    itemId,
+    quantity,
+    expiresWhen,
+    expiresAtMillis: grantExpiryMillis(
+      expiresWhen,
+      (itemId in state.itemRepeatSchedule ? state.itemRepeatSchedule[itemId] : throwErr(`Reconciling subscription ${state.subscriptionId} granted item ${itemId}, which is missing from the merged repeat schedule`)).nextRepeatMillis,
+      state.endedAtMillis,
+    ),
+  });
+  for (const itemId of itemIds) {
+    const liveGrants = live.get(itemId) ?? [];
+    // A grant with no expiry is compactable, and compacted changes can't be expired by id (see
+    // `payments-entries-item-quantity-change-compactable`), so those units can never be retracted —
+    // they also accumulate across repeats, so the customer's balance for such an item isn't a
+    // function of the snapshot at all. Leave them out of the reconciliation entirely: the new
+    // configuration applies to future repeats (via `mergeRepeatSchedule`) and to nothing else.
+    const retractableGrants = liveGrants.filter(grant => grant.expiresWhen !== null);
+    keptGrants.push(...liveGrants.filter(grant => grant.expiresWhen === null));
+    const item = itemId in state.product.includedItems ? state.product.includedItems[itemId] : undefined;
+    const targetQuantity = item === undefined ? 0 : item.quantity * state.quantity;
+    const targetExpiresWhen = item === undefined ? null : normalizedExpiresWhen(item);
+    // Nothing live to replace: either the item is new to the snapshot (grant it — the start
+    // transaction would have, had the snapshot said so at the time), or its units are permanent and
+    // handled above.
+    if (retractableGrants.length === 0) {
+      if (liveGrants.length === 0 && targetQuantity !== 0) grantNow(itemId, targetQuantity, targetExpiresWhen);
+      continue;
+    }
+    const liveQuantity = retractableGrants.reduce((sum, grant) => sum + grant.quantity, 0);
+    if (liveQuantity === targetQuantity && retractableGrants.every(grant => grant.expiresWhen === targetExpiresWhen)) {
+      keptGrants.push(...retractableGrants);
+      continue;
+    }
+    previousGrantsToExpire.push(...grantRefsToExpire(retractableGrants, "both"));
+    if (targetQuantity !== 0) grantNow(itemId, targetQuantity, targetExpiresWhen);
+  }
+  if (previousGrantsToExpire.length === 0 && newGrants.length === 0) return null;
+  return {
+    state: {
+      ...state,
+      lastReconcileMillis: currentMillis,
+      outstandingGrants: [
+        ...keptGrants,
+        ...newGrants.map((grant, index) => ({ txnId, entryIndex: previousGrantsToExpire.length + index, itemId: grant.itemId, quantity: grant.quantity, expiresWhen: grant.expiresWhen })),
+      ],
+    },
+    event: toPiledriverObject({
+      type: "item-grant-repeat",
+      sourceType: "subscription",
+      sourceId: state.subscriptionId,
+      tenancyId: state.tenancyId,
+      customerId: state.customerId,
+      customerType: state.customerType,
+      itemGrants: newGrants,
+      previousGrantsToExpire,
+      paymentProvider: state.paymentProvider,
+      effectiveAtMillis: currentMillis,
+      createdAtMillis: currentMillis,
+    }),
+  };
+}
+
+// When to stamp the reconciliation of a rewritten snapshot: the moment the writer made the change.
+// Floored past everything already granted (+1ms) so the reconciliation can never land on — and
+// therefore reuse the `igr:` transaction id of — a repeat boundary or an earlier reconciliation.
+const reconcileMillis = (state: SubscriptionFoldState, row: SubscriptionRow): number => Math.max(
+  row.updatedAtMillis ?? row.createdAtMillis,
+  processedThroughMillis(state.itemRepeatSchedule, row.createdAtMillis) + 1,
+  (state.lastReconcileMillis ?? row.createdAtMillis) + 1,
+);
 
 // Fold a rewritten subscription row into the existing fold state (Stripe webhooks re-upsert the
 // row on every subscription/invoice event, so this runs often, usually with no meaningful change).
@@ -777,6 +886,14 @@ export function createPaymentsSchema() {
         const hasRepeat = Object.values(updated.itemRepeatSchedule).some(schedule => schedule.nextRepeatMillis !== null);
         if (updated.endedAtMillis !== null && !hasRepeat && updated.endedAtMillis < sub.currentPeriodEndMillis) {
           return { newState: toPiledriverObject(updated), nextTriggerTime: null, appendRowData: toPiledriverObject([subscriptionEndEvent(updated)]) };
+        }
+        // A rewrite that changes what the product includes has to reach the customer's balances
+        // now, not at the next reset (and never, for items that don't repeat) — see
+        // `subscriptionReconcileStep`. Rewrites that leave the included items alone (the common
+        // webhook re-upsert) reconcile to nothing and append no transaction.
+        const reconciled = subscriptionReconcileStep(updated, reconcileMillis(updated, sub));
+        if (reconciled !== null) {
+          return { newState: toPiledriverObject(reconciled.state), nextTriggerTime: dateFromMillis(soonestNextMillis(reconciled.state, reconciled.state.endedAtMillis)), appendRowData: toPiledriverObject([reconciled.event]) };
         }
         return { newState: toPiledriverObject(updated), nextTriggerTime: dateFromMillis(soonestNextMillis(updated, updated.endedAtMillis)) };
       },

--- a/apps/bulldozer-js/src/payments/schema/index.ts
+++ b/apps/bulldozer-js/src/payments/schema/index.ts
@@ -519,14 +519,24 @@ function subscriptionReconcileStep(state: SubscriptionFoldState, currentMillis: 
   };
 }
 
-// When to stamp the reconciliation of a rewritten snapshot: the moment the writer made the change.
-// Floored past everything already granted (+1ms) so the reconciliation can never land on — and
-// therefore reuse the `igr:` transaction id of — a repeat boundary or an earlier reconciliation.
-const reconcileMillis = (state: SubscriptionFoldState, row: SubscriptionRow): number => Math.max(
-  row.updatedAtMillis ?? row.createdAtMillis,
-  processedThroughMillis(state.itemRepeatSchedule, row.createdAtMillis) + 1,
-  (state.lastReconcileMillis ?? row.createdAtMillis) + 1,
-);
+// When to stamp the reconciliation of a rewritten snapshot: the moment the writer made the change,
+// but strictly between the boundaries around it. A transaction's id is
+// `igr:<sourceId>:<effectiveAtMillis>` and the repeat step stamps its own at the boundary
+// millisecond, so a reconciliation may never share a millisecond with a repeat (or with an earlier
+// reconciliation of the same subscription). It also has to stay *before* a boundary that hasn't been
+// processed yet — the source row is folded in before pending timers fire, and that boundary's
+// expire-and-re-grant has to land on top of the reconciled grants, not under them. Null when no
+// millisecond is left in the gap; then the imminent boundary re-grants from the new snapshot anyway.
+const reconcileMillis = (state: SubscriptionFoldState, row: SubscriptionRow): number | null => {
+  const earliestMillis = Math.max(
+    processedThroughMillis(state.itemRepeatSchedule, row.createdAtMillis),
+    state.lastReconcileMillis ?? row.createdAtMillis,
+  ) + 1;
+  const millis = Math.max(row.updatedAtMillis ?? row.createdAtMillis, earliestMillis);
+  const pendingBoundaryMillis = soonestNextMillis(state, null);
+  if (pendingBoundaryMillis === null || millis < pendingBoundaryMillis) return millis;
+  return pendingBoundaryMillis - 1 < earliestMillis ? null : pendingBoundaryMillis - 1;
+};
 
 // Fold a rewritten subscription row into the existing fold state (Stripe webhooks re-upsert the
 // row on every subscription/invoice event, so this runs often, usually with no meaningful change).
@@ -891,7 +901,8 @@ export function createPaymentsSchema() {
         // now, not at the next reset (and never, for items that don't repeat) — see
         // `subscriptionReconcileStep`. Rewrites that leave the included items alone (the common
         // webhook re-upsert) reconcile to nothing and append no transaction.
-        const reconciled = subscriptionReconcileStep(updated, reconcileMillis(updated, sub));
+        const reconcileAtMillis = reconcileMillis(updated, sub);
+        const reconciled = reconcileAtMillis === null ? null : subscriptionReconcileStep(updated, reconcileAtMillis);
         if (reconciled !== null) {
           return { newState: toPiledriverObject(reconciled.state), nextTriggerTime: dateFromMillis(soonestNextMillis(reconciled.state, reconciled.state.endedAtMillis)), appendRowData: toPiledriverObject([reconciled.event]) };
         }

--- a/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
@@ -689,7 +689,7 @@ describe("item quantities: full-pipeline integration", () => {
      * rewrite stamped exactly at a repeat boundary that hasn't been processed yet would emit a
      * transaction whose id the boundary's own tick then emits a second time.
      *   t=0                subscription grants 100 emails/month (first reset at 1970-02-01)
-     *   t=firstReset       snapshot rewritten to 300 emails/month (reconciled just past the boundary)
+     *   t=firstReset       snapshot rewritten to 300 emails/month (reconciled 1ms before the boundary)
      *   tick to firstReset the reset grants the new 300
      * Expected: the reconciliation and the reset are two distinct transactions, 300 emails in total.
      */
@@ -709,7 +709,9 @@ describe("item quantities: full-pipeline integration", () => {
     snapshot = (await snapshot.tick(new Date(firstResetMillis))).newSnapshot;
     const group = customerGroup("u-boundary");
     const txnIds = (await rowDatas(snapshot, schema.transactions, group)).map(txn => asRecord(txn).txnId);
-    expect(new Set(txnIds).size).toBe(txnIds.length);
+    // Both the reconciliation and the reset landed, one millisecond apart, each with its own id.
+    expect(txnIds.length).toBe(3);
+    expect(new Set(txnIds)).toEqual(new Set([`igr:sub-boundary:${firstResetMillis - 1}`, `igr:sub-boundary:${firstResetMillis}`, "sub-start:sub-boundary"]));
     expect(await balanceAt(snapshot, group, "emails", firstResetMillis)).toBe(300);
   });
 

--- a/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it } from "vitest";
 import type { PiledriverObject } from "../../databases/piledriver/index.js";
 import { createPaymentsSchema, itemQuantitiesLedgerUpperBoundAsOf } from "./index.js";
 import type { IncludedItemConfig } from "./types.js";
-import { asRecord, balanceAt, collect, customerGroup, initializedSnapshot, MONTH_MS, product, rowsBySortKey, set, subscription, type Snapshot } from "./schema-test-helpers.js";
+import { asRecord, balanceAt, collect, customerGroup, initializedSnapshot, MONTH_MS, product, rowDatas, rowsBySortKey, set, subscription, type Snapshot } from "./schema-test-helpers.js";
 
 // Item-quantities parity suite: restores the ledger coverage from the retired bulldozer-server
 // payments tests, driven through the real payments schema.
@@ -681,6 +681,36 @@ describe("item quantities: full-pipeline integration", () => {
     snapshot = await set(snapshot, schema.subscriptions, "sub-regen", subRow({ seats: { ...seats, quantity: 9 }, emails: { ...emails, quantity: 300 } }, 6 * DAY_MS));
     expect(await balanceAt(snapshot, g, "storage", 6 * DAY_MS)).toBe(0);
     expect(await balanceAt(snapshot, g, "seats", 6 * DAY_MS)).toBe(9);
+  });
+
+  it("does not reuse a repeat boundary's transaction id when a rewrite lands exactly on that boundary", async () => {
+    /*
+     * Reconciliations share the repeat step's `igr:<subscriptionId>:<millis>` transaction ids, so a
+     * rewrite stamped exactly at a repeat boundary that hasn't been processed yet would emit a
+     * transaction whose id the boundary's own tick then emits a second time.
+     *   t=0                subscription grants 100 emails/month (first reset at 1970-02-01)
+     *   t=firstReset       snapshot rewritten to 300 emails/month (reconciled just past the boundary)
+     *   tick to firstReset the reset grants the new 300
+     * Expected: the reconciliation and the reset are two distinct transactions, 300 emails in total.
+     */
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    const firstResetMillis = Date.UTC(1970, 1, 1);
+    const subRow = (quantity: number, updatedAtMillis: number | null) => subscription("sub-boundary", {
+      customerId: "u-boundary",
+      productId: "prod-boundary",
+      product: product({ emails: { quantity, repeat: [1, "month"], expires: "when-repeated" } }),
+      currentPeriodEndMillis: 12 * MONTH_MS,
+      createdAtMillis: 0,
+      updatedAtMillis,
+    }) as unknown as PiledriverObject;
+    snapshot = await set(snapshot, schema.subscriptions, "sub-boundary", subRow(100, null));
+    snapshot = await set(snapshot, schema.subscriptions, "sub-boundary", subRow(300, firstResetMillis));
+    snapshot = (await snapshot.tick(new Date(firstResetMillis))).newSnapshot;
+    const group = customerGroup("u-boundary");
+    const txnIds = (await rowDatas(snapshot, schema.transactions, group)).map(txn => asRecord(txn).txnId);
+    expect(new Set(txnIds).size).toBe(txnIds.length);
+    expect(await balanceAt(snapshot, group, "emails", firstResetMillis)).toBe(300);
   });
 
   it("ranks a resetting (when-repeated) grant ahead of a later-expiring grant so a removal rides the reset", async () => {

--- a/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/item-quantities.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from "vitest";
 import type { PiledriverObject } from "../../databases/piledriver/index.js";
 import { createPaymentsSchema, itemQuantitiesLedgerUpperBoundAsOf } from "./index.js";
+import type { IncludedItemConfig } from "./types.js";
 import { asRecord, balanceAt, collect, customerGroup, initializedSnapshot, MONTH_MS, product, rowsBySortKey, set, subscription, type Snapshot } from "./schema-test-helpers.js";
 
 // Item-quantities parity suite: restores the ledger coverage from the retired bulldozer-server
@@ -632,6 +633,54 @@ describe("item quantities: full-pipeline integration", () => {
     }) as unknown as PiledriverObject);
     snapshot = (await snapshot.tick(new Date(11 * DAY_MS))).newSnapshot;
     expect(await balanceAt(snapshot, customerGroup("u-upgrade"), "emails", 11 * DAY_MS)).toBe(500);
+  });
+
+  it("reconciles item grants when a subscription's product snapshot is rewritten", async () => {
+    /*
+     * The stored product snapshot is frozen at purchase time, but it does get rewritten in place:
+     * quotas of an existing plan change, or a script pushes the latest config onto live
+     * subscriptions. Everything the (immutable) start transaction granted has to be brought in line
+     * with the new snapshot immediately, not at the next monthly reset — and items that don't repeat
+     * have no next reset at all.
+     *
+     * day 0 : subscribed to { seats: 5 (when-purchase-expires), emails: 100/month }
+     * day 3 : -20 emails
+     * day 5 : snapshot rewritten to { seats: 9, emails: 300/month, storage: 50 } — seats raised,
+     *         emails raised, storage added, all effective at the rewrite time
+     *
+     * Expected at day 5: seats 9, storage 50, emails 280 — a quota change is not a period reset, so
+     * the 20 emails already spent this period ride along onto the re-granted allowance instead of
+     * settling with the grant they were retired from.
+     */
+    const schema = createPaymentsSchema();
+    let snapshot = await initializedSnapshot();
+    const subRow = (includedItems: Parameters<typeof product>[0], updatedAtMillis: number | null) => subscription("sub-regen", {
+      customerId: "u-regen",
+      productId: "prod-regen",
+      product: product(includedItems),
+      currentPeriodEndMillis: MONTH_MS,
+      createdAtMillis: 0,
+      updatedAtMillis,
+    }) as unknown as PiledriverObject;
+    const seats: IncludedItemConfig = { quantity: 5, expires: "when-purchase-expires" };
+    const emails: IncludedItemConfig = { quantity: 100, repeat: [1, "month"], expires: "when-repeated" };
+    snapshot = await set(snapshot, schema.subscriptions, "sub-regen", subRow({ seats, emails }, null));
+    snapshot = await setManualChange(snapshot, manualChange("consume", "u-regen", "emails", -20, 3 * DAY_MS, null));
+    const g = customerGroup("u-regen");
+    expect(await balanceAt(snapshot, g, "emails", 3 * DAY_MS)).toBe(80);
+
+    snapshot = await set(snapshot, schema.subscriptions, "sub-regen", subRow({
+      seats: { ...seats, quantity: 9 },
+      emails: { ...emails, quantity: 300 },
+      storage: { quantity: 50, expires: "when-purchase-expires" },
+    }, 5 * DAY_MS));
+    expect(await balanceAt(snapshot, g, "seats", 5 * DAY_MS)).toBe(9);
+    expect(await balanceAt(snapshot, g, "emails", 5 * DAY_MS)).toBe(280);
+    expect(await balanceAt(snapshot, g, "storage", 5 * DAY_MS)).toBe(50);
+    // Dropping an item from the snapshot retires its grant the same way.
+    snapshot = await set(snapshot, schema.subscriptions, "sub-regen", subRow({ seats: { ...seats, quantity: 9 }, emails: { ...emails, quantity: 300 } }, 6 * DAY_MS));
+    expect(await balanceAt(snapshot, g, "storage", 6 * DAY_MS)).toBe(0);
+    expect(await balanceAt(snapshot, g, "seats", 6 * DAY_MS)).toBe(9);
   });
 
   it("ranks a resetting (when-repeated) grant ahead of a later-expiring grant so a removal rides the reset", async () => {

--- a/apps/bulldozer-js/src/payments/schema/performance.test.ts
+++ b/apps/bulldozer-js/src/payments/schema/performance.test.ts
@@ -53,6 +53,7 @@ const subscription = (index: number, namespace = ""): SubscriptionRow => ({
   productRevokedAtMillis: null,
   creationSource: "TEST_MODE",
   createdAtMillis: 1_000 + index,
+  updatedAtMillis: null,
 });
 const oneTimePurchase = (index: number, namespace = "") => ({
   id: `${namespace}otp-${index}`,

--- a/apps/bulldozer-js/src/payments/schema/schema-test-helpers.ts
+++ b/apps/bulldozer-js/src/payments/schema/schema-test-helpers.ts
@@ -76,6 +76,7 @@ export const subscription = (id: string, overrides: Partial<SubscriptionRow> = {
   productRevokedAtMillis: null,
   creationSource: "TEST_MODE",
   createdAtMillis: 0,
+  updatedAtMillis: null,
   ...overrides,
 });
 

--- a/apps/bulldozer-js/src/payments/schema/types.ts
+++ b/apps/bulldozer-js/src/payments/schema/types.ts
@@ -63,6 +63,14 @@ export type SubscriptionRow = {
   productRevokedAtMillis: number | null,
   creationSource: PurchaseCreationSource,
   createdAtMillis: number,
+  /**
+   * When the writer last rewrote this row. Used as the effective time of the
+   * item-grant reconciliation a rewritten product snapshot triggers (see
+   * `subscriptionReconcileStep`), so the adjustment lands when the change was
+   * actually made instead of being backdated. Null for rows written before the
+   * field existed, in which case we fall back to `createdAtMillis`.
+   */
+  updatedAtMillis: number | null,
 };
 
 export type SubscriptionInvoiceRow = {


### PR DESCRIPTION
A subscription stores a frozen product snapshot, and the row does get rewritten in place (quotas of a live plan change, or `regen-internal-subscriptions-to-latest` pushes the latest config onto existing subscriptions). The subscription TimeFold's `onSourceRowChanged` adopted the new snapshot into its private state but appended no transaction, so the item-quantity ledger — which is built only from emitted transaction entries — never saw the change. `mergeRepeatSchedule` picked a changed item up at its *next* reset only, and items with `repeat: "never"` were never granted at all (they have no next reset), leaving a newly-included item at quantity 0 forever.

Fix: on a rewrite whose included items differ from what the fold currently holds live, append one `item-grant-repeat` transaction that expires the affected grants and re-grants them at the new quantities — the same shape the periodic repeat step emits, so the ledger, subscription-end expiry and refund paths treat it identically. Emitted transactions stay immutable; nothing historical is rederived.

Details:
- Items whose grants have no expiry (`expires: "never"`) are left alone: those units are compacted in the ledger and can't be expired by id, and they accumulate across repeats, so the new config only applies to their future repeats (unchanged behavior).
- The reconciliation is stamped at the row's update time (new `updatedAtMillis` on the stored subscription row), clamped to stay strictly between the last processed repeat boundary and the next pending one. A transaction's id is `igr:<sourceId>:<effectiveAtMillis>`, so sharing a millisecond with a repeat would duplicate an id; and since source rows are folded in before pending timers fire, the reconciliation also has to stay *before* an unprocessed boundary so that boundary's expire-and-re-grant lands on top of it. If no millisecond is left in the gap, nothing is emitted — the imminent boundary re-grants from the new snapshot anyway.
- Consumption already booked this period rides onto the re-granted allowance (a quota change isn't a period reset).

Testing: `apps/backend/src/scripts/regen-internal-subscriptions-to-latest.test.ts` (previously failing on the newly-added-item assertion, 3/3 runs now green), new schema-level regression tests covering a raise / an added item / a removed item with prior consumption and a rewrite landing exactly on a repeat boundary, plus the bulldozer-js payments schema suites and the payments e2e suite.


Link to Devin session: https://app.devin.ai/sessions/042f41bbbe454c38b5a2eb7b12d71505
Requested by: @N2D4