### PR TITLE
Fix lost updates from reordered underlying writes in the instant-availability store

### DIFF
--- a/apps/backend/src/app/api/latest/teams/crud.tsx
+++ b/apps/backend/src/app/api/latest/teams/crud.tsx
@@ -138,9 +138,7 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
     });
 
     if (freePlanSubscription != null) {
-      // This is quite slow with current Bulldozer. Let's not block the team creation for this and run asynchronously.
-      // TODO: Run this synchronously once we have bulldozerjs
-      runAsynchronouslyAndWaitUntil(bulldozerWriteSubscription(freePlanSubscription));
+      await bulldozerWriteSubscription(freePlanSubscription);
     }
 
     const result = teamPrismaToCrud(db);

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
@@ -83,6 +83,92 @@ function createSlowSetDatabase() {
   };
 }
 
+function createReorderingSetDatabase() {
+  const committed = new Map<string, ArrayBuffer>();
+  const initialSeq = ["reordering", "initial"] as unknown as DatabaseSeq;
+  const seqToPromise = new Map<DatabaseSeq, Promise<void>>([[initialSeq, Promise.resolve()]]);
+  const callCountWaiters: Array<{ count: number, resolve: () => void }> = [];
+  const combineSeqArgs: DatabaseSeq[][] = [];
+  const setRequiresSeqs: Array<DatabaseSeq | undefined> = [];
+  let setCallCount = 0;
+  let firstSetStartedResolve: (() => void) | undefined;
+  let releaseFirstSet: (() => void) | undefined;
+  const firstSetStarted = new Promise<void>(resolve => {
+    firstSetStartedResolve = resolve;
+  });
+  const store: LowLevelKvStore = {
+    async get(key) {
+      return { buffer: committed.get(text(key)!)?.slice(0) ?? null, seq: initialSeq };
+    },
+    async setAll(entries, setOptions) {
+      setCallCount++;
+      setRequiresSeqs.push(setOptions?.requiresSeq);
+      for (const waiter of callCountWaiters) {
+        if (setCallCount >= waiter.count) waiter.resolve();
+      }
+      callCountWaiters.splice(0, callCountWaiters.length, ...callCountWaiters.filter(waiter => setCallCount < waiter.count));
+      const seq = ["reordering", crypto.randomUUID()] as unknown as DatabaseSeq;
+      let resolveSet!: () => void;
+      const committedPromise = new Promise<void>(resolve => {
+        resolveSet = resolve;
+      });
+      seqToPromise.set(seq, committedPromise);
+      if (setCallCount === 1) {
+        firstSetStartedResolve!();
+        await new Promise<void>(resolve => {
+          releaseFirstSet = resolve;
+        });
+      }
+      for (const { key, value } of entries) committed.set(text(key)!, value.slice(0));
+      resolveSet();
+      return { seq };
+    },
+    async deleteAll() {
+      throw new Error("not implemented");
+    },
+    async compareAndSet() {
+      throw new Error("not implemented");
+    },
+  };
+  const db: LowLevelDatabase = {
+    getDebugInfo() {
+      return { backend: "reordering-test", committed, initialSeq };
+    },
+    declareKvStore: () => store,
+    declareKvDump: () => {
+      throw new Error("not implemented");
+    },
+    async waitUntilAvailable(seq) {
+      await seqToPromise.get(seq);
+    },
+    async waitUntilDurable(seq) {
+      await seqToPromise.get(seq);
+    },
+    async waitUntilReplicated(seq) {
+      await seqToPromise.get(seq);
+    },
+    combineSeqs(...seqs) {
+      combineSeqArgs.push(seqs);
+      return seqs[seqs.length - 1] ?? initialSeq;
+    },
+    async close() {},
+    initialSeq,
+  };
+  return {
+    db,
+    firstSetStarted,
+    releaseFirstSet() {
+      releaseFirstSet!();
+    },
+    waitForSetCallCount(count: number) {
+      if (setCallCount >= count) return Promise.resolve();
+      return new Promise<void>(resolve => callCountWaiters.push({ count, resolve }));
+    },
+    combineSeqArgs: () => combineSeqArgs.map(seqs => [...seqs]),
+    setRequiresSeqs: () => [...setRequiresSeqs],
+  };
+}
+
 describe("instant-availability low-level database", () => {
   it("serves pending writes from memory before the wrapped database is available", async () => {
     const slow = createSlowSetDatabase();
@@ -179,5 +265,43 @@ describe("instant-availability low-level database", () => {
 
     // The stored value must reflect the single winner.
     expect(text((await store.get(buffer("key"))).buffer)).toBe(first.wasSet ? "a" : "b");
+  });
+
+  it("preserves instant-seq order when a prior underlying write is delayed", async () => {
+    const reordering = createReorderingSetDatabase();
+    const db = declareInstantAvailabilityLowLevelDatabase(reordering.db, { dbId: "instant-reordering-test" });
+    const store = db.declareKvStore("store");
+
+    const dependency = await store.setAll([{ key: buffer("dependency"), value: buffer("dependency") }]);
+    await reordering.firstSetStarted;
+    const requiresSeq = dependency.seq;
+    const oldWritePromise = store.setAll([{ key: buffer("key"), value: buffer("old") }], { requiresSeq });
+    const newWritePromise = store.setAll([{ key: buffer("key"), value: buffer("new") }]);
+    await new Promise(resolve => setTimeout(resolve, 10));
+    reordering.releaseFirstSet();
+    await reordering.waitForSetCallCount(2);
+    const [{ seq: oldSeq }, { seq: newSeq }] = await Promise.all([oldWritePromise, newWritePromise]);
+    await Promise.all([db.waitUntilAvailable(oldSeq), db.waitUntilAvailable(newSeq)]);
+    expect(text((await store.get(buffer("key"))).buffer)).toBe("new");
+  });
+
+  it("chains the prior underlying sequence into the next wrapped write", async () => {
+    const reordering = createReorderingSetDatabase();
+    const db = declareInstantAvailabilityLowLevelDatabase(reordering.db, { dbId: "instant-reordering-chain-test" });
+    const store = db.declareKvStore("store");
+
+    const previous = await store.setAll([{ key: buffer("previous"), value: buffer("value") }]);
+    await reordering.firstSetStarted;
+    reordering.releaseFirstSet();
+    await db.waitUntilAvailable(previous.seq);
+
+    const next = await store.setAll([{ key: buffer("next"), value: buffer("value") }]);
+    await reordering.waitForSetCallCount(2);
+    await db.waitUntilAvailable(next.seq);
+
+    const combineSeqArgs = reordering.combineSeqArgs();
+    expect(combineSeqArgs).toHaveLength(1);
+    expect(combineSeqArgs[0]).toHaveLength(2);
+    expect(reordering.setRequiresSeqs()[1]).toBe(combineSeqArgs[0][1]);
   });
 });

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.test.ts
@@ -90,6 +90,7 @@ function createReorderingSetDatabase() {
   const callCountWaiters: Array<{ count: number, resolve: () => void }> = [];
   const combineSeqArgs: DatabaseSeq[][] = [];
   const setRequiresSeqs: Array<DatabaseSeq | undefined> = [];
+  const underlyingSeqs: DatabaseSeq[] = [];
   let setCallCount = 0;
   let firstSetStartedResolve: (() => void) | undefined;
   let releaseFirstSet: (() => void) | undefined;
@@ -108,6 +109,7 @@ function createReorderingSetDatabase() {
       }
       callCountWaiters.splice(0, callCountWaiters.length, ...callCountWaiters.filter(waiter => setCallCount < waiter.count));
       const seq = ["reordering", crypto.randomUUID()] as unknown as DatabaseSeq;
+      underlyingSeqs.push(seq);
       let resolveSet!: () => void;
       const committedPromise = new Promise<void>(resolve => {
         resolveSet = resolve;
@@ -166,6 +168,7 @@ function createReorderingSetDatabase() {
     },
     combineSeqArgs: () => combineSeqArgs.map(seqs => [...seqs]),
     setRequiresSeqs: () => [...setRequiresSeqs],
+    underlyingSeqs: () => [...underlyingSeqs],
   };
 }
 
@@ -302,6 +305,7 @@ describe("instant-availability low-level database", () => {
     const combineSeqArgs = reordering.combineSeqArgs();
     expect(combineSeqArgs).toHaveLength(1);
     expect(combineSeqArgs[0]).toHaveLength(2);
+    expect(combineSeqArgs[0][1]).toBe(reordering.underlyingSeqs()[0]);
     expect(reordering.setRequiresSeqs()[1]).toBe(combineSeqArgs[0][1]);
   });
 });

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -140,6 +140,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
   };
   const declareStoreOrDump = (wrappedStore: LowLevelKvStore & LowLevelKvDump): LowLevelKvStore & LowLevelKvDump => {
     const cachedValues = new Map<string, CachedValue>();
+    let lastWriteSeq: DatabaseSeq | undefined;
     cacheMaps.add(cachedValues);
     const attributes = { "bulldozer.low_level.backend": "instant-availability" };
     const cacheKey = (key: ArrayBuffer) => encodeBase64(new Uint8Array(key));
@@ -156,15 +157,32 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
         })
         .catch(() => {});
     };
+    const waitForPreviousWriteToBeIssued = async (previousWriteSeq: DatabaseSeq | undefined) => {
+      if (previousWriteSeq === undefined) return;
+      // Same-key underlying writes must be issued in instant-seq order; otherwise an evicted cache entry exposes and persists the older value.
+      await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => {});
+    };
+    const getPreviousUnderlyingSeq = async (previousWriteSeq: DatabaseSeq | undefined) => {
+      if (previousWriteSeq === undefined) return undefined;
+      return await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => undefined);
+    };
 
     const setAllLocked = (entries: Array<{ key: ArrayBuffer, value: ArrayBuffer }>, setOptions?: { requiresSeq?: DatabaseSeq }): { seq: DatabaseSeq } => {
       const entriesForWrapped = entries.map(({ key, value }) => ({ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }));
+      const previousWriteSeq = lastWriteSeq;
       const underlyingSeq = (async () => {
+        await waitForPreviousWriteToBeIssued(previousWriteSeq);
         const requiresSeq = await getUnderlyingSeq(setOptions?.requiresSeq);
-        const { seq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq });
+        const previousUnderlyingSeq = await getPreviousUnderlyingSeq(previousWriteSeq);
+        const chainedRequiresSeq = previousUnderlyingSeq === undefined
+          ? requiresSeq
+          : wrapped.combineSeqs(requiresSeq, previousUnderlyingSeq);
+        // The chained dependency deliberately propagates prior commit failures so later writes cannot overtake a failed predecessor.
+        const { seq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq: chainedRequiresSeq });
         return seq;
       })();
       const seq = createSeq(underlyingSeq);
+      lastWriteSeq = seq;
       for (const { key, value } of entries) setCachedValue(key, value, seq);
       evictAfterWrappedAvailability(entries.map(({ key }) => key), seq);
       return { seq };
@@ -198,11 +216,15 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
           if (keys.length === 0) return { seq: initialSeq };
           return await withWriteGate(async () => {
             const keysForWrapped = keys.map(cloneArrayBuffer);
+            const previousWriteSeq = lastWriteSeq;
             const underlyingSeq = (async () => {
+              await waitForPreviousWriteToBeIssued(previousWriteSeq);
+              await getSeqRecord(previousWriteSeq).underlyingAvailable;
               const { seq } = await wrappedStore.deleteAll(keysForWrapped);
               return seq;
             })();
             const seq = createSeq(underlyingSeq);
+            lastWriteSeq = seq;
             for (const key of keys) setCachedValue(key, null, seq);
             evictAfterWrappedAvailability(keys, seq);
             return { seq };
@@ -217,6 +239,7 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
             const requiresSeq = await getUnderlyingSeq(insertOptions?.requiresSeq);
             const { keys, seq: underlyingInsertSeq } = await wrappedStore.insertAll(valuesForWrapped, { requiresSeq });
             const seq = createSeq(Promise.resolve(underlyingInsertSeq));
+            lastWriteSeq = seq;
             keys.forEach((key, index) => setCachedValue(key, values[index], seq));
             evictAfterWrappedAvailability(keys, seq);
             return { keys: keys.map(cloneArrayBuffer), seq };

--- a/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
+++ b/apps/bulldozer-js/src/databases/low-level/implementations/instant-availability.ts
@@ -157,26 +157,18 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
         })
         .catch(() => {});
     };
-    const waitForPreviousWriteToBeIssued = async (previousWriteSeq: DatabaseSeq | undefined) => {
-      if (previousWriteSeq === undefined) return;
+    const chainRequiresSeq = async (previousWriteSeq: DatabaseSeq | undefined, requiresSeq: DatabaseSeq): Promise<DatabaseSeq> => {
+      if (previousWriteSeq === undefined) return requiresSeq;
       // Same-key underlying writes must be issued in instant-seq order; otherwise an evicted cache entry exposes and persists the older value.
-      await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => {});
-    };
-    const getPreviousUnderlyingSeq = async (previousWriteSeq: DatabaseSeq | undefined) => {
-      if (previousWriteSeq === undefined) return undefined;
-      return await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => undefined);
+      const previousUnderlyingSeq = await getSeqRecord(previousWriteSeq).underlyingSeq.catch(() => undefined);
+      return previousUnderlyingSeq === undefined ? requiresSeq : wrapped.combineSeqs(requiresSeq, previousUnderlyingSeq);
     };
 
     const setAllLocked = (entries: Array<{ key: ArrayBuffer, value: ArrayBuffer }>, setOptions?: { requiresSeq?: DatabaseSeq }): { seq: DatabaseSeq } => {
       const entriesForWrapped = entries.map(({ key, value }) => ({ key: cloneArrayBuffer(key), value: cloneArrayBuffer(value) }));
       const previousWriteSeq = lastWriteSeq;
       const underlyingSeq = (async () => {
-        await waitForPreviousWriteToBeIssued(previousWriteSeq);
-        const requiresSeq = await getUnderlyingSeq(setOptions?.requiresSeq);
-        const previousUnderlyingSeq = await getPreviousUnderlyingSeq(previousWriteSeq);
-        const chainedRequiresSeq = previousUnderlyingSeq === undefined
-          ? requiresSeq
-          : wrapped.combineSeqs(requiresSeq, previousUnderlyingSeq);
+        const chainedRequiresSeq = await chainRequiresSeq(previousWriteSeq, await getUnderlyingSeq(setOptions?.requiresSeq));
         // The chained dependency deliberately propagates prior commit failures so later writes cannot overtake a failed predecessor.
         const { seq } = await wrappedStore.setAll(entriesForWrapped, { requiresSeq: chainedRequiresSeq });
         return seq;
@@ -218,7 +210,6 @@ export function declareInstantAvailabilityLowLevelDatabase(wrapped: LowLevelData
             const keysForWrapped = keys.map(cloneArrayBuffer);
             const previousWriteSeq = lastWriteSeq;
             const underlyingSeq = (async () => {
-              await waitForPreviousWriteToBeIssued(previousWriteSeq);
               await getSeqRecord(previousWriteSeq).underlyingAvailable;
               const { seq } = await wrappedStore.deleteAll(keysForWrapped);
               return seq;


### PR DESCRIPTION
Fixes a cluster of flaky e2e failures where a successful payments write was immediately followed by a read that saw stale (or permanently missing) Bulldozer-derived state.

Root cause: in the instant-availability low-level database, the wrapped (LMDB) write is issued from an unawaited closure after resolving `requiresSeq`, so two consecutive writes to the same key (the bulldozer snapshot root is rewritten on every mutation) could reach the underlying store out of order — both at issuance time and across LMDB commit batches. LMDB is last-write-wins, so the older root could win; once the newer write's cache entry was evicted, readers and subsequent writers saw the older snapshot, permanently dropping the newer write's data.

Fix: per-store write chaining in the instant-availability wrapper —
- `setAll`/`deleteAll` wait for the previous write's underlying call to be issued before issuing their own, and
- `setAll` additionally chains the previous write's underlying seq into its `requiresSeq` (via `combineSeqs`) so a later write's commit batch cannot overtake an earlier one.

Also makes the internal free-plan subscription dual write on team creation synchronous (resolving the existing TODO), closing a read-after-write hole where the write could land after the team-creation response.

Reproduction/validation: a hammer issuing test-mode purchase → immediate item read against the LMDB-backed dev stack failed 5/600 and 3/600 iterations before the fix (write acknowledged, all derived views empty, no healing), and 0/2400 after. Added regression tests for both the issuance-order and cross-batch cases.

Link to Devin session: https://app.devin.ai/sessions/404ff8e1c9e14be7aecfe3af157afbc6
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes lost updates in the instant-availability store by enforcing per-store write ordering and chaining prior underlying sequences so later writes can’t overtake earlier ones. Also makes the free-plan subscription write synchronous during team creation to close a read-after-write gap.

- **Bug Fixes**
  - Enforce per-store write ordering across `setAll`, `deleteAll` (waits for prior underlying availability), and `insertAll`.
  - Chain the prior underlying seq into `setAll`’s `requiresSeq` via `combineSeqs` so later commits can’t overtake earlier ones, and failures propagate.
  - Await the free-plan subscription write during team creation to prevent late writes after the response.

- **Refactors**
  - Collapsed helper logic for write-dependency chaining to simplify sequencing and reduce duplication.

<sup>Written for commit ecb774a49969088f8067cd354e235363bb3d0b69. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1863?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Improved data consistency by ensuring rapid updates to the same data source are processed in the correct order.
  - Prevented deletions from occurring before preceding writes are safely completed.
  - Improved error handling when an earlier write fails.
  - Team creation now reliably completes free-plan subscription setup before continuing.

- **Tests**
  - Added coverage for delayed and reordered write scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->