### PR TITLE
test: skip the signup verification email wait where tests don't need it

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/auth-flows.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth-flows.test.ts
@@ -68,7 +68,7 @@ it("should not be able to sign in with OTP anymore after signing in with passwor
     }
   });
 
-  await Auth.Password.signUpWithEmail({ password: "some-password" });
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "some-password" });
 
   const response2 = await niceBackendFetch("/api/v1/auth/otp/send-sign-in-code", {
     method: "POST",
@@ -125,7 +125,7 @@ it("signs in with password first, then signs in with oauth should give an accoun
   await InternalApiKey.createAndSetProjectKeys(proj.adminAccessToken);
 
 
-  await Auth.Password.signUpWithEmail({ password: "some-password" });
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "some-password" });
   const cc = await ContactChannels.getTheOnlyContactChannel();
   expect(cc.is_verified).toBe(false);
   expect(cc.used_for_auth).toBe(true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-comprehensive.test.ts
@@ -39,7 +39,7 @@ it("anonymous JWT has different kid and role", async ({ expect }) => {
   expect(header.kid).toBeTruthy();
 
   // The kid should be different from regular users
-  const regularSignUp = await Auth.Password.signUpWithEmail();
+  const regularSignUp = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const regularToken = regularSignUp.signUpResponse.body.access_token;
   const [regularHeader] = regularToken.split('.').slice(0, 1).map((part: string) =>
     JSON.parse(Buffer.from(part, 'base64url').toString())
@@ -259,7 +259,7 @@ it("search users excludes anonymous users by default", async ({ expect }) => {
 
   // Create a regular user
   await Auth.signOut();
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Search for users with query matching anonymous user
   const searchRes = await niceBackendFetch("/api/v1/users?query=Unique", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-upgrade.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/anonymous/anonymous-upgrade.test.ts
@@ -150,7 +150,7 @@ it("non-anonymous user sign-up creates new account (does not upgrade)", async ({
   await Project.createAndSwitch();
 
   // Create a regular user
-  const firstUser = await Auth.Password.signUpWithEmail();
+  const firstUser = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const firstUserId = firstUser.userId;
   const firstAccessToken = firstUser.signUpResponse.body.access_token;
 
@@ -227,7 +227,7 @@ it("non-anonymous user sign-up creates new account (does not upgrade)", async ({
 
 it("signing in to an existing account while logged in as anonymous does not upgrade the user", async ({ expect }) => {
   const password = "TestPassword123!";
-  const { userId: existingUserId } = await Auth.Password.signUpWithEmail({ password });
+  const { userId: existingUserId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password });
   await Auth.signOut();
 
   const { accessToken: anonAccessToken, userId: anonUserId } = await Auth.Anonymous.signUp();
@@ -507,7 +507,7 @@ it("cannot upgrade anonymous user to email that already exists", async ({ expect
   // Create a regular user with an email
   await bumpEmailAddress();
   const existingEmail = backendContext.value.mailbox.emailAddress;
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create an anonymous user
   const anonSignUp = await Auth.Anonymous.signUp();

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/email-normalization.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/email-normalization.test.ts
@@ -32,6 +32,7 @@ it("password sign-in should work with normalized email when account was created 
 
   backendContext.set({ mailbox: createMailbox(uppercaseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -68,6 +69,7 @@ it("password sign-in should work with unnormalized email when account was create
 
   backendContext.set({ mailbox: createMailbox(normalizedEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -153,6 +155,7 @@ it("password reset should work with normalized email when account was created wi
 
   backendContext.set({ mailbox: createMailbox(uppercaseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -228,6 +231,7 @@ it("password reset should work with unnormalized email when account was created 
 
   backendContext.set({ mailbox: createMailbox(normalizedEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);
@@ -297,6 +301,7 @@ it("should not allow duplicate accounts with same normalized email", async ({ ex
 
   backendContext.set({ mailbox: createMailbox(email1) });
   const signUpRes1 = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password: password1,
   });
   expect(signUpRes1.signUpResponse.status).toBe(200);
@@ -351,6 +356,7 @@ it("case-insensitive email should work for sign in even with mixed case variatio
   // Create account
   backendContext.set({ mailbox: createMailbox(baseEmail) });
   const signUpRes = await Auth.Password.signUpWithEmail({
+    noWaitForEmail: true,
     password,
   });
   expect(signUpRes.signUpResponse.status).toBe(200);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/mfa/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/mfa/sign-in.test.ts
@@ -3,7 +3,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should sign in users with MFA enabled", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail();
+  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const signInRes = await niceBackendFetch("/api/v1/auth/password/sign-in", {
@@ -64,7 +64,7 @@ it("should sign in users with MFA enabled", async ({ expect }) => {
 });
 
 it("should reject invalid attempt codes", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail();
+  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const totp = generateTOTP(totpSecret, 30, 6);
@@ -94,7 +94,7 @@ it("should reject invalid attempt codes", async ({ expect }) => {
 
 
 it("should reject invalid totp codes", async ({ expect }) => {
-  const passwordRes = await Auth.Password.signUpWithEmail();
+  const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const { totpSecret } = await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
   const signInRes = await niceBackendFetch("/api/v1/auth/password/sign-in", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/merge-strategy.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/oauth/merge-strategy.test.ts
@@ -116,7 +116,7 @@ it("should not merge accounts if the merge strategy is set to link_method, but t
   });
   await InternalApiKey.createAndSetProjectKeys(proj.adminAccessToken);
 
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const cc = await ContactChannels.getTheOnlyContactChannel();
   expect(cc.is_verified).toBe(false);
   expect(cc.used_for_auth).toBe(true);

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/sign-in.test.ts
@@ -6,7 +6,7 @@ import { Auth, niceBackendFetch, Project } from "../../../../../backend-helpers"
 
 it("should allow initiating passkey authentication", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true, magic_link_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch("/api/v1/auth/passkey/initiate-passkey-authentication", {
     method: "POST",
     accessType: "client",
@@ -34,7 +34,7 @@ it("should allow initiating passkey authentication", async ({ expect }) => {
 
 it("should successfully sign in with a passkey", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   const expectedUserId = res.userId;
   await Auth.Passkey.register();
@@ -87,7 +87,7 @@ it("should successfully sign in with a passkey", async ({ expect }) => {
 
 it("should fail if passkey does not exist", async ({ expect }) => {
   await Project.createAndSwitch({ config: { passkey_enabled: true } });
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.Passkey.register();
   const response_initiation = await niceBackendFetch("/api/v1/auth/passkey/initiate-passkey-authentication", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/passkey/wildcard-domains.test.ts
@@ -89,7 +89,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Configure wildcard domain that matches our test origin
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -162,7 +162,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const expectedUserId = res.userId;
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
@@ -227,7 +227,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up a user first
-    await Auth.Password.signUpWithEmail();
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Configure exact domain that doesn't match
     const configResponse = await niceBackendFetch("/api/v1/internal/config/override/environment", {
@@ -303,7 +303,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     await Auth.Passkey.register();
     await Auth.signOut();
 
@@ -375,7 +375,7 @@ describe("Passkey with wildcard domains", () => {
     await InternalApiKey.createAndSetProjectKeys();
 
     // Sign up and register passkey with default localhost allowed
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     await Auth.Passkey.register(); // This uses http://localhost:8103
     await Auth.signOut();
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/reset.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/reset.test.ts
@@ -33,7 +33,7 @@ async function getResetCode() {
 
 
 it("should reset the password", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const resetCode = await getResetCode();
   const response = await niceBackendFetch("/api/v1/auth/password/reset", {
@@ -81,7 +81,7 @@ it("should set a password if signed up with magic link", async ({ expect }) => {
 });
 
 it("should not reset the password if it's too weak", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const resetCode = await getResetCode();
   const response = await niceBackendFetch("/api/v1/auth/password/reset", {
@@ -109,7 +109,7 @@ it("should not reset the password if it's too weak", async ({ expect }) => {
 });
 
 it("should be able to check the password reset code without using it", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const resetCode = await getResetCode();
   const checkResponse1 = await niceBackendFetch("/api/v1/auth/password/reset/check-code", {
@@ -164,7 +164,7 @@ it("should be able to check the password reset code without using it", async ({ 
 });
 
 it("should return USER_NOT_FOUND if the user was deleted after the reset code was sent", async ({ expect }) => {
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const resetCode = await getResetCode();
   const deleteResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/send-reset-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/send-reset-code.test.ts
@@ -84,7 +84,7 @@ it("should send a password reset code even if the user signed up with magic link
 });
 
 it('should not send a password reset code if the redirect URL is invalid', async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const mailbox = backendContext.value.mailbox;
   const response = await niceBackendFetch("/api/v1/auth/password/send-reset-code", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/set.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/set.test.ts
@@ -23,7 +23,7 @@ it("should set password", async ({ expect }) => {
 });
 
 it("is not allowed to set password if user already has a password", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   const response = await niceBackendFetch("/api/v1/auth/password/set", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-in.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-in.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("should allow signing in to existing accounts", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   backendContext.set({ userAuth: null });
   await Auth.expectToBeSignedOut();
   const res2 = await Auth.Password.signInWithEmail({ password: res.password });
@@ -81,7 +81,7 @@ it("should not allow signing in with an e-mail that never signed up", async ({ e
 });
 
 it("should not allow signing in with an incorrect password", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch("/api/v1/auth/password/sign-in", {
     method: "POST",
     accessType: "client",
@@ -106,7 +106,7 @@ it("should not allow signing in with an incorrect password", async ({ expect }) 
 });
 
 it("should not allow signing in when MFA is required", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.Mfa.setupTotpMfa();
   await Auth.signOut();
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/password/sign-up.test.ts
@@ -126,7 +126,7 @@ it("should not sign up new users if verification callback url is not valid", asy
 });
 
 it("should not allow signing up with an e-mail that already exists", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const res2 = await niceBackendFetch("/api/v1/auth/password/sign-up", {
     method: "POST",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/index.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/index.test.ts
@@ -85,7 +85,7 @@ it("should not crash when deleting a session that was already deleted by a bulk 
 });
 
 it("should sign out users", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.expectToBeSignedIn();
   const res = await Auth.signOut();
   expect(res.signOutResponse).toMatchInlineSnapshot(`
@@ -116,7 +116,7 @@ it("should sign out users", async ({ expect }) => {
 });
 
 it("should sign out user without refresh token, only using access token", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch("/api/v1/auth/sessions/current", {
     method: "DELETE",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/current/refresh.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../../../backend-helpers";
 
 it("should refresh sessions", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   backendContext.set({ userAuth: { ...backendContext.value.userAuth, accessToken: undefined } });
   await Auth.expectSessionToBeValid();
   const refreshSessionResponse = await niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
@@ -22,7 +22,7 @@ it("should refresh sessions", async ({ expect }) => {
 });
 
 it("should not refresh sessions given invalid refresh tokens", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const refreshSessionResponse = await niceBackendFetch("/api/v1/auth/sessions/current/refresh", {
     method: "POST",
     accessType: "client",
@@ -48,7 +48,7 @@ it("should not refresh sessions given invalid refresh tokens", async ({ expect }
 it.todo("should not refresh sessions of other projects");
 
 it("should not refresh sessions when user has been deleted", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // delete the user
   const response = await niceBackendFetch("/api/v1/users/me", {
@@ -84,7 +84,7 @@ it("should not refresh sessions when user has been deleted", async ({ expect }) 
 
 it("should not refresh revoked sessions", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create an additional session for the user
   const additionalSession = await niceBackendFetch("/api/v1/auth/sessions", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/index.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sessions/index.test.ts
@@ -4,7 +4,7 @@ import { it } from "../../../../../../helpers";
 import { Auth, backendContext, createMailbox, niceBackendFetch } from "../../../../../backend-helpers";
 
 it("cannot create sessions from the client", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "client",
     method: "POST",
@@ -36,7 +36,7 @@ it("cannot create sessions from the client", async ({ expect }) => {
 });
 
 it("creates sessions for existing users", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   backendContext.set({ userAuth: null });
   await Auth.expectToBeSignedOut();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -59,7 +59,7 @@ it("creates sessions for existing users", async ({ expect }) => {
 });
 
 it("creates sessions that expire", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.expectToBeSignedIn();
   const beginDate = new Date();
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -133,7 +133,7 @@ it("creates sessions that expire", async ({ expect }) => {
 });
 
 it("cannot create sessions with an expiry date larger than a year away", async ({ expect }) => {
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const res2 = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "server",
     method: "POST",
@@ -168,7 +168,7 @@ it("cannot create sessions with an expiry date larger than a year away", async (
 
 it("can delete sessions as client", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const additionalSession = await niceBackendFetch("/api/v1/auth/sessions", {
     accessType: "server",
     method: "POST",
@@ -217,7 +217,7 @@ it("can delete sessions as client", async ({ expect }) => {
 
 it("cannot delete current session as client", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // List sessions to get the current session ID
   const listResponse = await niceBackendFetch("/api/v1/auth/sessions", {
@@ -323,7 +323,7 @@ it("server cannot list sessions without user_id", async ({ expect }) => {
 
 it("impersonation sessions hidden for non-admin clients and shown for admins", async ({ expect }) => {
   // Create a user and sign up
-  const res = await Auth.Password.signUpWithEmail();
+  const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create an impersonation session for the user
   const impersonationSession = await niceBackendFetch("/api/v1/auth/sessions", {

--- a/apps/e2e/tests/backend/endpoints/api/v1/auth/sign-up-rules.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/auth/sign-up-rules.test.ts
@@ -48,7 +48,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -74,7 +74,7 @@ describe("sign-up rules", () => {
     });
 
     // Sign up with a different email should work
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -173,7 +173,7 @@ describe("sign-up rules", () => {
       'auth.signUpRulesDefaultAction': 'allow',
     });
 
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -815,7 +815,7 @@ describe("sign-up rules", () => {
       'auth.signUpRulesDefaultAction': 'allow',
     });
 
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -1159,7 +1159,7 @@ describe("sign-up rules", () => {
     });
 
     // Password signup should work
-    const passwordRes = await Auth.Password.signUpWithEmail();
+    const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(passwordRes.signUpResponse.status).toBe(200);
   });
 
@@ -1186,7 +1186,7 @@ describe("sign-up rules", () => {
     });
 
     // Password signup should work
-    const passwordRes = await Auth.Password.signUpWithEmail();
+    const passwordRes = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(passwordRes.signUpResponse.status).toBe(200);
   });
 
@@ -2000,7 +2000,7 @@ describe("sign-up rules", () => {
     });
 
     // Should be allowed since rule never matches
-    const res = await Auth.Password.signUpWithEmail();
+    const res = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     expect(res.signUpResponse.status).toBe(200);
   });
 
@@ -2434,7 +2434,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // User should not be restricted initially
     const beforeResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2475,7 +2475,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Restrict without reason or details - should succeed (both are optional)
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2505,7 +2505,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Try to set unrestricted with a reason - should fail
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2527,7 +2527,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Try to set unrestricted with private details - should fail
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {
@@ -2611,7 +2611,7 @@ describe("sign-up rules", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Restrict with reason + details
     const restrictResponse = await niceBackendFetch(`/api/v1/users/${userId}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/connected-accounts.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/connected-accounts.test.ts
@@ -535,7 +535,7 @@ it("should return 400 when trying to get access token for non-existent provider_
 
 it("should return empty list when user has no connected accounts", async ({ expect }) => {
   // Sign in without OAuth (using password)
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   const response = await niceBackendFetch("/api/v1/connected-accounts/me", {
     accessType: "client",
@@ -706,7 +706,7 @@ it("should forbid client access to other users' connected accounts", async ({ ex
 
   // User 2 signs in
   backendContext.set({ mailbox: createMailbox() });
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Try to access user 1's connected accounts as user 2
   const response = await niceBackendFetch(`/api/v1/connected-accounts/${user1Id}`, {
@@ -952,7 +952,7 @@ it("should allow server access to list any user's connected accounts", async ({ 
 
   // User 2 signs in
   backendContext.set({ mailbox: createMailbox() });
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Server can access user 1's connected accounts
   const response = await niceBackendFetch(`/api/v1/connected-accounts/${user1Id}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/legacy-send-verification-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/legacy-send-verification-code.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../helpers";
 import { Auth, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 it("doesn't send a verification code if logged out", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   backendContext.set({ userAuth: null });
   const response = await niceBackendFetch("/api/v1/contact-channels/send-verification-code", {
     method: "POST",

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/send-verification-code.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/send-verification-code.test.ts
@@ -2,7 +2,7 @@ import { it } from "../../../../../helpers";
 import { Auth, ContactChannels, backendContext, niceBackendFetch } from "../../../../backend-helpers";
 
 it("can't send a verification code while logged out", async ({ expect }) => {
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const ccResponse = await niceBackendFetch("/api/v1/contact-channels?user_id=me", {
     method: "GET",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/verify.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/contact-channels/verify.test.ts
@@ -80,7 +80,7 @@ it("each verification code that was already requested can be used exactly once",
 });
 
 it("should not allow verify a code that doesn't exist", async ({ expect }) => {
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch("/api/v1/contact-channels/verify", {
     method: "POST",
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/emails/email-queue.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/emails/email-queue.test.ts
@@ -119,7 +119,7 @@ describe("email queue edge cases", () => {
     });
 
     const mailbox = await bumpEmailAddress();
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Get the contact channel ID
     const contactChannelsResponse = await niceBackendFetch(`/api/v1/contact-channels?user_id=${userId}`, {
@@ -185,7 +185,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     const createDraftResponse = await niceBackendFetch("/api/v1/internal/email-drafts", {
       method: "POST",
@@ -249,7 +249,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Unsubscribe from Marketing first
     await niceBackendFetch(
@@ -333,7 +333,7 @@ describe("email queue edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const sendResponse = await niceBackendFetch("/api/v1/emails/send-email", {
       method: "POST",
       accessType: "server",
@@ -512,7 +512,7 @@ describe("template rendering edge cases", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Create a draft with a subject in the template
     const templateWithSubject = `import { Container } from "@react-email/components";
@@ -569,7 +569,7 @@ export function EmailTemplate({ user, project }: Props) {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Create a draft with a subject in the template
     const templateWithSubject = `import { Container } from "@react-email/components";
@@ -627,7 +627,7 @@ export function EmailTemplate({ user, project }: Props) {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Create a draft without NotificationCategory export
     const templateWithoutCategory = `import { Container } from "@react-email/components";
@@ -956,7 +956,7 @@ describe("template variables", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Create a simple template
     const simpleTemplate = deindent`
@@ -1065,7 +1065,7 @@ describe("template variables", () => {
       },
     });
 
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Create a simple template
     const simpleTemplate = deindent`

--- a/apps/e2e/tests/backend/endpoints/api/v1/integrations/credential-scanning/revoke.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/integrations/credential-scanning/revoke.test.ts
@@ -12,7 +12,7 @@ it("should send email notification to user when revoking an API key through cred
   await Project.createAndSwitch({ config: { magic_link_enabled: true, allow_team_api_keys: true, allow_user_api_keys: true } });
 
   const mailbox2 = await bumpEmailAddress();
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const mailbox1 = await bumpEmailAddress();
   const user1 = await Auth.fastSignUp({ primary_email: mailbox1.emailAddress, primary_email_verified: true });
@@ -134,13 +134,13 @@ it("should send email notification to team members when revoking a team API key 
   await InternalApiKey.createAndSetProjectKeys();
 
   const mailbox2 = await bumpEmailAddress();
-  const user2 = await Auth.Password.signUpWithEmail();
+  const user2 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const mailbox3 = await bumpEmailAddress();
-  const user3 = await Auth.Password.signUpWithEmail();
+  const user3 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   await Auth.signOut();
   const mailbox1 = await bumpEmailAddress();
-  const user1 = await Auth.Password.signUpWithEmail();
+  const user1 = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create a team and add all users
   const { teamId } = await Team.create();

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal-metrics.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal-metrics.test.ts
@@ -372,7 +372,7 @@ it("should handle mixed auth methods excluding anonymous users", async ({ expect
   // Regular user with password
   const passwordMailbox = createMailbox();
   backendContext.set({ mailbox: passwordMailbox });
-  await Auth.Password.signUpWithEmail({ password: "test1234" });
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "test1234" });
 
   // Anonymous users (should not be counted)
   for (let i = 0; i < 5; i++) {

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/sign-up-rules-stats.test.ts
@@ -131,7 +131,9 @@ describe("with admin access", () => {
       await wait(1_000 + 10_000 - (now.getTime() - lastSecondOfHour.getTime()));
     }
 
-    // Sign up a user to trigger the rule
+    // Sign up a user to trigger the rule. Keep the (otherwise unnecessary) verification email wait:
+    // it doubles as the delay that lets the rule-trigger event land in ClickHouse before we query
+    // the stats endpoint below, which snapshots exact trigger counts.
     const { userId } = await Auth.Password.signUpWithEmail();
 
     const response = await niceBackendFetch("/api/v1/internal/sign-up-rules-stats", { accessType: "admin" });
@@ -188,7 +190,7 @@ describe("with admin access", () => {
       },
     });
 
-    await Auth.Password.signUpWithEmail();
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     // Wait for the ClickHouse event to appear and verify via a raw COALESCE query
     let chResult: any;

--- a/apps/e2e/tests/backend/endpoints/api/v1/project-permissions.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/project-permissions.test.ts
@@ -119,7 +119,7 @@ it("can create a new permission and grant it to a user on the server", async ({ 
 
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
 
   // list current permissions
   const response1 = await niceBackendFetch(`/api/v1/project-permissions?user_id=me`, {
@@ -254,7 +254,7 @@ it("can customize default user permissions", async ({ expect }) => {
   `);
 
   // sign up a new user
-  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
   // list permissions for the new user
   const response3 = await niceBackendFetch(`/api/v1/project-permissions?user_id=${userId}`, {
     accessType: "client",

--- a/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/projects.test.ts
@@ -1614,7 +1614,7 @@ it("should increment and decrement userCount when a user is added to a project",
 
 
   // Create a new user in the project
-  await Auth.Password.signUpWithEmail();
+  await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // The metrics endpoint reads from ClickHouse (eventual consistency).
   // Poll until the new user is visible.

--- a/apps/e2e/tests/backend/endpoints/api/v1/risk-scores.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/risk-scores.test.ts
@@ -141,7 +141,7 @@ describe("risk scores", () => {
   it("server responses include risk_scores while client responses omit them", async ({ expect }) => {
     await Project.createAndSwitch({ config: { credential_enabled: true } });
 
-    const signUpResult = await Auth.Password.signUpWithEmail();
+    const signUpResult = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
     const serverUser = await readServerUser(signUpResult.userId);
     expectDerivedRiskScores(expect, serverUser.risk_scores.sign_up);
@@ -154,7 +154,7 @@ describe("risk scores", () => {
   it("client cannot update risk_scores", async ({ expect }) => {
     await Project.createAndSwitch({ config: { credential_enabled: true } });
 
-    const signUpResult = await Auth.Password.signUpWithEmail();
+    const signUpResult = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const beforeUpdate = (await readServerUser(signUpResult.userId)).risk_scores.sign_up;
     const updateResponse = await niceBackendFetch("/api/v1/users/me", {
       method: "PATCH",

--- a/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/send-email.test.ts
@@ -213,7 +213,7 @@ it("should return 200 and send email successfully", async ({ expect }) => {
       email_config: testEmailConfig,
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch(
     "/api/v1/emails/send-email",
     {
@@ -418,7 +418,7 @@ it("should send email using a draft_id and mark draft as sent", async ({ expect 
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   const tsxSource = `import { Container } from "@react-email/components";
 import { Subject, NotificationCategory, Props } from "@stackframe/emails";
@@ -750,7 +750,7 @@ describe("notification categories", () => {
         email_config: testEmailConfig,
       },
     });
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const response = await niceBackendFetch(
       "/api/v1/emails/send-email",
       {
@@ -783,7 +783,7 @@ describe("notification categories", () => {
         email_config: testEmailConfig,
       },
     });
-    const { userId } = await Auth.Password.signUpWithEmail();
+    const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
     const response = await niceBackendFetch(
       "/api/v1/emails/send-email",
       {

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-memberships.test.ts
@@ -503,9 +503,9 @@ it("should give team creator default permissions", async ({ expect }) => {
   const { adminAccessToken } = await Project.createAndGetAdminToken({ config: { magic_link_enabled: true } });
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId: userId1 } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
+  const { userId: userId1 } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
   await bumpEmailAddress();
-  const { userId: userId2 } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
+  const { userId: userId2 } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
   const { teamId } = await Team.createWithCurrentAsCreator();
 
   await niceBackendFetch(`/api/v1/team-memberships/${teamId}/${userId1}`, {

--- a/apps/e2e/tests/backend/endpoints/api/v1/team-permissions.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/team-permissions.test.ts
@@ -123,7 +123,7 @@ it("can create a new permission and grant it to a user on the server", async ({ 
 
   await InternalApiKey.createAndSetProjectKeys(adminAccessToken);
 
-  const { userId } = await Auth.Password.signUpWithEmail({ password: 'test1234' });
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: 'test1234' });
   const { teamId } = await Team.createWithCurrentAsCreator();
 
   // list current permissions

--- a/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/token-refresh-events.test.ts
@@ -148,7 +148,7 @@ it("password signup creates exactly one $token-refresh event", async ({ expect }
     config: { credential_enabled: true },
   });
   await InternalApiKey.createAndSetProjectKeys();
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   const events = await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });
   expect(events[0]).toMatchObject({
@@ -230,7 +230,7 @@ it("password signin (existing user) creates exactly one additional $token-refres
   await InternalApiKey.createAndSetProjectKeys();
 
   // First, sign up
-  const { userId, password } = await Auth.Password.signUpWithEmail();
+  const { userId, password } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Wait for the signup event to be recorded
   await expectExactlyNTokenRefreshEvents(userId, 1, { projectId });

--- a/apps/e2e/tests/backend/endpoints/api/v1/unsubscribe-link.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/unsubscribe-link.test.ts
@@ -17,7 +17,7 @@ it("unsubscribe link should be sent and update notification preference", async (
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
   const response = await niceBackendFetch(
     "/api/v1/emails/send-email",
     {
@@ -150,7 +150,7 @@ it("unsubscribe link should be included when template exports Marketing notifica
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create a draft with a template that exports Marketing notification category
   const marketingTemplate = `import { Container } from "@react-email/components";
@@ -222,7 +222,7 @@ it("unsubscribe link should NOT be included when template exports Transactional 
       },
     },
   });
-  const { userId } = await Auth.Password.signUpWithEmail();
+  const { userId } = await Auth.Password.signUpWithEmail({ noWaitForEmail: true });
 
   // Create a draft with a template that exports Transactional notification category
   // Using default theme so we can verify the theme doesn't add unsubscribe link for Transactional

--- a/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users.test.ts
@@ -2385,7 +2385,7 @@ describe("with server access", () => {
   });
 
   it("should be able to update primary email and sign-in with the new email", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ password: "password123" });
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
     const mailbox = createMailbox();
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
@@ -2467,7 +2467,7 @@ describe("with server access", () => {
     const primaryEmail = backendContext.value.mailbox.emailAddress;
     await Auth.signOut();
     await bumpEmailAddress();
-    await Auth.Password.signUpWithEmail({ password: "password123" });
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
     const response = await niceBackendFetch("/api/v1/users/me", {
       accessType: "server",
       method: "PATCH",
@@ -2529,7 +2529,7 @@ describe("with server access", () => {
   });
 
   it("should not be able to sign up with an email already in use for auth", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ password: "password123" });
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
     const response = await niceBackendFetch("/api/v1/auth/password/sign-up", {
       method: "POST",
       accessType: "client",
@@ -2560,7 +2560,7 @@ describe("with server access", () => {
   });
 
   it("should be able to sign up with an email already in use for auth in a different project", async ({ expect }) => {
-    await Auth.Password.signUpWithEmail({ password: "password123" });
+    await Auth.Password.signUpWithEmail({ noWaitForEmail: true, password: "password123" });
     await Project.createAndSwitch({});
     const response = await niceBackendFetch("/api/v1/auth/password/sign-up", {
       method: "POST",


### PR DESCRIPTION
`Auth.Password.signUpWithEmail` blocks on `mailbox.waitForMessagesWithSubject("Verify your email")` unless `noWaitForEmail: true` is passed — 5–20s per call under CI load. Most tests never look at that email.

Passes `noWaitForEmail: true` at 102 call sites across 34 e2e test files. No helper or product code changes.

Sites that keep the wait, because the sign-up email is load-bearing:
- `auth/password/sign-up.test.ts`, `auth/password/send-reset-code.test.ts` — snapshot the verification email itself.
- `contact-channels/{verify,send-verification-code,legacy-send-verification-code}.test.ts` — consume it or assert on a `Verify your email` message count that includes it.
- `internal/sign-up-rules-stats.test.ts` — the wait doubles as the delay that lets the rule-trigger event land in ClickHouse before the stats snapshot; noted in a comment there.

Kept the flag off nowhere else: remaining mailbox/outbox reads in the touched tests are subject-filtered, so a still-in-flight verification email can't affect them.

Verified by running the changed test files locally against a local emulator. Preexisting, unrelated failures remain in `users.test.ts`, `internal-metrics.test.ts` and `anonymous-comprehensive.test.ts` (risk score snapshots expect `0`, get `38`); they reproduce with the email wait restored.


Link to Devin session: https://app.devin.ai/sessions/e4c4b99cdb6b472d87b0ab42b7aa2ebe
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Skip waiting for the sign-up verification email in e2e tests by passing `noWaitForEmail: true` to `Auth.Password.signUpWithEmail`. This saves 5–20s per sign-up in CI and speeds up the test suite.

- **Refactors**
  - Added `noWaitForEmail: true` at 102 call sites across 34 e2e files; no helpers or product code changed.
  - Kept the wait only where the email is needed (e.g., verification email snapshot in `auth/password/sign-up.test.ts`) and for the ClickHouse timing check in `internal/sign-up-rules-stats.test.ts` (now documented with a clarifying comment).

<sup>Written for commit ddf99df352f89570b99d9a30760def2e3b403a5f. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1869?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Streamlined end-to-end authentication and API test setup by skipping unnecessary email-delivery waits during account creation.
  * Preserved existing authentication, session, email, permissions, metrics, and user-management coverage and assertions.
  * Retained explicit email-wait behavior where required for event-ingestion validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->