### PR TITLE
fix(e2e): stop the analytics free-plan entitlement race and the passkey email-wait timeout

### DIFF
--- a/apps/backend/src/app/api/latest/teams/crud.tsx
+++ b/apps/backend/src/app/api/latest/teams/crud.tsx
@@ -138,9 +138,12 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
     });
 
     if (freePlanSubscription != null) {
-      // This is quite slow with current Bulldozer. Let's not block the team creation for this and run asynchronously.
-      // TODO: Run this synchronously once we have bulldozerjs
-      runAsynchronouslyAndWaitUntil(bulldozerWriteSubscription(freePlanSubscription));
+      // Keep the write after the transaction commits so Bulldozer only receives a
+      // subscription row that is durable in Prisma. Bulldozer's initial
+      // subscription grant cascades synchronously through its materialized item
+      // quantities, so awaiting this write makes billing-gated endpoints ready
+      // when team creation returns.
+      await bulldozerWriteSubscription(freePlanSubscription);
     }
 
     const result = teamPrismaToCrud(db);

--- a/apps/backend/src/app/api/latest/teams/crud.tsx
+++ b/apps/backend/src/app/api/latest/teams/crud.tsx
@@ -13,7 +13,7 @@ import { KnownErrors } from "@hexclave/shared";
 import { teamsCrud } from "@hexclave/shared/dist/interface/crud/teams";
 import { userIdOrMeSchema, yupNumber, yupObject, yupString } from "@hexclave/shared/dist/schema-fields";
 import { validateBase64Image } from "@hexclave/shared/dist/utils/base64";
-import { StatusError, throwErr } from "@hexclave/shared/dist/utils/errors";
+import { captureError, StatusError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { getOrUndefined } from "@hexclave/shared/dist/utils/objects";
 import { createLazyProxy } from "@hexclave/shared/dist/utils/proxies";
 import { isUuid } from "@hexclave/shared/dist/utils/uuids";
@@ -142,8 +142,14 @@ export const teamsCrudHandlers = createLazyProxy(() => createCrudHandlers(teamsC
       // subscription row that is durable in Prisma. Bulldozer's initial
       // subscription grant cascades synchronously through its materialized item
       // quantities, so awaiting this write makes billing-gated endpoints ready
-      // when team creation returns.
-      await bulldozerWriteSubscription(freePlanSubscription);
+      // when team creation returns. A failed write must not fail team creation:
+      // the committed subscription row is reconciled by the next sync or webhook,
+      // and the failure is captured in Sentry.
+      try {
+        await bulldozerWriteSubscription(freePlanSubscription);
+      } catch (error) {
+        captureError("bulldozer-free-plan-subscription-write", error);
+      }
     }
 
     const result = teamPrismaToCrud(db);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
@@ -89,7 +89,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Configure wildcard domain that matches our test origin
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -162,7 +162,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const expectedUserId = res.userId;
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
@@ -227,7 +227,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    await Auth.Password.signUpWithEmail();
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Configure exact domain that doesn't match
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -303,7 +303,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     await Auth.Passkey.register();
     await Auth.signOut();
 
@@ -375,7 +375,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
 


### PR DESCRIPTION
Two more load-dependent e2e flakes on `dev` CI.

### 1. `analytics-query.test.ts`: `ITEM_QUANTITY_INSUFFICIENT_AMOUNT` on a fresh project

Team creation grants the free plan in the team's transaction, but the Bulldozer write that materializes the item quantities was fired asynchronously (`runAsynchronouslyAndWaitUntil`). Until it lands, `getItem(analytics_timeout_seconds)` reads `0`, so an analytics query right after project creation 400s. The e2e `waitForBillingTeamPlanEntitlement` mitigation is best-effort (caps at half the test budget), so a backed-up write on a loaded runner still flakes.

Fix: `await bulldozerWriteSubscription(...)` in team creation, per the existing TODO ("Run this synchronously once we have bulldozerjs"). Every other subscription-grant path (products grant/switch, purchase-session) already awaits it, and Bulldozer's initial subscription grant cascades synchronously through item quantities via `withSnapshotReplicated`, so billing-gated endpoints are ready as soon as team creation returns.

Repro: with the write fire-and-forget + a 5s injected delay + the e2e readiness wait bypassed, the analytics route provably read `quantity=0` ~2.5s before the write completed and returned the exact 400 from the flake; with the awaited write the same test passes.

### 2. `passkey/wildcard-domains.test.ts`: `Test timed out in 60000ms`

Same mechanism as #1861's anonymous-comprehensive fix: `signUpWithEmail()` waits for the queued verification email, which none of these five tests use — on a loaded runner that wait can eat the whole 60s budget before the passkey flow even starts. The expected-failure origin-validation path itself has no network fetch or retry loop that could hang.

Fix: `signUpWithEmail({ noWaitForEmail: true })` for all five tests in the file.

### Validation
- `analytics-query.test.ts` (70), `wildcard-domains.test.ts` (7), `teams.test.ts` (30) all pass locally.
- The fixed passkey target test passes with the mail container paused.
- Lint + typecheck pass for `apps/backend` and `apps/e2e`.

No timeouts were raised; only the team-creation write ordering and the test harness changed.

Link to Devin session: https://app.devin.ai/sessions/bd99d05d6cf0490f9ca71cbd457a51a5
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes two flaky e2e tests on CI by awaiting the free‑plan entitlement write during team creation without changing failure semantics, and skipping email waits in passkey tests.

- **Bug Fixes**
  - Await `bulldozerWriteSubscription` after the transaction commits so free‑plan item quantities are ready before analytics queries; prevents `ITEM_QUANTITY_INSUFFICIENT_AMOUNT` on new projects. Failures are captured and do not block team creation.
  - In `passkey/wildcard-domains` tests, use `Auth.Password.signUpWithEmail({ noWaitForEmail: true })` to avoid the 60s verification‑email timeout (five tests).

<sup>Written for commit 7d547b7a0a4476e7a3fafc254de5f5b47cc50730. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1864?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **Bug Fixes**
  - Team creation now ensures subscription billing quantities are updated before completion, while safely handling background processing errors.
  - Improved passkey wildcard-domain test reliability by avoiding unnecessary email waits during account setup.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->