### PR TITLE
Impersonation dialog: inline Impersonate button + always-visible console snippet

### DIFF
--- a/apps/dashboard/src/components/user-dialogs.tsx
+++ b/apps/dashboard/src/components/user-dialogs.tsx
@@ -1,10 +1,10 @@
 import type { StackAdminApp } from "@hexclave/next";
 import { ServerUser } from '@hexclave/next';
-import { ActionDialog, Alert, Button, CopyField, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Typography } from "@/components/ui";
+import { ActionDialog, Alert, Button, CopyField, Input, Select, SelectContent, SelectItem, SelectTrigger, SelectValue, Separator, Spinner, Typography } from "@/components/ui";
 import { generateImpersonateSnippet } from "@hexclave/shared/dist/utils/browser-action-snippets";
 import { throwErr } from "@hexclave/shared/dist/utils/errors";
-import { runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
-import { useEffect, useMemo, useState } from "react";
+import { runAsynchronously, runAsynchronouslyWithAlert } from "@hexclave/shared/dist/utils/promises";
+import { useEffect, useMemo, useRef, useState } from "react";
 import { openBrowserActionInNewTab } from "@/lib/browser-actions";
 import { getTrustedOriginOptions, normalizeTrustedOrigin } from "@/lib/trusted-origins";
 import { Link } from './link';
@@ -69,6 +69,13 @@ export function ImpersonateUserDialog(props: {
   const [selectedOrigin, setSelectedOrigin] = useState("");
   const [customOrigin, setCustomOrigin] = useState("");
   const [fallbackSnippet, setFallbackSnippet] = useState<string | null>(null);
+  const [fallbackSnippetLoading, setFallbackSnippetLoading] = useState(false);
+  const [fallbackSnippetError, setFallbackSnippetError] = useState<string | null>(null);
+  const snippetRequestGeneration = useRef(0);
+  const userRef = useRef(props.user);
+  const adminAppRef = useRef(props.adminApp);
+  userRef.current = props.user;
+  adminAppRef.current = props.adminApp;
   const canUseCustomOrigin = config.domains.allowLocalhost;
 
   useEffect(() => {
@@ -78,8 +85,39 @@ export function ImpersonateUserDialog(props: {
   useEffect(() => {
     if (!props.open) {
       setFallbackSnippet(null);
+      setFallbackSnippetError(null);
+      setFallbackSnippetLoading(false);
+      return;
     }
-  }, [props.open]);
+    const requestGeneration = snippetRequestGeneration.current + 1;
+    snippetRequestGeneration.current = requestGeneration;
+    setFallbackSnippet(null);
+    setFallbackSnippetError(null);
+    setFallbackSnippetLoading(true);
+    runAsynchronously((async () => {
+      const expiresInMillis = 2 * 60 * 60 * 1000;
+      const session = await userRef.current.createSession({ expiresInMillis, isImpersonation: true });
+      const tokens = await session.getTokens();
+      if (snippetRequestGeneration.current === requestGeneration) {
+        setFallbackSnippet(generateImpersonateSnippet(
+          adminAppRef.current.projectId,
+          tokens.refreshToken ?? throwErr("Expected refresh token for newly created impersonation session"),
+          new Date(Date.now() + expiresInMillis),
+        ));
+        setFallbackSnippetLoading(false);
+      }
+    })(), {
+      onError: (error) => {
+        if (snippetRequestGeneration.current === requestGeneration) {
+          setFallbackSnippetError(error.message);
+          setFallbackSnippetLoading(false);
+        }
+      },
+    });
+    return () => {
+      snippetRequestGeneration.current = requestGeneration + 1;
+    };
+  }, [props.open, props.user.id]);
 
   async function openBrowserAction() {
     const origin = normalizeTrustedOrigin(customOrigin.trim() || selectedOrigin);
@@ -98,17 +136,6 @@ export function ImpersonateUserDialog(props: {
     }
   }
 
-  async function createFallbackSnippet() {
-    const expiresInMillis = 2 * 60 * 60 * 1000;
-    const session = await props.user.createSession({ expiresInMillis, isImpersonation: true });
-    const tokens = await session.getTokens();
-    setFallbackSnippet(generateImpersonateSnippet(
-      props.adminApp.projectId,
-      tokens.refreshToken ?? throwErr("Expected refresh token for newly created impersonation session"),
-      new Date(Date.now() + expiresInMillis),
-    ));
-  }
-
   return (
     <ActionDialog
       open={props.open}
@@ -116,11 +143,6 @@ export function ImpersonateUserDialog(props: {
       title="Impersonate User"
       description="Open a trusted website with a short-lived impersonation action."
       cancelButton
-      okButton={origins.length > 0 || canUseCustomOrigin ? {
-        label: "Impersonate",
-        onClick: openBrowserAction,
-        props: { disabled: selectedOrigin === "" && customOrigin.trim() === "" },
-      } : undefined}
     >
       <div className="space-y-4">
         {origins.length === 0 && !canUseCustomOrigin ? (
@@ -132,32 +154,66 @@ export function ImpersonateUserDialog(props: {
             {origins.length > 0 && (
               <>
                 <Typography>Select the website where the impersonated session should open.</Typography>
-                <Select value={selectedOrigin} onValueChange={setSelectedOrigin}>
-                  <SelectTrigger>
-                    <SelectValue placeholder="Select a trusted website" />
-                  </SelectTrigger>
-                  <SelectContent>
-                    {origins.map((origin) => <SelectItem key={origin.id} value={origin.origin}>{origin.origin}</SelectItem>)}
-                  </SelectContent>
-                </Select>
+                <div className="flex flex-col gap-2 sm:flex-row">
+                  <Select value={selectedOrigin} onValueChange={setSelectedOrigin}>
+                    <SelectTrigger className="min-w-0 flex-1">
+                      <SelectValue placeholder="Select a trusted website" />
+                    </SelectTrigger>
+                    <SelectContent>
+                      {origins.map((origin) => <SelectItem key={origin.id} value={origin.origin}>{origin.origin}</SelectItem>)}
+                    </SelectContent>
+                  </Select>
+                  <Button
+                    onClick={openBrowserAction}
+                    disabled={selectedOrigin === "" && customOrigin.trim() === ""}
+                  >
+                    Impersonate
+                  </Button>
+                </div>
               </>
             )}
             {canUseCustomOrigin && (
-              <Input
-                value={customOrigin}
-                onChange={(event) => setCustomOrigin(event.target.value)}
-                placeholder="Exact website address, e.g. http://localhost:5173"
-              />
+              <div className="flex flex-col gap-2 sm:flex-row">
+                <Input
+                  className="min-w-0 flex-1"
+                  value={customOrigin}
+                  onChange={(event) => setCustomOrigin(event.target.value)}
+                  placeholder="Exact website address, e.g. http://localhost:5173"
+                />
+                {origins.length === 0 && (
+                  <Button
+                    onClick={openBrowserAction}
+                    disabled={selectedOrigin === "" && customOrigin.trim() === ""}
+                  >
+                    Impersonate
+                  </Button>
+                )}
+              </div>
             )}
           </>
         )}
-        {fallbackSnippet == null ? (
-          <Button variant="secondary" onClick={async () => await createFallbackSnippet()}>
-            Copy console snippet instead
-          </Button>
-        ) : (
+        <div className="flex items-center justify-center">
+          <div className="flex-1">
+            <Separator />
+          </div>
+          <div className="mx-2 text-sm text-muted-foreground">OR</div>
+          <div className="flex-1">
+            <Separator />
+          </div>
+        </div>
+        <Typography variant="secondary" className="text-sm">
+          Paste this snippet into the browser console on your app.
+        </Typography>
+        {fallbackSnippetLoading ? (
+          <div className="flex items-center justify-center gap-2 text-sm text-muted-foreground">
+            <Spinner />
+            Generating console snippet…
+          </div>
+        ) : fallbackSnippetError != null ? (
+          <Alert variant="destructive">{fallbackSnippetError}</Alert>
+        ) : fallbackSnippet != null ? (
           <CopyField type="textarea" monospace height={100} value={fallbackSnippet} isSecret />
-        )}
+        ) : null}
       </div>
     </ActionDialog>
   );

--- a/apps/dashboard/src/components/user-dialogs.tsx
+++ b/apps/dashboard/src/components/user-dialogs.tsx
@@ -164,7 +164,9 @@ export function ImpersonateUserDialog(props: {
                     </SelectContent>
                   </Select>
                   <Button
-                    onClick={openBrowserAction}
+                    onClick={async () => {
+                      await openBrowserAction();
+                    }}
                     disabled={selectedOrigin === "" && customOrigin.trim() === ""}
                   >
                     Impersonate
@@ -182,7 +184,9 @@ export function ImpersonateUserDialog(props: {
                 />
                 {origins.length === 0 && (
                   <Button
-                    onClick={openBrowserAction}
+                    onClick={async () => {
+                      await openBrowserAction();
+                    }}
                     disabled={selectedOrigin === "" && customOrigin.trim() === ""}
                   >
                     Impersonate


### PR DESCRIPTION
Restructures `ImpersonateUserDialog`:

- The `Impersonate` action moves out of the dialog footer and sits next to the trusted-domain dropdown (or next to the custom-origin input when there are no trusted domains).
- Below it, an `OR` separator and the console snippet directly, with an instruction to paste it into the browser console — replacing the previous "Copy console snippet instead" button.

Because the snippet is now shown directly, the impersonation session is created eagerly when the dialog opens (spinner while generating, `Alert` on failure). The effect is keyed on `open` + `user.id` and reads the SDK objects through refs so parent re-renders can't create extra sessions.


Link to Devin session: https://app.devin.ai/sessions/a802b7108fd44453b548d847648e42d5
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Reworked the impersonation dialog to inline the Impersonate action and always show the console snippet, making both paths clearer and faster. The dialog creates an impersonation session on open with loading and error states.

- **New Features**
  - Moved the Impersonate button next to the trusted-domain dropdown or custom-origin input; removed the dialog OK button.
  - Always shows a console snippet with instructions and an OR separator; removed the “Copy console snippet instead” button.
  - Creates the impersonation session on open; shows a `Spinner` while generating and an `Alert` on failure.

- **Refactors**
  - Effect keyed on `open` and `user.id`, reading SDK objects from refs to prevent duplicate/outdated sessions; guarded with a generation counter.
  - UI and typing polish: responsive field/button layout, `Separator` usage, and fixed Impersonate button onClick typing; imports consolidated from `@hexclave/next` and `@hexclave/shared`.

<sup>Written for commit 0a9934dae05636ffe7422d9083b463288bc03445. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1865?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added inline impersonation actions to browser controls.
  * Added responsive origin and custom-origin input fields.
  * Added clear loading and error states while generating impersonation details.
* **Improvements**
  * Simplified impersonation workflows by removing the manual console-snippet fallback action.
  * Prevented outdated results from appearing after dialogs are closed or refreshed.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->