### PR TITLE
fix(e2e): stop two load-dependent flakes in the backend e2e suite

### DIFF
--- a/apps/e2e/tests/backend/backend-helpers.ts
+++ b/apps/e2e/tests/backend/backend-helpers.ts
@@ -4,6 +4,7 @@ import { ITEM_IDS } from "@hexclave/shared/dist/plans";
 import { encodeBase64 } from "@hexclave/shared/dist/utils/bytes";
 import { generateSecureRandomString } from "@hexclave/shared/dist/utils/crypto";
 import { HexclaveAssertionError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { getJwtInfo } from "@hexclave/shared/dist/utils/jwt";
 import { publishableClientKeyNotNecessarySentinel } from "@hexclave/shared/dist/utils/oauth";
 import { filterUndefined, omit } from "@hexclave/shared/dist/utils/objects";
 import { wait } from "@hexclave/shared/dist/utils/promises";
@@ -163,7 +164,34 @@ export async function niceBackendFetch(url: string | URL, options?: Omit<NiceReq
     expectSnakeCase(body, "req.body");
   }
   const projectKeys = backendContext.value.projectKeys;
-  const userAuth = userAuthOverride ?? backendContext.value.userAuth;
+  let userAuth = userAuthOverride ?? backendContext.value.userAuth;
+  // Access tokens live for only 60s in dev/CI (HEXCLAVE_ACCESS_TOKEN_EXPIRATION_TIME), and every request we send carries
+  // the context user's access token, even server-access ones. So any test that spends more than a minute between signing a
+  // user up and its next request fails with ACCESS_TOKEN_EXPIRED, no matter which access type it uses. Refresh the token
+  // the way a real client would instead. Tests that want to observe an expired token can pass an explicit `userAuth`
+  // (skipped below) or leave the refresh token unset.
+  if (userAuthOverride === undefined && projectKeys !== "no-project" && userAuth?.accessToken && userAuth.refreshToken) {
+    const jwtInfo = await getJwtInfo({ jwt: userAuth.accessToken });
+    const expiresAt = jwtInfo.status === "ok" && typeof jwtInfo.data.payload.exp === "number"
+      ? jwtInfo.data.payload.exp * 1000
+      : undefined;
+    if (expiresAt !== undefined && expiresAt <= Date.now() + 5_000) {
+      const refreshResponse = await niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
+        method: "POST",
+        accessType: "client",
+        userAuth: {
+          refreshToken: userAuth.refreshToken,
+        },
+      });
+      if (refreshResponse.status === 200 && typeof refreshResponse.body === "object" && refreshResponse.body !== null && "access_token" in refreshResponse.body && typeof refreshResponse.body.access_token === "string") {
+        userAuth = {
+          ...userAuth,
+          accessToken: refreshResponse.body.access_token,
+        };
+        backendContext.set({ userAuth });
+      }
+    }
+  }
   const fullUrl = new URL(url, STACK_BACKEND_BASE_URL);
   if (fullUrl.origin !== new URL(STACK_BACKEND_BASE_URL).origin) throw new HexclaveAssertionError(`Invalid niceBackendFetch origin: ${fullUrl.origin}`);
   if (fullUrl.protocol !== new URL(STACK_BACKEND_BASE_URL).protocol) throw new HexclaveAssertionError(`Invalid niceBackendFetch protocol: ${fullUrl.protocol}`);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
@@ -149,7 +149,8 @@ it("list users excludes anonymous users by default", async ({ expect }) => {
   await Auth.Anonymous.signUp();
 
   // Create a regular user
-  await Auth.Password.signUpWithEmail();
+  // Email delivery is queue-driven and can take tens of seconds in dev/CI; this test only needs the user record.
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // List users without include_anonymous
   const listRes = await niceBackendFetch("/api/v1/users", {
@@ -172,7 +173,8 @@ it("list users includes anonymous users when requested", async ({ expect }) => {
 
   // Create a regular user
   await bumpEmailAddress();
-  await Auth.Password.signUpWithEmail();
+  // Email delivery is queue-driven and can take tens of seconds in dev/CI; this test only needs the user record.
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // List users with include_anonymous=true
   const listRes = await niceBackendFetch("/api/v1/users?include_anonymous=true", {


### PR DESCRIPTION
Two intermittent e2e failures on `dev` CI, both caused by test-harness assumptions rather than product bugs.

### 1. `payments-perf.test.ts`: `expected 401 to be 200` in the server-key grant loop

`niceBackendFetch` attaches the context user's `x-stack-access-token` to *every* request, including `accessType: "server"` ones, and dev/CI sets `HEXCLAVE_ACCESS_TOKEN_EXPIRATION_TIME=60s`. Once a test spends >60s between signing a user up and its next request, the backend rejects that stale token with `ACCESS_TOKEN_EXPIRED` (401) even though the secret server key is perfectly valid. On a loaded runner the benchmark's purchase phases cross the 60s mark before the grant loop, so the first grant 401s.

Fix: `niceBackendFetch` now refreshes the context user's access token via `/auth/sessions/current/refresh` when it is expired/about to expire, like a real client would. It only applies when both an access token and a refresh token are in the context (never for an explicit `userAuth` override), ignores non-JWT placeholder tokens, cannot recurse, and leaves the auth untouched if the refresh fails — so tests that intentionally observe expired/invalid tokens keep working.

Repro: forcing a 65s gap before the grant loop reproduces the exact 401 (`code: "ACCESS_TOKEN_EXPIRED"`); with the change the same test passes.

### 2. `anonymous-comprehensive.test.ts`: `Test timed out in 60000ms` on "list users includes anonymous users when requested"

Not the list-users query: in the failing CI run those requests took 14–150ms, and the failing test's tenancy never issued the list request at all — it hung after a successful `POST /auth/password/sign-up`. The only thing in between is `signUpWithEmail()`'s wait for the verification email, and email delivery in dev/CI is queue-driven (`run-email-queue` → `email-queue-step`, ~1 email per step, step duration p50 4.7s / p90 8.6s / max 29s in that run), so the wait can consume the whole 60s test budget. Locally the mailbox wait is already ~3.5s of a ~4.7s test.

Fix: the two tests that create a regular user *only* so it shows up in a list no longer wait for the verification email (`noWaitForEmail: true`). Nothing else in them touches the email or verification state.

Repro: pausing the mail container makes the test fail with exactly `Test timed out in 60000ms` and no list request; with the change both tests pass in ~4s while mail delivery is still stalled.

No timeouts were raised and no product code changed.

Measured separately while ruling out the query hypothesis (pre-existing, not addressed here): listing a 50k-user tenancy without `limit` fails with a Prisma bind-parameter error, and unlimited list responses get slow well before that (~2.4s at 10k users). Happy to file that separately.


Link to Devin session: https://app.devin.ai/sessions/6d6f38260c154fbcbabe34b93d1c57ef
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two backend e2e flakes by refreshing expiring user tokens in the test harness and skipping email waits in list-users tests. No product code changed.

- **Bug Fixes**
  - `niceBackendFetch`: auto-refreshes the context access token via `/api/v1/auth/sessions/current/refresh` when near expiry, only if no `userAuth` override and both access/refresh tokens are present; prevents `ACCESS_TOKEN_EXPIRED` 401s after >60s gaps in dev/CI.
  - `anonymous-comprehensive.test.ts`: uses `signUpWithEmail({ noWaitForEmail: true })` for tests that only need the user record; avoids 60s timeouts caused by queued email delivery.

<sup>Written for commit 3f692415b0c449c929e32bcb24a0630173d91b8e. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1861?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved authentication reliability by refreshing access credentials before they expire, helping prevent unexpected sign-in interruptions.
  * Improved anonymous account creation flow validation by avoiding unnecessary delays during email-related processing.
* **Tests**
  * Updated automated coverage to better verify authentication and anonymous sign-up behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->