### PR TITLE
Show a user overview in the session replay header

### DIFF
--- a/apps/backend/src/app/api/latest/internal/session-replays/[session_replay_id]/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/session-replays/[session_replay_id]/route.tsx
@@ -25,6 +25,7 @@ export const GET = createSmartRouteHandler({
     bodyType: yupString().oneOf(["json"]).defined(),
     body: yupObject({
       id: yupString().defined(),
+      refresh_token_id: yupString().defined(),
       project_user: yupObject({
         id: yupString().defined(),
         display_name: yupString().nullable().defined(),

--- a/apps/backend/src/app/api/latest/internal/session-replays/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/session-replays/route.tsx
@@ -108,6 +108,7 @@ export const GET = createSmartRouteHandler({
     body: yupObject({
       items: yupArray(yupObject({
         id: yupString().defined(),
+        refresh_token_id: yupString().defined(),
         project_user: yupObject({
           id: yupString().defined(),
           display_name: yupString().nullable().defined(),

--- a/apps/backend/src/app/api/latest/internal/session-replays/session-replay-admin-rows.ts
+++ b/apps/backend/src/app/api/latest/internal/session-replays/session-replay-admin-rows.ts
@@ -5,6 +5,7 @@ import { type PrismaClientWithReplica, sqlQuoteIdent } from "@/prisma-client";
 export type SessionReplayAdminListRow = {
   id: string,
   projectUserId: string,
+  refreshTokenId: string,
   startedAt: Date,
   lastEventAt: Date,
   projectUserDisplayName: string | null,
@@ -28,6 +29,7 @@ export async function querySessionReplayAdminRows(options: {
     SELECT
       sr."id",
       sr."projectUserId",
+      sr."refreshTokenId",
       sr."startedAt",
       sr."lastEventAt",
       pu."displayName" AS "projectUserDisplayName",
@@ -79,6 +81,9 @@ export function sessionReplayAdminRowToApiItem(
 ) {
   return {
     id: row.id,
+    // Lets the dashboard correlate the replay with the analytics events of this
+    // exact session, rather than with the same user's other concurrent sessions.
+    refresh_token_id: row.refreshTokenId,
     project_user: {
       id: row.projectUserId,
       display_name: row.projectUserDisplayName ?? null,

--- a/apps/backend/src/lib/seed-dummy-data.ts
+++ b/apps/backend/src/lib/seed-dummy-data.ts
@@ -2508,6 +2508,10 @@ async function seedDummySessionReplays({
     const projectUserId = userIds[Math.floor(rand() * userIds.length)]!;
     const replayId = deterministicUuid(`session-replay:${tenancyId}:${i}`);
     const refreshTokenId = deterministicUuid(`session-replay-refresh-token:${tenancyId}:${i}`);
+    // The overview's bounce rate and average session duration group events by
+    // segment (one browser tab), skipping rows where it's null, so seeded events
+    // need one too — the browser SDK always sends it.
+    const segmentId = deterministicUuid(`session-replay-segment:${tenancyId}:${i}`);
 
     seeds.push({
       tenancyId,
@@ -2559,7 +2563,7 @@ async function seedDummySessionReplays({
         team_id: null,
         refresh_token_id: refreshTokenId,
         session_replay_id: replayId,
-        session_replay_segment_id: null,
+        session_replay_segment_id: segmentId,
       });
     }
 
@@ -2581,7 +2585,7 @@ async function seedDummySessionReplays({
         team_id: null,
         refresh_token_id: refreshTokenId,
         session_replay_id: replayId,
-        session_replay_segment_id: null,
+        session_replay_segment_id: segmentId,
       });
     }
   }

--- a/apps/backend/src/lib/seed-dummy-data.ts
+++ b/apps/backend/src/lib/seed-dummy-data.ts
@@ -2208,6 +2208,8 @@ export async function seedDummyProject(options: SeedDummyProjectOptions): Promis
     seedDummySessionReplays({
       prisma: dummyPrisma,
       tenancyId: dummyTenancy.id,
+      projectId,
+      clickhouseClient,
       userEmailToId,
       freshProject,
     }),
@@ -2450,15 +2452,32 @@ async function seedDummyAnalyticsMirrorTables(options: {
   ]);
 }
 
+// Device/browser strings the replay seeder cycles through, so the dashboard's
+// replay overview shows a realistic spread of desktop, mobile and tablet
+// sessions instead of one hardcoded browser.
+const SESSION_REPLAY_DEVICES = [
+  { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36', screenWidth: 2560, screenHeight: 1440, viewportWidth: 1512, viewportHeight: 916 },
+  { userAgent: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.3485.66', screenWidth: 1920, screenHeight: 1080, viewportWidth: 1920, viewportHeight: 969 },
+  { userAgent: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15', screenWidth: 1728, screenHeight: 1117, viewportWidth: 1440, viewportHeight: 810 },
+  { userAgent: 'Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1', screenWidth: 393, screenHeight: 852, viewportWidth: 393, viewportHeight: 659 },
+  { userAgent: 'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Mobile Safari/537.36', screenWidth: 412, screenHeight: 915, viewportWidth: 412, viewportHeight: 780 },
+  { userAgent: 'Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/604.1', screenWidth: 1024, screenHeight: 1366, viewportWidth: 1024, viewportHeight: 1219 },
+  { userAgent: 'Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0', screenWidth: 1920, screenHeight: 1200, viewportWidth: 1680, viewportHeight: 1050 },
+];
+
 async function seedDummySessionReplays({
   prisma,
   tenancyId,
+  projectId,
+  clickhouseClient,
   userEmailToId,
   freshProject,
   targetSessionReplayCount = 250,
 }: {
   prisma: PrismaClientTransaction,
   tenancyId: string,
+  projectId: string,
+  clickhouseClient: ClickHouseClient,
   userEmailToId: Map<string, string>,
   freshProject: boolean,
   targetSessionReplayCount?: number,
@@ -2481,20 +2500,90 @@ async function seedDummySessionReplays({
   const rand = deterministicPrng(seedFromString(`session-replays:${tenancyId}`));
 
   const seeds: Prisma.SessionReplayCreateManyInput[] = [];
+  const clickhouseRows: Array<Record<string, unknown>> = [];
   for (let i = 0; i < targetSessionReplayCount; i++) {
     const startedAt = new Date(twoWeeksAgo.getTime() + rand() * windowMs);
     const durationMs = 10_000 + Math.floor(rand() * (20 * 60 * 1000)); // 10s..20m
     const lastEventAt = new Date(startedAt.getTime() + durationMs);
     const projectUserId = userIds[Math.floor(rand() * userIds.length)]!;
+    const replayId = deterministicUuid(`session-replay:${tenancyId}:${i}`);
+    const refreshTokenId = deterministicUuid(`session-replay-refresh-token:${tenancyId}:${i}`);
 
     seeds.push({
       tenancyId,
-      refreshTokenId: deterministicUuid(`session-replay-refresh-token:${tenancyId}:${i}`),
+      refreshTokenId,
       projectUserId,
-      id: deterministicUuid(`session-replay:${tenancyId}:${i}`),
+      id: replayId,
       startedAt,
       lastEventAt,
     });
+
+    // The dashboard reads the device, entry page, referrer and location of a
+    // replay from the analytics events recorded alongside it, so a replay
+    // without events would render a header full of blanks. Seed the same event
+    // shapes the browser SDK emits.
+    const device = SESSION_REPLAY_DEVICES[Math.floor(rand() * SESSION_REPLAY_DEVICES.length)]!;
+    const location = sessionActivityLocations[Math.floor(rand() * sessionActivityLocations.length)]!;
+    clickhouseRows.push(buildTokenRefreshClickhouseRow({
+      projectId,
+      userId: projectUserId,
+      refreshTokenId,
+      eventAt: startedAt,
+      ipAddress: bulkFakeIp(`${10 + Math.floor(rand() * 200)}.${Math.floor(rand() * 256)}`, rand),
+      location,
+    }));
+
+    const pageViewCount = 1 + Math.floor(rand() * 4);
+    for (let p = 0; p < pageViewCount; p++) {
+      const path = BULK_PAGE_PATHS[Math.floor(rand() * BULK_PAGE_PATHS.length)]!;
+      clickhouseRows.push({
+        event_type: '$page-view',
+        event_at: formatClickhouseTimestamp(new Date(startedAt.getTime() + Math.floor((durationMs * p) / pageViewCount))),
+        data: {
+          url: `https://demo.hexclave.com${path}`,
+          path,
+          // Only the session's first page-view has a referrer; later ones are
+          // internal navigations, exactly like in the real SDK.
+          referrer: p === 0 ? pickBulkReferrer(rand) : '',
+          title: 'Demo Project',
+          user_agent: device.userAgent,
+          screen_width: device.screenWidth,
+          screen_height: device.screenHeight,
+          viewport_width: device.viewportWidth,
+          viewport_height: device.viewportHeight,
+          is_anonymous: false,
+        },
+        project_id: projectId,
+        branch_id: DEFAULT_BRANCH_ID,
+        user_id: projectUserId,
+        team_id: null,
+        refresh_token_id: refreshTokenId,
+        session_replay_id: replayId,
+        session_replay_segment_id: null,
+      });
+    }
+
+    const clickCount = Math.floor(rand() * 12);
+    for (let c = 0; c < clickCount; c++) {
+      clickhouseRows.push({
+        event_type: '$click',
+        event_at: formatClickhouseTimestamp(new Date(startedAt.getTime() + Math.floor(rand() * durationMs))),
+        data: {
+          selector: 'button.cta-primary',
+          tag_name: 'button',
+          text: 'Get started',
+          user_agent: device.userAgent,
+          is_anonymous: false,
+        },
+        project_id: projectId,
+        branch_id: DEFAULT_BRANCH_ID,
+        user_id: projectUserId,
+        team_id: null,
+        refresh_token_id: refreshTokenId,
+        session_replay_id: replayId,
+        session_replay_segment_id: null,
+      });
+    }
   }
 
   // Delete existing deterministic IDs first, then bulk-insert (Prisma createMany
@@ -2513,5 +2602,20 @@ async function seedDummySessionReplays({
     data: seeds,
   });
 
-  console.log(`Seeded ${targetSessionReplayCount} session replays`);
+  // Self-hosted setups without ClickHouse still get the replay rows; only the
+  // analytics-derived parts of the replay overview stay empty for them.
+  const shouldSeedClickhouse = getEnvVariable('STACK_CLICKHOUSE_URL', '') !== '';
+  if (shouldSeedClickhouse) {
+    await clickhouseClient.insert({
+      table: 'analytics_internal.events',
+      values: clickhouseRows,
+      format: 'JSONEachRow',
+      clickhouse_settings: {
+        date_time_input_format: 'best_effort',
+        async_insert: 1,
+      },
+    });
+  }
+
+  console.log(`Seeded ${targetSessionReplayCount} session replays (${shouldSeedClickhouse ? clickhouseRows.length : 0} analytics events)`);
 }

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/top-lists.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/(overview)/top-lists.tsx
@@ -1,6 +1,7 @@
 'use client';
 
 import { DesignAnalyticsCard, useInfiniteListWindow } from "@/components/design-components";
+import { CountryFlag, getReferrerHost, ReferrerFavicon, regionName } from "@/components/geo-referrer";
 import { Link } from "@/components/link";
 import { SimpleTooltip, Typography } from "@/components/ui";
 import { type AppId } from "@/lib/apps-frontend";
@@ -55,76 +56,6 @@ function useAnimatedBarValues(rows: Array<{ id: string, value: number }>): Map<s
   }, [rows]);
 
   return animatedValues;
-}
-
-export function getReferrerHost(referrer: string): string | null {
-  if (!referrer) return null;
-  try {
-    const url = new URL(/^https?:\/\//i.test(referrer) ? referrer : `https://${referrer}`);
-    const host = url.hostname.toLowerCase();
-    if (!host || !host.includes(".")) return null;
-    return host;
-  } catch {
-    return null;
-  }
-}
-
-export function ReferrerFavicon({ host }: { host: string }) {
-  const [failed, setFailed] = useState(false);
-  if (failed) {
-    return <span aria-hidden className="h-4 w-4 shrink-0 rounded-sm bg-foreground/[0.06]" />;
-  }
-  return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`}
-      alt=""
-      width={16}
-      height={16}
-      loading="lazy"
-      decoding="async"
-      onError={() => setFailed(true)}
-      className="h-4 w-4 shrink-0 rounded-sm object-contain"
-    />
-  );
-}
-
-export function CountryFlag({ code }: { code: string }) {
-  const [failed, setFailed] = useState(false);
-  const lower = code.toLowerCase();
-  if (failed || !/^[a-z]{2}$/.test(lower)) {
-    return (
-      <span aria-hidden className="inline-flex h-4 w-5 shrink-0 items-center justify-center rounded-sm bg-foreground/[0.06] text-[9px] font-semibold tabular-nums text-muted-foreground">
-        {code.toUpperCase()}
-      </span>
-    );
-  }
-  return (
-    // eslint-disable-next-line @next/next/no-img-element
-    <img
-      src={`https://flagcdn.com/w40/${lower}.png`}
-      srcSet={`https://flagcdn.com/w40/${lower}.png 1x, https://flagcdn.com/w80/${lower}.png 2x`}
-      alt=""
-      width={20}
-      height={15}
-      loading="lazy"
-      decoding="async"
-      onError={() => setFailed(true)}
-      className="h-[15px] w-5 shrink-0 rounded-[2px] object-cover ring-1 ring-black/[0.08] dark:ring-white/[0.08]"
-    />
-  );
-}
-
-export function regionName(code: string): string {
-  try {
-    // Use a fixed locale so server and client render identical region names; the
-    // dashboard UI is English-only, and navigator.language would cause hydration
-    // mismatches for non-English users.
-    const dn = new Intl.DisplayNames(["en"], { type: "region" });
-    return dn.of(code.toUpperCase()) ?? code;
-  } catch {
-    return code;
-  }
 }
 
 function SetupAppPromptInline({

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/page-client.tsx
@@ -68,6 +68,7 @@ type RrwebReplayer = InstanceType<typeof import("rrweb").Replayer>;
 
 type RecordingRow = {
   id: string,
+  refreshTokenId: string,
   projectUser: {
     id: string,
     displayName: string | null,
@@ -1917,6 +1918,7 @@ export default function PageClient({ initialReplayId, lockedUserId }: PageClient
                         replay={{
                           id: selectedRecording.id,
                           userId: selectedRecording.projectUser.id,
+                          refreshTokenId: selectedRecording.refreshTokenId,
                           startedAt: selectedRecording.startedAt,
                           lastEventAt: selectedRecording.lastEventAt,
                         }}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/page-client.tsx
@@ -6,6 +6,7 @@ import { StyledLink } from "@/components/link";
 import { Alert, Button, Dialog, DialogContent, DialogHeader, DialogTitle, Skeleton, Switch, Typography } from "@/components/ui";
 import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "@/components/ui/dropdown-menu";
 import { useFromNow } from "@/hooks/use-from-now";
+import { formatDurationMs } from "@/lib/session-replay-format";
 import {
   getDesiredGlobalOffsetFromPlaybackState,
   INTER_TAB_GAP_FAST_FORWARD_MULTIPLIER,
@@ -27,6 +28,7 @@ import { AppEnabledGuard } from "../app-enabled-guard";
 import { PageLayout } from "../page-layout";
 import { useAdminApp, useServerApp } from "../use-admin-app";
 import { SessionReplayLimitBanner } from "../analytics/shared";
+import { ReplayUserOverview, ReplayUserOverviewSkeleton } from "./replay-user-overview";
 import {
   ALLOWED_PLAYER_SPEEDS,
   areStatesRenderEquivalent,
@@ -46,6 +48,10 @@ const replaysListChromeClass =
   "shrink-0 space-y-2 border-b border-black/[0.06] px-3 py-2.5 dark:border-border/30";
 const replaysDetailChromeClass =
   "flex h-10 shrink-0 items-center justify-between gap-3 border-b border-black/[0.06] px-3 py-2 dark:border-border/30";
+// Same chrome as above, but the user overview is multi-line, so it grows instead
+// of being pinned to the transport bar's height.
+const replaysDetailOverviewChromeClass =
+  "flex shrink-0 items-start justify-between gap-3 border-b border-black/[0.06] px-3 py-2.5 dark:border-border/30";
 const replaysViewerSurfaceClass = "bg-zinc-100 dark:bg-background";
 const replaysTransportBarClass =
   "flex items-center gap-3 border-t border-black/[0.06] bg-white/95 px-3 dark:border-border/30 dark:bg-background/80";
@@ -143,16 +149,6 @@ function coerceRrwebEvents(raw: unknown[]): RrwebEventWithTime[] {
     filtered.push(e as { timestamp: number });
   }
   return filtered as unknown as RrwebEventWithTime[];
-}
-
-function formatDurationMs(ms: number) {
-  if (!Number.isFinite(ms) || ms < 0) return "—";
-  const s = Math.floor(ms / 1000);
-  const m = Math.floor(s / 60);
-  const h = Math.floor(m / 60);
-  if (h > 0) return `${h}h ${m % 60}m`;
-  if (m > 0) return `${m}m ${s % 60}s`;
-  return `${s}s`;
 }
 
 function formatTimelineMs(ms: number) {
@@ -1914,14 +1910,18 @@ export default function PageClient({ initialReplayId, lockedUserId }: PageClient
                   </div>
                 )}
 
-                <div className={replaysDetailChromeClass}>
+                <div className={cn(selectedRecording ? replaysDetailOverviewChromeClass : replaysDetailChromeClass)}>
                   {selectedRecording ? (
-                    <StyledLink
-                      href={`/projects/${encodeURIComponent(adminApp.projectId)}/users/${encodeURIComponent(selectedRecording.projectUser.id)}`}
-                      className="text-sm font-medium truncate"
-                    >
-                      {getRecordingTitle(selectedRecording)}
-                    </StyledLink>
+                    <React.Suspense fallback={<ReplayUserOverviewSkeleton />}>
+                      <ReplayUserOverview
+                        replay={{
+                          id: selectedRecording.id,
+                          userId: selectedRecording.projectUser.id,
+                          startedAt: selectedRecording.startedAt,
+                          lastEventAt: selectedRecording.lastEventAt,
+                        }}
+                      />
+                    </React.Suspense>
                   ) : isStandaloneReplayPage && selectedRecordingId ? (
                     <Typography className="text-sm font-medium truncate font-mono">
                       Replay {selectedRecordingId}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
@@ -1,0 +1,581 @@
+"use client";
+
+import { DesignBadge } from "@/components/design-components";
+import { CountryFlag, getReferrerHost, ReferrerFavicon, regionName } from "@/components/geo-referrer";
+import { StyledLink } from "@/components/link";
+import { Avatar, AvatarFallback, AvatarImage, CopyButton, SimpleTooltip, Skeleton, Typography } from "@/components/ui";
+import { useFromNow } from "@/hooks/use-from-now";
+import { formatDurationMs } from "@/lib/session-replay-format";
+import { describeUserAgent, type UserAgentDeviceType } from "@/lib/user-agent";
+import { cn } from "@/lib/utils";
+import {
+  ArrowUUpLeftIcon,
+  CheckCircleIcon,
+  ClockIcon,
+  CursorClickIcon,
+  DesktopIcon,
+  DeviceMobileIcon,
+  DeviceTabletIcon,
+  FileHtmlIcon,
+  IdentificationCardIcon,
+  KeyIcon,
+  MapPinIcon,
+  RobotIcon,
+  SignInIcon,
+  UsersThreeIcon,
+  WarningCircleIcon,
+} from "@phosphor-icons/react";
+import type { Icon } from "@phosphor-icons/react";
+import type { ServerUser } from "@hexclave/next";
+import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
+import React, { useEffect, useMemo, useState } from "react";
+import { useAdminApp, useServerApp } from "../use-admin-app";
+
+/** The bits of a session replay row the overview needs; keeps this component decoupled from the player's state. */
+export type ReplayUserOverviewReplay = {
+  id: string,
+  userId: string,
+  startedAt: Date,
+  lastEventAt: Date,
+};
+
+type ReplayGeo = {
+  countryCode: string | null,
+  regionCode: string | null,
+  cityName: string | null,
+  tzIdentifier: string | null,
+};
+
+type ReplaySessionContext = {
+  userAgent: string | null,
+  entryPath: string | null,
+  referrer: string | null,
+  screenWidth: number | null,
+  screenHeight: number | null,
+  viewportWidth: number | null,
+  viewportHeight: number | null,
+  pageViews: number,
+  clicks: number,
+  geo: ReplayGeo | null,
+};
+
+type SessionContextState =
+  | { status: "loading" }
+  | { status: "error", error: unknown }
+  | { status: "success", context: ReplaySessionContext };
+
+// The entry page-view carries everything the browser told us about this session:
+// which device it ran on, how large the window was, and where the visitor came
+// from. Later page-views repeat the device fields, so the first row is enough.
+const ENTRY_PAGE_VIEW_QUERY = `
+  SELECT
+    CAST(data.user_agent, 'Nullable(String)') AS user_agent,
+    CAST(data.path, 'Nullable(String)') AS entry_path,
+    CAST(data.referrer, 'Nullable(String)') AS referrer,
+    CAST(data.screen_width, 'Nullable(Int64)') AS screen_width,
+    CAST(data.screen_height, 'Nullable(Int64)') AS screen_height,
+    CAST(data.viewport_width, 'Nullable(Int64)') AS viewport_width,
+    CAST(data.viewport_height, 'Nullable(Int64)') AS viewport_height
+  FROM default.events
+  WHERE session_replay_id = {replayId:String}
+    AND event_type = '$page-view'
+  ORDER BY event_at ASC
+  LIMIT 1
+`;
+
+const ACTIVITY_COUNTS_QUERY = `
+  SELECT
+    countIf(event_type = '$page-view') AS page_views,
+    countIf(event_type = '$click') AS clicks
+  FROM default.events
+  WHERE session_replay_id = {replayId:String}
+`;
+
+// Geo is only ever attached to `$token-refresh` events (it's derived from the
+// request IP, which replay events don't carry), so we take the refresh closest
+// to — but not after — the end of the session. Refreshes happen every few
+// minutes while a user is active, so one within the surrounding day describes
+// where this session came from; anything older would be a different trip.
+const SESSION_GEO_QUERY = `
+  SELECT
+    CAST(data.ip_info.country_code, 'Nullable(String)') AS country_code,
+    CAST(data.ip_info.region_code, 'Nullable(String)') AS region_code,
+    CAST(data.ip_info.city_name, 'Nullable(String)') AS city_name,
+    CAST(data.ip_info.tz_identifier, 'Nullable(String)') AS tz_identifier
+  FROM default.events
+  WHERE user_id = {userId:String}
+    AND event_type = '$token-refresh'
+    AND event_at >= fromUnixTimestamp64Milli({sinceMillis:Int64})
+    AND event_at <= fromUnixTimestamp64Milli({untilMillis:Int64})
+  ORDER BY event_at DESC
+  LIMIT 1
+`;
+
+const GEO_LOOKBEHIND_MS = 24 * 60 * 60 * 1000;
+const GEO_LOOKAHEAD_MS = 60 * 60 * 1000;
+
+function toStringOrNull(value: unknown): string | null {
+  if (typeof value !== "string") return null;
+  const trimmed = value.trim();
+  return trimmed === "" ? null : trimmed;
+}
+
+function toNumberOrNull(value: unknown): number | null {
+  // ClickHouse serializes 64-bit integers as strings in its JSON formats, so
+  // both shapes legitimately reach us for the same column.
+  if (typeof value === "number") return Number.isFinite(value) ? value : null;
+  if (typeof value === "string" && value.trim() !== "") {
+    const parsed = Number(value);
+    return Number.isFinite(parsed) ? parsed : null;
+  }
+  return null;
+}
+
+function toCount(value: unknown): number {
+  return toNumberOrNull(value) ?? 0;
+}
+
+function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionContextState {
+  const serverApp = useServerApp();
+  const [state, setState] = useState<SessionContextState>({ status: "loading" });
+
+  const replayId = replay.id;
+  const userId = replay.userId;
+  const startedAtMs = replay.startedAt.getTime();
+  const lastEventAtMs = replay.lastEventAt.getTime();
+
+  useEffect(() => {
+    let cancelled = false;
+    setState({ status: "loading" });
+    runAsynchronously(async () => {
+      try {
+        const [entryRes, countsRes, geoRes] = await Promise.all([
+          serverApp.queryAnalytics({
+            query: ENTRY_PAGE_VIEW_QUERY,
+            params: { replayId },
+            include_all_branches: false,
+            timeout_ms: 15_000,
+          }),
+          serverApp.queryAnalytics({
+            query: ACTIVITY_COUNTS_QUERY,
+            params: { replayId },
+            include_all_branches: false,
+            timeout_ms: 15_000,
+          }),
+          serverApp.queryAnalytics({
+            query: SESSION_GEO_QUERY,
+            params: {
+              userId,
+              sinceMillis: startedAtMs - GEO_LOOKBEHIND_MS,
+              untilMillis: lastEventAtMs + GEO_LOOKAHEAD_MS,
+            },
+            include_all_branches: false,
+            timeout_ms: 15_000,
+          }),
+        ]);
+        if (cancelled) return;
+
+        // `.at(0)` rather than `[0]`: an empty result set is the normal case for
+        // replays whose project doesn't send analytics events.
+        const entry = entryRes.result.at(0) ?? null;
+        const counts = countsRes.result.at(0) ?? null;
+        const geoRow = geoRes.result.at(0) ?? null;
+        const geo: ReplayGeo | null = geoRow === null ? null : {
+          countryCode: toStringOrNull(geoRow.country_code),
+          regionCode: toStringOrNull(geoRow.region_code),
+          cityName: toStringOrNull(geoRow.city_name),
+          tzIdentifier: toStringOrNull(geoRow.tz_identifier),
+        };
+
+        setState({
+          status: "success",
+          context: {
+            userAgent: entry === null ? null : toStringOrNull(entry.user_agent),
+            entryPath: entry === null ? null : toStringOrNull(entry.entry_path),
+            referrer: entry === null ? null : toStringOrNull(entry.referrer),
+            screenWidth: entry === null ? null : toNumberOrNull(entry.screen_width),
+            screenHeight: entry === null ? null : toNumberOrNull(entry.screen_height),
+            viewportWidth: entry === null ? null : toNumberOrNull(entry.viewport_width),
+            viewportHeight: entry === null ? null : toNumberOrNull(entry.viewport_height),
+            pageViews: counts === null ? 0 : toCount(counts.page_views),
+            clicks: counts === null ? 0 : toCount(counts.clicks),
+            geo: geo !== null && geo.countryCode === null && geo.cityName === null ? null : geo,
+          },
+        });
+      } catch (error) {
+        if (cancelled) return;
+        setState({ status: "error", error });
+      }
+    }, { noErrorLogging: true });
+    return () => {
+      cancelled = true;
+    };
+  }, [lastEventAtMs, replayId, serverApp, startedAtMs, userId]);
+
+  return state;
+}
+
+const DEVICE_ICONS = new Map<UserAgentDeviceType, Icon>([
+  ["desktop", DesktopIcon],
+  ["mobile", DeviceMobileIcon],
+  ["tablet", DeviceTabletIcon],
+  ["bot", RobotIcon],
+]);
+
+function Fact({ icon, label, tooltip, children, className }: {
+  icon: Icon,
+  /** Screen-reader/tooltip name of the fact; the value itself is what's rendered. */
+  label: string,
+  tooltip?: React.ReactNode,
+  children: React.ReactNode,
+  className?: string,
+}) {
+  const IconComponent = icon;
+  const content = (
+    <span className={cn("inline-flex min-w-0 items-center gap-1.5", className)}>
+      <IconComponent className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" aria-hidden />
+      <span className="truncate text-[11px] text-foreground/90">{children}</span>
+    </span>
+  );
+  return (
+    <SimpleTooltip inline tooltip={tooltip ?? label} className="min-w-0 max-w-full">
+      {content}
+    </SimpleTooltip>
+  );
+}
+
+function FactSeparator() {
+  return <span aria-hidden className="h-3 w-px shrink-0 bg-foreground/[0.12]" />;
+}
+
+function RelativeTime({ date }: { date: Date }) {
+  return <>{useFromNow(date)}</>;
+}
+
+function formatLocalTime(date: Date, timeZone: string): string | null {
+  try {
+    return new Intl.DateTimeFormat("en", { hour: "numeric", minute: "2-digit", timeZone }).format(date);
+  } catch {
+    // An unknown IANA zone from an old event shouldn't take down the header.
+    return null;
+  }
+}
+
+function formatLocation(geo: ReplayGeo): string | null {
+  const parts = [geo.cityName, geo.countryCode === null ? null : regionName(geo.countryCode)].filter((p): p is string => p !== null);
+  return parts.length === 0 ? null : parts.join(", ");
+}
+
+function getUserInitials(user: ServerUser): string {
+  const source = user.displayName ?? user.primaryEmail ?? user.id;
+  const words = source.split(/[\s@._-]+/).filter((w) => w !== "");
+  const initials = words.slice(0, 2).map((w) => w.slice(0, 1)).join("");
+  return (initials === "" ? source.slice(0, 2) : initials).toUpperCase();
+}
+
+/** Auth methods the user can sign in with, eg. `Google, Password`. */
+function useAuthMethods(user: ServerUser): string[] {
+  const oauthProviders = user.useOAuthProviders();
+  return useMemo(() => {
+    const methods: string[] = [];
+    for (const provider of oauthProviders) {
+      if (!provider.allowSignIn) continue;
+      const label = provider.type.charAt(0).toUpperCase() + provider.type.slice(1);
+      if (!methods.includes(label)) methods.push(label);
+    }
+    if (user.hasPassword) methods.push("Password");
+    if (user.passkeyAuthEnabled) methods.push("Passkey");
+    if (user.otpAuthEnabled) methods.push("Email code");
+    return methods;
+  }, [oauthProviders, user.hasPassword, user.otpAuthEnabled, user.passkeyAuthEnabled]);
+}
+
+function UserBadges({ user, deviceType }: { user: ServerUser, deviceType: UserAgentDeviceType | null }) {
+  return (
+    <>
+      {user.isAnonymous && <DesignBadge label="Anonymous" color="orange" size="sm" />}
+      {user.isRestricted && (
+        <DesignBadge
+          label={user.restrictedByAdmin ? "Restricted by admin" : "Restricted"}
+          color="red"
+          size="sm"
+          icon={WarningCircleIcon}
+        />
+      )}
+      {user.isMultiFactorRequired && <DesignBadge label="2FA" color="blue" size="sm" icon={KeyIcon} />}
+      {deviceType === "bot" && <DesignBadge label="Bot UA" color="purple" size="sm" icon={RobotIcon} />}
+      {user.riskScores.signUp.bot >= 50 && (
+        <DesignBadge label={`Bot risk ${user.riskScores.signUp.bot}`} color="red" size="sm" icon={RobotIcon} />
+      )}
+    </>
+  );
+}
+
+function SessionFacts({ replay, state, deviceType }: {
+  replay: ReplayUserOverviewReplay,
+  state: SessionContextState,
+  deviceType: UserAgentDeviceType | null,
+}) {
+  const durationMs = replay.lastEventAt.getTime() - replay.startedAt.getTime();
+
+  if (state.status === "loading") {
+    return (
+      <div className="flex items-center gap-3">
+        <Skeleton className="h-3 w-40" />
+        <Skeleton className="h-3 w-32" />
+        <Skeleton className="h-3 w-24" />
+      </div>
+    );
+  }
+
+  if (state.status === "error") {
+    return (
+      <SimpleTooltip
+        inline
+        tooltip={`Couldn't load the device, location and referrer for this session: ${state.error instanceof Error ? state.error.message : String(state.error)}`}
+      >
+        <span className="inline-flex items-center gap-1.5 text-[11px] text-muted-foreground">
+          <WarningCircleIcon className="h-3.5 w-3.5" aria-hidden />
+          Session context unavailable
+        </span>
+      </SimpleTooltip>
+    );
+  }
+
+  const context = state.context;
+  const device = context.userAgent === null ? null : describeUserAgent(context.userAgent);
+  const deviceLabel = device === null
+    ? null
+    : [device.browser, device.os].filter((p): p is string => p !== null).join(" on ");
+  const screenLabel = context.screenWidth !== null && context.screenHeight !== null
+    ? `${context.screenWidth}×${context.screenHeight}`
+    : null;
+  const viewportLabel = context.viewportWidth !== null && context.viewportHeight !== null
+    ? `${context.viewportWidth}×${context.viewportHeight}`
+    : null;
+  const location = context.geo === null ? null : formatLocation(context.geo);
+  const localTime = context.geo?.tzIdentifier == null
+    ? null
+    : formatLocalTime(replay.startedAt, context.geo.tzIdentifier);
+  const referrerHost = context.referrer === null ? null : getReferrerHost(context.referrer);
+
+  const activityParts = [
+    formatDurationMs(durationMs),
+    `${context.pageViews} ${context.pageViews === 1 ? "page" : "pages"}`,
+    `${context.clicks} ${context.clicks === 1 ? "click" : "clicks"}`,
+  ];
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
+      <Fact
+        icon={ClockIcon}
+        label="This session"
+        tooltip={`Session started ${replay.startedAt.toLocaleString()}`}
+      >
+        {activityParts.join(" · ")}
+      </Fact>
+
+      {(deviceLabel !== null || deviceType !== null) && (
+        <>
+          <FactSeparator />
+          <Fact
+            icon={(deviceType === null ? null : DEVICE_ICONS.get(deviceType)) ?? DesktopIcon}
+            label="Device"
+            tooltip={context.userAgent ?? "Device unknown"}
+          >
+            {deviceLabel ?? "Unknown browser"}
+            {screenLabel !== null && <span className="text-muted-foreground"> · {screenLabel}</span>}
+          </Fact>
+        </>
+      )}
+
+      {viewportLabel !== null && (
+        <>
+          <FactSeparator />
+          <Fact icon={DesktopIcon} label="Window size at session start">
+            <span className="text-muted-foreground">window</span> {viewportLabel}
+          </Fact>
+        </>
+      )}
+
+      {location !== null && context.geo !== null && (
+        <>
+          <FactSeparator />
+          <Fact
+            icon={MapPinIcon}
+            label="Location"
+            tooltip={`Approximate location from the IP address used during this session${context.geo.regionCode === null ? "" : ` (${context.geo.regionCode})`}`}
+          >
+            <span className="inline-flex items-center gap-1.5">
+              {context.geo.countryCode !== null && <CountryFlag code={context.geo.countryCode} />}
+              {location}
+              {localTime !== null && <span className="text-muted-foreground">· {localTime} local</span>}
+            </span>
+          </Fact>
+        </>
+      )}
+
+      <FactSeparator />
+      <Fact
+        icon={ArrowUUpLeftIcon}
+        label="Came from"
+        tooltip={context.referrer ?? "No referrer — the visitor arrived directly"}
+      >
+        {referrerHost === null ? (
+          <span className="text-muted-foreground">Direct traffic</span>
+        ) : (
+          <span className="inline-flex items-center gap-1.5">
+            <ReferrerFavicon host={referrerHost} />
+            {referrerHost}
+          </span>
+        )}
+      </Fact>
+
+      {context.entryPath !== null && (
+        <>
+          <FactSeparator />
+          <Fact icon={FileHtmlIcon} label="Landed on" tooltip={`First page of the session: ${context.entryPath}`}>
+            <span className="font-mono">{context.entryPath}</span>
+          </Fact>
+        </>
+      )}
+    </div>
+  );
+}
+
+function AccountFacts({ user }: { user: ServerUser }) {
+  const authMethods = useAuthMethods(user);
+  const teams = user.useTeams();
+
+  return (
+    <div className="flex min-w-0 flex-wrap items-center gap-x-3 gap-y-1.5">
+      <Fact icon={SignInIcon} label="Signed up" tooltip={`Signed up ${user.signedUpAt.toLocaleString()}`}>
+        <span className="text-muted-foreground">signed up</span> <RelativeTime date={user.signedUpAt} />
+      </Fact>
+      <FactSeparator />
+      <Fact icon={ClockIcon} label="Last active" tooltip={`Last active ${user.lastActiveAt.toLocaleString()}`}>
+        <span className="text-muted-foreground">last active</span> <RelativeTime date={user.lastActiveAt} />
+      </Fact>
+      {authMethods.length > 0 && (
+        <>
+          <FactSeparator />
+          <Fact icon={KeyIcon} label="Sign-in methods">
+            {authMethods.join(", ")}
+          </Fact>
+        </>
+      )}
+      {teams.length > 0 && (
+        <>
+          <FactSeparator />
+          <Fact icon={UsersThreeIcon} label="Teams" tooltip={teams.map((t) => t.displayName).join(", ")}>
+            {teams.length === 1 ? teams[0]!.displayName : `${teams.length} teams`}
+          </Fact>
+        </>
+      )}
+      <FactSeparator />
+      <Fact icon={IdentificationCardIcon} label="User ID" tooltip={user.id}>
+        <span className="font-mono">{user.id.slice(0, 8)}…</span>
+      </Fact>
+      <CopyButton content={user.id} className="h-5 w-5 p-0.5" aria-label="Copy user ID" />
+    </div>
+  );
+}
+
+function OverviewShell({ children }: { children: React.ReactNode }) {
+  return <div className="flex min-w-0 flex-1 flex-col gap-1.5">{children}</div>;
+}
+
+export function ReplayUserOverviewSkeleton() {
+  return (
+    <OverviewShell>
+      <div className="flex items-center gap-2.5">
+        <Skeleton className="h-9 w-9 rounded-full" />
+        <div className="flex flex-col gap-1.5">
+          <Skeleton className="h-3.5 w-32" />
+          <Skeleton className="h-3 w-44" />
+        </div>
+      </div>
+      <Skeleton className="h-3 w-full max-w-lg" />
+    </OverviewShell>
+  );
+}
+
+/**
+ * Header of the session replay player: everything you'd want to know about the
+ * person you're watching without leaving the replay. Account facts come from
+ * the user itself; the device, location and referrer are session-specific and
+ * come from the analytics events recorded alongside this replay.
+ *
+ * Suspends while the user loads — render inside a `<Suspense>` boundary with
+ * `<ReplayUserOverviewSkeleton />` as the fallback.
+ */
+export function ReplayUserOverview({ replay }: { replay: ReplayUserOverviewReplay }) {
+  const adminApp = useAdminApp();
+  const user = adminApp.useUser(replay.userId);
+  const sessionContext = useReplaySessionContext(replay);
+
+  const deviceType = sessionContext.status === "success" && sessionContext.context.userAgent !== null
+    ? describeUserAgent(sessionContext.context.userAgent).deviceType
+    : null;
+
+  if (user === null) {
+    // Replays outlive their user: the account can be deleted while the
+    // recording is still around, so this is an expected state, not an error.
+    return (
+      <OverviewShell>
+        <Typography className="truncate text-sm font-medium">Deleted user</Typography>
+        <span className="truncate font-mono text-[11px] text-muted-foreground">{replay.userId}</span>
+        <SessionFacts replay={replay} state={sessionContext} deviceType={deviceType} />
+      </OverviewShell>
+    );
+  }
+
+  const profileHref = `/projects/${encodeURIComponent(adminApp.projectId)}/users/${encodeURIComponent(user.id)}`;
+
+  return (
+    <OverviewShell>
+      <div className="flex min-w-0 items-center gap-2.5">
+        <Avatar className="h-9 w-9 shrink-0">
+          {user.profileImageUrl !== null && <AvatarImage src={user.profileImageUrl} alt="" />}
+          <AvatarFallback className="text-[11px] font-medium">{getUserInitials(user)}</AvatarFallback>
+        </Avatar>
+        <div className="flex min-w-0 flex-col">
+          <div className="flex min-w-0 items-center gap-2">
+            <StyledLink href={profileHref} className="truncate text-sm font-medium">
+              {user.displayName ?? user.primaryEmail ?? "Unnamed user"}
+            </StyledLink>
+            <UserBadges user={user} deviceType={deviceType} />
+          </div>
+          <div className="flex min-w-0 items-center gap-1.5">
+            {user.primaryEmail === null ? (
+              <span className="text-[11px] text-muted-foreground">No email address</span>
+            ) : (
+              <>
+                <a
+                  href={`mailto:${encodeURIComponent(user.primaryEmail)}`}
+                  className="truncate text-[11px] text-muted-foreground transition-colors duration-150 hover:text-foreground hover:transition-none"
+                >
+                  {user.primaryEmail}
+                </a>
+                <SimpleTooltip inline tooltip={user.primaryEmailVerified ? "Email verified" : "Email not verified"}>
+                  {user.primaryEmailVerified ? (
+                    <CheckCircleIcon className="h-3.5 w-3.5 shrink-0 text-emerald-600 dark:text-emerald-500" aria-hidden />
+                  ) : (
+                    <WarningCircleIcon className="h-3.5 w-3.5 shrink-0 text-amber-600 dark:text-amber-500" aria-hidden />
+                  )}
+                </SimpleTooltip>
+              </>
+            )}
+          </div>
+        </div>
+      </div>
+
+      <SessionFacts replay={replay} state={sessionContext} deviceType={deviceType} />
+      {/* Own boundary: the teams/OAuth providers of the user load separately, and
+          suspending them here keeps the already-rendered facts above on screen. */}
+      <React.Suspense fallback={<Skeleton className="h-3 w-64" />}>
+        <AccountFacts user={user} />
+      </React.Suspense>
+    </OverviewShell>
+  );
+}

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
@@ -27,7 +27,7 @@ import {
 } from "@phosphor-icons/react";
 import type { Icon } from "@phosphor-icons/react";
 import type { ServerUser } from "@hexclave/next";
-import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { captureError, throwErr } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import React, { useEffect, useMemo, useState } from "react";
 import { useAdminApp, useServerApp } from "../use-admin-app";
@@ -57,8 +57,8 @@ type ReplaySessionContext = {
   screenHeight: number | null,
   viewportWidth: number | null,
   viewportHeight: number | null,
-  pageViews: number,
-  clicks: number,
+  /** `null` when the counting query failed, which is different from a session with no page views. */
+  activity: { pageViews: number, clicks: number } | null,
   geo: ReplayGeo | null,
 };
 
@@ -154,6 +154,11 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
     setState({ status: "loading" });
     runAsynchronously(async () => {
       try {
+        // ClickHouse rejects a blank substitution with an opaque "is not set"
+        // error, which would surface as a generic failed facet; the replay row
+        // always carries its session, so an empty one means the row was built
+        // from something other than the replay API.
+        if (refreshTokenId === "") throwErr("Session replay row has no refreshTokenId, so its analytics events can't be looked up", { replayId });
         // The three queries describe unrelated facets of the session, so a failure
         // in one (a geo lookup timing out, say) shouldn't hide the other two.
         const results = await Promise.allSettled([
@@ -220,12 +225,14 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
             screenHeight: entry === null ? null : toNumberOrNull(entry.screen_height),
             viewportWidth: entry === null ? null : toNumberOrNull(entry.viewport_width),
             viewportHeight: entry === null ? null : toNumberOrNull(entry.viewport_height),
-            pageViews: counts === null ? 0 : toCount(counts.page_views),
-            clicks: counts === null ? 0 : toCount(counts.clicks),
+            activity: counts === null ? null : { pageViews: toCount(counts.page_views), clicks: toCount(counts.clicks) },
             geo: geo !== null && geo.countryCode === null && geo.cityName === null ? null : geo,
           },
         });
       } catch (error) {
+        // Not the rejected-query path above (those are captured individually);
+        // this is a bug in the overview itself, so it must reach Sentry.
+        captureError("replay-user-overview", error);
         if (cancelled) return;
         setState({ status: "error", error });
       }
@@ -385,10 +392,14 @@ function SessionFacts({ replay, state, deviceType }: {
     : formatLocalTime(replay.startedAt, context.geo.tzIdentifier);
   const referrerHost = context.referrer === null ? null : getReferrerHost(context.referrer);
 
+  // Without the counts we only know the duration; showing "0 pages" would
+  // claim the visitor never loaded anything.
   const activityParts = [
     formatDurationMs(durationMs),
-    `${context.pageViews} ${context.pageViews === 1 ? "page" : "pages"}`,
-    `${context.clicks} ${context.clicks === 1 ? "click" : "clicks"}`,
+    ...context.activity === null ? [] : [
+      `${context.activity.pageViews} ${context.activity.pageViews === 1 ? "page" : "pages"}`,
+      `${context.activity.clicks} ${context.activity.clicks === 1 ? "click" : "clicks"}`,
+    ],
   ];
 
   return (
@@ -396,7 +407,7 @@ function SessionFacts({ replay, state, deviceType }: {
       <Fact
         icon={ClockIcon}
         label="This session"
-        tooltip={`Session started ${replay.startedAt.toLocaleString()}`}
+        tooltip={`Session started ${replay.startedAt.toLocaleString()}${context.activity === null ? " (page and click counts unavailable)" : ""}`}
       >
         {activityParts.join(" · ")}
       </Fact>

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
@@ -99,7 +99,9 @@ const ACTIVITY_COUNTS_QUERY = `
 // the session the replay belongs to. Matching on the refresh token rather than
 // the user is what keeps a user's other concurrent sessions — a phone on mobile
 // data, say — from lending their location to this replay. The time window is
-// only a guard against a long-lived token that travelled since.
+// only a guard against a long-lived token that travelled since: refreshes after
+// the replay ended may already come from somewhere else, so the window stops at
+// the session's last event.
 const SESSION_GEO_QUERY = `
   SELECT
     CAST(data.ip_info.country_code, 'Nullable(String)') AS country_code,
@@ -116,7 +118,6 @@ const SESSION_GEO_QUERY = `
 `;
 
 const GEO_LOOKBEHIND_MS = 24 * 60 * 60 * 1000;
-const GEO_LOOKAHEAD_MS = 60 * 60 * 1000;
 
 function toStringOrNull(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -173,7 +174,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
             params: {
               refreshTokenId,
               sinceMillis: startedAtMs - GEO_LOOKBEHIND_MS,
-              untilMillis: lastEventAtMs + GEO_LOOKAHEAD_MS,
+              untilMillis: lastEventAtMs,
             },
             include_all_branches: false,
             timeout_ms: 15_000,

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
@@ -27,6 +27,7 @@ import {
 } from "@phosphor-icons/react";
 import type { Icon } from "@phosphor-icons/react";
 import type { ServerUser } from "@hexclave/next";
+import { captureError } from "@hexclave/shared/dist/utils/errors";
 import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import React, { useEffect, useMemo, useState } from "react";
 import { useAdminApp, useServerApp } from "../use-admin-app";
@@ -35,6 +36,8 @@ import { useAdminApp, useServerApp } from "../use-admin-app";
 export type ReplayUserOverviewReplay = {
   id: string,
   userId: string,
+  /** Identifies the session, which is how the replay is correlated with its analytics events. */
+  refreshTokenId: string,
   startedAt: Date,
   lastEventAt: Date,
 };
@@ -92,10 +95,11 @@ const ACTIVITY_COUNTS_QUERY = `
 `;
 
 // Geo is only ever attached to `$token-refresh` events (it's derived from the
-// request IP, which replay events don't carry), so we take the refresh closest
-// to — but not after — the end of the session. Refreshes happen every few
-// minutes while a user is active, so one within the surrounding day describes
-// where this session came from; anything older would be a different trip.
+// request IP, which replay events don't carry), so we take the latest refresh of
+// the session the replay belongs to. Matching on the refresh token rather than
+// the user is what keeps a user's other concurrent sessions — a phone on mobile
+// data, say — from lending their location to this replay. The time window is
+// only a guard against a long-lived token that travelled since.
 const SESSION_GEO_QUERY = `
   SELECT
     CAST(data.ip_info.country_code, 'Nullable(String)') AS country_code,
@@ -103,7 +107,7 @@ const SESSION_GEO_QUERY = `
     CAST(data.ip_info.city_name, 'Nullable(String)') AS city_name,
     CAST(data.ip_info.tz_identifier, 'Nullable(String)') AS tz_identifier
   FROM default.events
-  WHERE user_id = {userId:String}
+  WHERE refresh_token_id = {refreshTokenId:String}
     AND event_type = '$token-refresh'
     AND event_at >= fromUnixTimestamp64Milli({sinceMillis:Int64})
     AND event_at <= fromUnixTimestamp64Milli({untilMillis:Int64})
@@ -140,7 +144,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
   const [state, setState] = useState<SessionContextState>({ status: "loading" });
 
   const replayId = replay.id;
-  const userId = replay.userId;
+  const refreshTokenId = replay.refreshTokenId;
   const startedAtMs = replay.startedAt.getTime();
   const lastEventAtMs = replay.lastEventAt.getTime();
 
@@ -149,7 +153,9 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
     setState({ status: "loading" });
     runAsynchronously(async () => {
       try {
-        const [entryRes, countsRes, geoRes] = await Promise.all([
+        // The three queries describe unrelated facets of the session, so a failure
+        // in one (a geo lookup timing out, say) shouldn't hide the other two.
+        const results = await Promise.allSettled([
           serverApp.queryAnalytics({
             query: ENTRY_PAGE_VIEW_QUERY,
             params: { replayId },
@@ -165,7 +171,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
           serverApp.queryAnalytics({
             query: SESSION_GEO_QUERY,
             params: {
-              userId,
+              refreshTokenId,
               sinceMillis: startedAtMs - GEO_LOOKBEHIND_MS,
               untilMillis: lastEventAtMs + GEO_LOOKAHEAD_MS,
             },
@@ -175,11 +181,27 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
         ]);
         if (cancelled) return;
 
+        const queryNames = ["entry-page-view", "activity-counts", "session-geo"] as const;
+        const rejections: unknown[] = [];
+        for (const [index, result] of results.entries()) {
+          if (result.status === "rejected") {
+            rejections.push(result.reason);
+            captureError(`replay-user-overview-query:${queryNames[index]}`, result.reason);
+          }
+        }
+        // Only a total failure is worth telling the operator about; a single
+        // missing facet just renders one fewer fact.
+        if (rejections.length === results.length) {
+          setState({ status: "error", error: rejections[0] });
+          return;
+        }
+
+        const [entryRes, countsRes, geoRes] = results;
         // `.at(0)` rather than `[0]`: an empty result set is the normal case for
         // replays whose project doesn't send analytics events.
-        const entry = entryRes.result.at(0) ?? null;
-        const counts = countsRes.result.at(0) ?? null;
-        const geoRow = geoRes.result.at(0) ?? null;
+        const entry = entryRes.status === "fulfilled" ? entryRes.value.result.at(0) ?? null : null;
+        const counts = countsRes.status === "fulfilled" ? countsRes.value.result.at(0) ?? null : null;
+        const geoRow = geoRes.status === "fulfilled" ? geoRes.value.result.at(0) ?? null : null;
         const geo: ReplayGeo | null = geoRow === null ? null : {
           countryCode: toStringOrNull(geoRow.country_code),
           regionCode: toStringOrNull(geoRow.region_code),
@@ -210,7 +232,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
     return () => {
       cancelled = true;
     };
-  }, [lastEventAtMs, replayId, serverApp, startedAtMs, userId]);
+  }, [lastEventAtMs, refreshTokenId, replayId, serverApp, startedAtMs]);
 
   return state;
 }
@@ -232,7 +254,9 @@ function Fact({ icon, label, tooltip, children, className }: {
 }) {
   const IconComponent = icon;
   const content = (
-    <span className={cn("inline-flex min-w-0 items-center gap-1.5", className)}>
+    // The icon is decorative, so the label is the only thing naming the value
+    // for a screen reader ("Location: Berlin, Germany" instead of a bare city).
+    <span aria-label={label} className={cn("inline-flex min-w-0 items-center gap-1.5", className)}>
       <IconComponent className="h-3.5 w-3.5 shrink-0 text-muted-foreground/70" aria-hidden />
       <span className="truncate text-[11px] text-foreground/90">{children}</span>
     </span>
@@ -344,9 +368,10 @@ function SessionFacts({ replay, state, deviceType }: {
 
   const context = state.context;
   const device = context.userAgent === null ? null : describeUserAgent(context.userAgent);
-  const deviceLabel = device === null
-    ? null
-    : [device.browser, device.os].filter((p): p is string => p !== null).join(" on ");
+  // An entirely unrecognized user agent leaves both halves null; joining those
+  // would give an empty string, which would render as an icon with no text.
+  const deviceParts = device === null ? [] : [device.browser, device.os].filter((p): p is string => p !== null);
+  const deviceLabel = deviceParts.length === 0 ? null : deviceParts.join(" on ");
   const screenLabel = context.screenWidth !== null && context.screenHeight !== null
     ? `${context.screenWidth}×${context.screenHeight}`
     : null;

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/session-replays/replay-user-overview.tsx
@@ -95,13 +95,17 @@ const ACTIVITY_COUNTS_QUERY = `
 `;
 
 // Geo is only ever attached to `$token-refresh` events (it's derived from the
-// request IP, which replay events don't carry), so we take the latest refresh of
+// request IP, which replay events don't carry), so we read it off a refresh of
 // the session the replay belongs to. Matching on the refresh token rather than
 // the user is what keeps a user's other concurrent sessions — a phone on mobile
-// data, say — from lending their location to this replay. The time window is
-// only a guard against a long-lived token that travelled since: refreshes after
-// the replay ended may already come from somewhere else, so the window stops at
-// the session's last event.
+// data, say — from lending their location to this replay.
+//
+// Every refresh of that token belongs to this one session, so rather than cutting
+// the search off at the replay's boundaries we take the refresh closest to when
+// the replay started: a session that travelled mid-flight still reports where it
+// began, and no valid row is discarded just because the replay's boundaries come
+// from the visitor's clock (they're rrweb event timestamps) while `event_at` comes
+// from ours.
 const SESSION_GEO_QUERY = `
   SELECT
     CAST(data.ip_info.country_code, 'Nullable(String)') AS country_code,
@@ -111,13 +115,9 @@ const SESSION_GEO_QUERY = `
   FROM default.events
   WHERE refresh_token_id = {refreshTokenId:String}
     AND event_type = '$token-refresh'
-    AND event_at >= fromUnixTimestamp64Milli({sinceMillis:Int64})
-    AND event_at <= fromUnixTimestamp64Milli({untilMillis:Int64})
-  ORDER BY event_at DESC
+  ORDER BY abs(dateDiff('millisecond', event_at, fromUnixTimestamp64Milli({startedAtMillis:Int64}))) ASC
   LIMIT 1
 `;
-
-const GEO_LOOKBEHIND_MS = 24 * 60 * 60 * 1000;
 
 function toStringOrNull(value: unknown): string | null {
   if (typeof value !== "string") return null;
@@ -147,7 +147,6 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
   const replayId = replay.id;
   const refreshTokenId = replay.refreshTokenId;
   const startedAtMs = replay.startedAt.getTime();
-  const lastEventAtMs = replay.lastEventAt.getTime();
 
   useEffect(() => {
     let cancelled = false;
@@ -178,8 +177,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
             query: SESSION_GEO_QUERY,
             params: {
               refreshTokenId,
-              sinceMillis: startedAtMs - GEO_LOOKBEHIND_MS,
-              untilMillis: lastEventAtMs,
+              startedAtMillis: startedAtMs,
             },
             include_all_branches: false,
             timeout_ms: 15_000,
@@ -240,7 +238,7 @@ function useReplaySessionContext(replay: ReplayUserOverviewReplay): SessionConte
     return () => {
       cancelled = true;
     };
-  }, [lastEventAtMs, refreshTokenId, replayId, serverApp, startedAtMs]);
+  }, [refreshTokenId, replayId, serverApp, startedAtMs]);
 
   return state;
 }

--- a/apps/dashboard/src/components/geo-referrer.tsx
+++ b/apps/dashboard/src/components/geo-referrer.tsx
@@ -1,0 +1,73 @@
+"use client";
+
+import { useState } from "react";
+
+export function getReferrerHost(referrer: string): string | null {
+  if (!referrer) return null;
+  try {
+    const url = new URL(/^https?:\/\//i.test(referrer) ? referrer : `https://${referrer}`);
+    const host = url.hostname.toLowerCase();
+    if (!host || !host.includes(".")) return null;
+    return host;
+  } catch {
+    return null;
+  }
+}
+
+export function ReferrerFavicon({ host }: { host: string }) {
+  const [failed, setFailed] = useState(false);
+  if (failed) {
+    return <span aria-hidden className="h-4 w-4 shrink-0 rounded-sm bg-foreground/[0.06]" />;
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`https://www.google.com/s2/favicons?domain=${encodeURIComponent(host)}&sz=32`}
+      alt=""
+      width={16}
+      height={16}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+      className="h-4 w-4 shrink-0 rounded-sm object-contain"
+    />
+  );
+}
+
+export function CountryFlag({ code }: { code: string }) {
+  const [failed, setFailed] = useState(false);
+  const lower = code.toLowerCase();
+  if (failed || !/^[a-z]{2}$/.test(lower)) {
+    return (
+      <span aria-hidden className="inline-flex h-4 w-5 shrink-0 items-center justify-center rounded-sm bg-foreground/[0.06] text-[9px] font-semibold tabular-nums text-muted-foreground">
+        {code.toUpperCase()}
+      </span>
+    );
+  }
+  return (
+    // eslint-disable-next-line @next/next/no-img-element
+    <img
+      src={`https://flagcdn.com/w40/${lower}.png`}
+      srcSet={`https://flagcdn.com/w40/${lower}.png 1x, https://flagcdn.com/w80/${lower}.png 2x`}
+      alt=""
+      width={20}
+      height={15}
+      loading="lazy"
+      decoding="async"
+      onError={() => setFailed(true)}
+      className="h-[15px] w-5 shrink-0 rounded-[2px] object-cover ring-1 ring-black/[0.08] dark:ring-white/[0.08]"
+    />
+  );
+}
+
+export function regionName(code: string): string {
+  try {
+    // Use a fixed locale so server and client render identical region names; the
+    // dashboard UI is English-only, and navigator.language would cause hydration
+    // mismatches for non-English users.
+    const dn = new Intl.DisplayNames(["en"], { type: "region" });
+    return dn.of(code.toUpperCase()) ?? code;
+  } catch {
+    return code;
+  }
+}

--- a/apps/dashboard/src/components/geo-referrer.tsx
+++ b/apps/dashboard/src/components/geo-referrer.tsx
@@ -15,8 +15,11 @@ export function getReferrerHost(referrer: string): string | null {
 }
 
 export function ReferrerFavicon({ host }: { host: string }) {
-  const [failed, setFailed] = useState(false);
-  if (failed) {
+  // Remember *which* host failed rather than just that one did: React reuses this
+  // component instance when the host changes, and a boolean would keep showing
+  // the placeholder for a new host whose favicon might load fine.
+  const [failedHost, setFailedHost] = useState<string | null>(null);
+  if (failedHost === host) {
     return <span aria-hidden className="h-4 w-4 shrink-0 rounded-sm bg-foreground/[0.06]" />;
   }
   return (
@@ -28,16 +31,16 @@ export function ReferrerFavicon({ host }: { host: string }) {
       height={16}
       loading="lazy"
       decoding="async"
-      onError={() => setFailed(true)}
+      onError={() => setFailedHost(host)}
       className="h-4 w-4 shrink-0 rounded-sm object-contain"
     />
   );
 }
 
 export function CountryFlag({ code }: { code: string }) {
-  const [failed, setFailed] = useState(false);
+  const [failedCode, setFailedCode] = useState<string | null>(null);
   const lower = code.toLowerCase();
-  if (failed || !/^[a-z]{2}$/.test(lower)) {
+  if (failedCode === code || !/^[a-z]{2}$/.test(lower)) {
     return (
       <span aria-hidden className="inline-flex h-4 w-5 shrink-0 items-center justify-center rounded-sm bg-foreground/[0.06] text-[9px] font-semibold tabular-nums text-muted-foreground">
         {code.toUpperCase()}
@@ -54,7 +57,7 @@ export function CountryFlag({ code }: { code: string }) {
       height={15}
       loading="lazy"
       decoding="async"
-      onError={() => setFailed(true)}
+      onError={() => setFailedCode(code)}
       className="h-[15px] w-5 shrink-0 rounded-[2px] object-cover ring-1 ring-black/[0.08] dark:ring-white/[0.08]"
     />
   );

--- a/apps/dashboard/src/lib/session-replay-format.ts
+++ b/apps/dashboard/src/lib/session-replay-format.ts
@@ -1,0 +1,10 @@
+/** Human-readable session length, eg. `3m 12s`. Shared by the replay list, the player, and the user overview header. */
+export function formatDurationMs(ms: number) {
+  if (!Number.isFinite(ms) || ms < 0) return "—";
+  const s = Math.floor(ms / 1000);
+  const m = Math.floor(s / 60);
+  const h = Math.floor(m / 60);
+  if (h > 0) return `${h}h ${m % 60}m`;
+  if (m > 0) return `${m}m ${s % 60}s`;
+  return `${s}s`;
+}

--- a/apps/dashboard/src/lib/user-agent.test.ts
+++ b/apps/dashboard/src/lib/user-agent.test.ts
@@ -82,6 +82,26 @@ describe("describeUserAgent", () => {
     });
   });
 
+  test("Internet Explorer 11 hides behind Trident/rv:", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Windows NT 6.1; Trident/7.0; rv:11.0) like Gecko")).toEqual({
+      deviceType: "desktop",
+      browser: "Internet Explorer 11",
+      os: "Windows 7",
+    });
+  });
+
+  test("older Internet Explorer uses the MSIE token", () => {
+    expect(describeUserAgent("Mozilla/5.0 (compatible; MSIE 9.0; Windows NT 6.1; Trident/5.0)")).toEqual({
+      deviceType: "desktop",
+      browser: "Internet Explorer 9",
+      os: "Windows 7",
+    });
+  });
+
+  test("unnamed Windows NT versions degrade to a plain Windows", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Windows NT 5.1) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/49.0.0.0 Safari/537.36").os).toBe("Windows");
+  });
+
   test("crawlers are flagged as bots", () => {
     expect(describeUserAgent("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)").deviceType).toBe("bot");
     expect(describeUserAgent("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36").deviceType).toBe("bot");
@@ -103,6 +123,7 @@ describe("formatUserAgentSummary", () => {
 
   test("falls back to whichever half is known", () => {
     expect(formatUserAgentSummary("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe("macOS");
+    expect(formatUserAgentSummary("Mozilla/5.0 Firefox/133.0")).toBe("Firefox 133");
     expect(formatUserAgentSummary("some-internal-client/1.0")).toBe(null);
   });
 });

--- a/apps/dashboard/src/lib/user-agent.test.ts
+++ b/apps/dashboard/src/lib/user-agent.test.ts
@@ -1,0 +1,108 @@
+import { describe, expect, test } from "vitest";
+import { describeUserAgent, formatUserAgentSummary } from "./user-agent";
+
+describe("describeUserAgent", () => {
+  test("Chrome on macOS", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")).toEqual({
+      deviceType: "desktop",
+      browser: "Chrome 141",
+      os: "macOS",
+    });
+  });
+
+  test("Edge is not reported as Chrome", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/140.0.0.0 Safari/537.36 Edg/140.0.3485.66")).toEqual({
+      deviceType: "desktop",
+      browser: "Edge 140",
+      os: "Windows 10+",
+    });
+  });
+
+  test("Safari on macOS uses the Version/ token, not the WebKit build", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/18.2 Safari/605.1.15")).toEqual({
+      deviceType: "desktop",
+      browser: "Safari 18",
+      os: "macOS",
+    });
+  });
+
+  test("Safari on iPhone", () => {
+    expect(describeUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Mobile/15E148 Safari/604.1")).toEqual({
+      deviceType: "mobile",
+      browser: "Safari 17",
+      os: "iOS 17.2",
+    });
+  });
+
+  test("Chrome on iOS reports itself as CriOS", () => {
+    expect(describeUserAgent("Mozilla/5.0 (iPhone; CPU iPhone OS 16_6 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/115.0.5790.130 Mobile/15E148 Safari/604.1")).toEqual({
+      deviceType: "mobile",
+      browser: "Chrome 115",
+      os: "iOS 16.6",
+    });
+  });
+
+  test("iPad is a tablet", () => {
+    expect(describeUserAgent("Mozilla/5.0 (iPad; CPU OS 17_2 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.2 Safari/604.1")).toEqual({
+      deviceType: "tablet",
+      browser: "Safari 17",
+      os: "iOS 17.2",
+    });
+  });
+
+  test("Android phone", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Mobile Safari/537.36")).toEqual({
+      deviceType: "mobile",
+      browser: "Chrome 141",
+      os: "Android 14",
+    });
+  });
+
+  test("Android without the Mobile token is a tablet", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Linux; Android 13; SM-X710) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")).toEqual({
+      deviceType: "tablet",
+      browser: "Chrome 141",
+      os: "Android 13",
+    });
+  });
+
+  test("Firefox on Linux", () => {
+    expect(describeUserAgent("Mozilla/5.0 (X11; Linux x86_64; rv:133.0) Gecko/20100101 Firefox/133.0")).toEqual({
+      deviceType: "desktop",
+      browser: "Firefox 133",
+      os: "Linux",
+    });
+  });
+
+  test("Samsung Internet is not reported as Chrome", () => {
+    expect(describeUserAgent("Mozilla/5.0 (Linux; Android 13; SM-S918B) AppleWebKit/537.36 (KHTML, like Gecko) SamsungBrowser/23.0 Chrome/115.0.0.0 Mobile Safari/537.36")).toEqual({
+      deviceType: "mobile",
+      browser: "Samsung Internet 23",
+      os: "Android 13",
+    });
+  });
+
+  test("crawlers are flagged as bots", () => {
+    expect(describeUserAgent("Mozilla/5.0 (compatible; Googlebot/2.1; +http://www.google.com/bot.html)").deviceType).toBe("bot");
+    expect(describeUserAgent("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36").deviceType).toBe("bot");
+  });
+
+  test("unrecognized user agents degrade to nulls instead of throwing", () => {
+    expect(describeUserAgent("some-internal-client/1.0")).toEqual({
+      deviceType: "desktop",
+      browser: null,
+      os: null,
+    });
+  });
+});
+
+describe("formatUserAgentSummary", () => {
+  test("joins browser and OS", () => {
+    expect(formatUserAgentSummary("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/141.0.0.0 Safari/537.36")).toBe("Chrome 141 on macOS");
+  });
+
+  test("falls back to whichever half is known", () => {
+    expect(formatUserAgentSummary("Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)")).toBe("macOS");
+    expect(formatUserAgentSummary("some-internal-client/1.0")).toBe(null);
+  });
+});

--- a/apps/dashboard/src/lib/user-agent.test.ts
+++ b/apps/dashboard/src/lib/user-agent.test.ts
@@ -107,6 +107,14 @@ describe("describeUserAgent", () => {
     expect(describeUserAgent("Mozilla/5.0 AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36").deviceType).toBe("bot");
   });
 
+  test("headless Chrome keeps its browser label alongside the bot classification", () => {
+    expect(describeUserAgent("Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 (KHTML, like Gecko) HeadlessChrome/141.0.0.0 Safari/537.36")).toEqual({
+      deviceType: "bot",
+      browser: "Chrome 141",
+      os: "Linux",
+    });
+  });
+
   test("unrecognized user agents degrade to nulls instead of throwing", () => {
     expect(describeUserAgent("some-internal-client/1.0")).toEqual({
       deviceType: "desktop",

--- a/apps/dashboard/src/lib/user-agent.ts
+++ b/apps/dashboard/src/lib/user-agent.ts
@@ -31,7 +31,9 @@ const BROWSER_RULES: Array<{ name: string, regex: RegExp }> = [
   { name: "Brave", regex: /\bBrave\/([\d.]+)/ },
   { name: "Vivaldi", regex: /\bVivaldi\/([\d.]+)/ },
   { name: "Firefox", regex: /\b(?:Firefox|FxiOS)\/([\d.]+)/ },
-  { name: "Chrome", regex: /\b(?:Chrome|CriOS|Chromium)\/([\d.]+)/ },
+  // `HeadlessChrome` has no word boundary before `Chrome`, so it needs naming
+  // explicitly; it still gets classified as a bot separately.
+  { name: "Chrome", regex: /\b(?:HeadlessChrome|Chrome|CriOS|Chromium)\/([\d.]+)/ },
   // Safari puts the user-facing version in `Version/`; the `Safari/` token is a
   // WebKit build number and useless as a version.
   { name: "Safari", regex: /\bVersion\/([\d.]+).*\bSafari\// },

--- a/apps/dashboard/src/lib/user-agent.ts
+++ b/apps/dashboard/src/lib/user-agent.ts
@@ -39,12 +39,14 @@ const BROWSER_RULES: Array<{ name: string, regex: RegExp }> = [
   { name: "Internet Explorer", regex: /\bMSIE ([\d.]+)/ },
 ];
 
-const WINDOWS_NT_VERSIONS: Record<string, string> = {
-  "10.0": "Windows 10+",
-  "6.3": "Windows 8.1",
-  "6.2": "Windows 8",
-  "6.1": "Windows 7",
-};
+// A Map rather than a Record so unlisted NT versions (older or newer than the
+// ones we name) are typed as absent and fall back to a plain "Windows".
+const WINDOWS_NT_VERSIONS = new Map<string, string>([
+  ["10.0", "Windows 10+"],
+  ["6.3", "Windows 8.1"],
+  ["6.2", "Windows 8"],
+  ["6.1", "Windows 7"],
+]);
 
 function majorVersion(version: string): string {
   return version.split(".")[0] ?? version;
@@ -63,7 +65,7 @@ function describeBrowser(userAgent: string): string | null {
 function describeOs(userAgent: string): string | null {
   const windows = /Windows NT ([\d.]+)/.exec(userAgent);
   if (windows?.[1] != null) {
-    return WINDOWS_NT_VERSIONS[windows[1]] ?? "Windows";
+    return WINDOWS_NT_VERSIONS.get(windows[1]) ?? "Windows";
   }
 
   // iPadOS/iOS report the version with underscores, and iPad Safari in desktop

--- a/apps/dashboard/src/lib/user-agent.ts
+++ b/apps/dashboard/src/lib/user-agent.ts
@@ -1,0 +1,120 @@
+/**
+ * Minimal user-agent describer for admin surfaces (session replays, activity
+ * lists). We deliberately don't pull in a UA-parsing dependency: we only need a
+ * human-readable "Chrome 141 on macOS" summary, and every UA we see is one the
+ * event tracker collected from `navigator.userAgent` in a real browser.
+ *
+ * The rules are ordered because UA strings lie for backwards-compatibility
+ * reasons: Edge claims to be Chrome and Safari, Chrome claims to be Safari, and
+ * every iOS browser claims to be Safari. Matching the most specific token first
+ * is the only way to get the right answer.
+ */
+
+export type UserAgentDeviceType = "desktop" | "mobile" | "tablet" | "bot";
+
+export type DescribedUserAgent = {
+  deviceType: UserAgentDeviceType,
+  /** Browser name plus major version, eg. `Chrome 141`. Null when unrecognized. */
+  browser: string | null,
+  /** OS name plus version where the UA reports a meaningful one, eg. `iOS 17.2`. Null when unrecognized. */
+  os: string | null,
+};
+
+const BOT_REGEX = /bot\b|crawler|spider|crawling|slurp|headlesschrome|lighthouse|bingpreview|facebookexternalhit|pingdom|curl\/|wget\/|python-requests/i;
+
+// Ordered: the first rule that matches wins.
+const BROWSER_RULES: Array<{ name: string, regex: RegExp }> = [
+  { name: "Edge", regex: /\bEdg(?:e|A|iOS)?\/([\d.]+)/ },
+  { name: "Opera", regex: /\bOPR\/([\d.]+)/ },
+  { name: "Opera", regex: /\bOpera\/([\d.]+)/ },
+  { name: "Samsung Internet", regex: /\bSamsungBrowser\/([\d.]+)/ },
+  { name: "Brave", regex: /\bBrave\/([\d.]+)/ },
+  { name: "Vivaldi", regex: /\bVivaldi\/([\d.]+)/ },
+  { name: "Firefox", regex: /\b(?:Firefox|FxiOS)\/([\d.]+)/ },
+  { name: "Chrome", regex: /\b(?:Chrome|CriOS|Chromium)\/([\d.]+)/ },
+  // Safari puts the user-facing version in `Version/`; the `Safari/` token is a
+  // WebKit build number and useless as a version.
+  { name: "Safari", regex: /\bVersion\/([\d.]+).*\bSafari\// },
+  { name: "Internet Explorer", regex: /\bTrident\/.*\brv:([\d.]+)/ },
+  { name: "Internet Explorer", regex: /\bMSIE ([\d.]+)/ },
+];
+
+const WINDOWS_NT_VERSIONS: Record<string, string> = {
+  "10.0": "Windows 10+",
+  "6.3": "Windows 8.1",
+  "6.2": "Windows 8",
+  "6.1": "Windows 7",
+};
+
+function majorVersion(version: string): string {
+  return version.split(".")[0] ?? version;
+}
+
+function describeBrowser(userAgent: string): string | null {
+  for (const rule of BROWSER_RULES) {
+    const match = rule.regex.exec(userAgent);
+    if (match?.[1] != null) {
+      return `${rule.name} ${majorVersion(match[1])}`;
+    }
+  }
+  return null;
+}
+
+function describeOs(userAgent: string): string | null {
+  const windows = /Windows NT ([\d.]+)/.exec(userAgent);
+  if (windows?.[1] != null) {
+    return WINDOWS_NT_VERSIONS[windows[1]] ?? "Windows";
+  }
+
+  // iPadOS/iOS report the version with underscores, and iPad Safari in desktop
+  // mode reports `Macintosh` — that ambiguity is unresolvable from the UA, so
+  // such a request is described as macOS.
+  const ios = /(?:iPhone OS|CPU OS|iPhone_OS) ([\d_]+)/.exec(userAgent);
+  if (ios?.[1] != null) {
+    return `iOS ${ios[1].replaceAll("_", ".")}`;
+  }
+  if (/\biPad\b|\biPhone\b|\biPod\b/.test(userAgent)) {
+    return "iOS";
+  }
+
+  const android = /Android ([\d.]+)/.exec(userAgent);
+  if (android?.[1] != null) {
+    return `Android ${majorVersion(android[1])}`;
+  }
+  if (/\bAndroid\b/.test(userAgent)) {
+    return "Android";
+  }
+
+  if (/\bCrOS\b/.test(userAgent)) return "ChromeOS";
+  // The reported `Mac OS X 10_15_7` has been frozen by browsers for years, so
+  // showing it would be actively misleading.
+  if (/\bMac OS X\b|\bMacintosh\b/.test(userAgent)) return "macOS";
+  if (/\bWindows\b/.test(userAgent)) return "Windows";
+  if (/\bUbuntu\b/.test(userAgent)) return "Ubuntu";
+  if (/\bLinux\b|\bX11\b/.test(userAgent)) return "Linux";
+  return null;
+}
+
+function describeDeviceType(userAgent: string): UserAgentDeviceType {
+  if (BOT_REGEX.test(userAgent)) return "bot";
+  // Android tablets are Android UAs *without* the `Mobile` token.
+  if (/\biPad\b|\bTablet\b|\bSilk\b|\bPlayBook\b/.test(userAgent)) return "tablet";
+  if (/\bAndroid\b/.test(userAgent) && !/\bMobile\b/.test(userAgent)) return "tablet";
+  if (/\bMobi\b|\bMobile\b|\biPhone\b|\biPod\b|\bAndroid\b|\bWindows Phone\b/.test(userAgent)) return "mobile";
+  return "desktop";
+}
+
+export function describeUserAgent(userAgent: string): DescribedUserAgent {
+  return {
+    deviceType: describeDeviceType(userAgent),
+    browser: describeBrowser(userAgent),
+    os: describeOs(userAgent),
+  };
+}
+
+/** `Chrome 141 on macOS`, degrading gracefully when either half is unknown. */
+export function formatUserAgentSummary(userAgent: string): string | null {
+  const described = describeUserAgent(userAgent);
+  if (described.browser != null && described.os != null) return `${described.browser} on ${described.os}`;
+  return described.browser ?? described.os;
+}

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -5,6 +5,15 @@ import { wait } from "@hexclave/shared/dist/utils/promises";
 import { it } from "../../../../helpers";
 import { Auth, Project, Team, backendContext, bumpEmailAddress, niceBackendFetch, withInternalProject } from "../../../backend-helpers";
 
+/**
+ * Response bodies come back as `any` from the fetch helper; this narrows a list
+ * of them to something indexable so the tests can read fields without casts.
+ */
+function asObjects(value: unknown): Record<string, unknown>[] {
+  if (!Array.isArray(value)) return [];
+  return value.filter((item): item is Record<string, unknown> => typeof item === "object" && item !== null);
+}
+
 async function uploadBatch(options: {
   browserSessionId: string,
   batchId: string,
@@ -721,7 +730,7 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
 
 it("admin session replay endpoints expose the recording session's refresh token", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
-  await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
+  await Project.updateConfig({ "apps.installed.analytics.enabled": true });
   await Auth.Otp.signIn();
 
   const upload = await uploadBatch({
@@ -745,12 +754,12 @@ it("admin session replay endpoints expose the recording session's refresh token"
     accessType: "client",
   });
   expect(sessions.status).toBe(200);
-  const currentSessionId = sessions.body?.items?.find((s: any) => s.is_current_session)?.id;
+  const currentSessionId = asObjects(sessions.body?.items).find(s => s.is_current_session === true)?.id;
   if (typeof currentSessionId !== "string") {
     throw new Error("Expected the signed-in session to be listed as the current session.");
   }
 
-  const single = await niceBackendFetch(`/api/v1/internal/session-replays/${recordingId}`, {
+  const single = await niceBackendFetch(`/api/v1/internal/session-replays/${encodeURIComponent(recordingId)}`, {
     method: "GET",
     accessType: "admin",
   });
@@ -759,9 +768,9 @@ it("admin session replay endpoints expose the recording session's refresh token"
 
   const list = await listReplaysWithRetry(
     {},
-    (res) => res.status === 200 && (res.body?.items ?? []).some((i: any) => i.id === recordingId),
+    (res) => res.status === 200 && asObjects(res.body?.items).some(i => i.id === recordingId),
   );
-  const listed = list.body?.items?.find((i: any) => i.id === recordingId);
+  const listed = asObjects(list.body?.items).find(i => i.id === recordingId);
   expect(listed?.refresh_token_id).toBe(currentSessionId);
 });
 

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -719,6 +719,52 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
   `);
 });
 
+it("admin session replay endpoints expose the recording session's refresh token", async ({ expect }) => {
+  await Project.createAndSwitch({ config: { magic_link_enabled: true } });
+  await Project.updateConfig({ apps: { installed: { analytics: { enabled: true } } } });
+  await Auth.Otp.signIn();
+
+  const upload = await uploadBatch({
+    browserSessionId: randomUUID(),
+    batchId: randomUUID(),
+    startedAtMs: 1_700_000_000_000,
+    sentAtMs: 1_700_000_000_400,
+    events: [{ type: 1, timestamp: 1_700_000_000_100 }],
+  });
+  expect(upload.status).toBe(200);
+  const recordingId = upload.body?.session_replay_id;
+  if (typeof recordingId !== "string") {
+    throw new Error("Expected session replay id.");
+  }
+
+  // The session that uploaded the replay, straight from the sessions endpoint —
+  // asserting against this is what proves the field isn't just some other UUID
+  // (the replay's own id, say) that happens to survive snapshot anonymization.
+  const sessions = await niceBackendFetch("/api/v1/auth/sessions?user_id=me", {
+    method: "GET",
+    accessType: "client",
+  });
+  expect(sessions.status).toBe(200);
+  const currentSessionId = sessions.body?.items?.find((s: any) => s.is_current_session)?.id;
+  if (typeof currentSessionId !== "string") {
+    throw new Error("Expected the signed-in session to be listed as the current session.");
+  }
+
+  const single = await niceBackendFetch(`/api/v1/internal/session-replays/${recordingId}`, {
+    method: "GET",
+    accessType: "admin",
+  });
+  expect(single.status).toBe(200);
+  expect(single.body?.refresh_token_id).toBe(currentSessionId);
+
+  const list = await listReplaysWithRetry(
+    {},
+    (res) => res.status === 200 && (res.body?.items ?? []).some((i: any) => i.id === recordingId),
+  );
+  const listed = list.body?.items?.find((i: any) => i.id === recordingId);
+  expect(listed?.refresh_token_id).toBe(currentSessionId);
+});
+
 it("admin get session replay returns 404 for nonexistent id", async ({ expect }) => {
   await Project.createAndSwitch({ config: { magic_link_enabled: true } });
   await Auth.Otp.signIn();

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -711,6 +711,7 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
           "id": "<stripped UUID>",
           "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
         },
+        "refresh_token_id": "<stripped UUID>",
         "started_at_millis": 1700000000100,
       },
       "headers": Headers { <some fields may have been hidden> },

--- a/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/session-replays.test.ts
@@ -720,7 +720,7 @@ it("admin can fetch a single session replay by id", async ({ expect }) => {
           "id": "<stripped UUID>",
           "primary_email": "default-mailbox--<stripped UUID>@stack-generated.example.com",
         },
-        "refresh_token_id": "<stripped UUID>",
+        "refresh_token_id": <stripped field 'refresh_token_id'>,
         "started_at_millis": 1700000000100,
       },
       "headers": Headers { <some fields may have been hidden> },

--- a/packages/shared/src/interface/crud/session-replays.ts
+++ b/packages/shared/src/interface/crud/session-replays.ts
@@ -13,6 +13,7 @@ export type AdminListSessionReplaysOptions = {
 export type AdminListSessionReplaysResponse = {
   items: Array<{
     id: string,
+    refresh_token_id: string,
     project_user: {
       id: string,
       display_name: string | null,
@@ -30,6 +31,7 @@ export type AdminListSessionReplaysResponse = {
 
 export type AdminGetSessionReplayResponse = {
   id: string,
+  refresh_token_id: string,
   project_user: {
     id: string,
     display_name: string | null,

--- a/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
+++ b/packages/template/src/lib/hexclave-app/apps/implementations/admin-app-impl.ts
@@ -1430,6 +1430,7 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
 
     const items: AdminSessionReplay[] = response.items.map((r) => ({
       id: r.id,
+      refreshTokenId: r.refresh_token_id,
       projectUser: {
         id: r.project_user.id,
         displayName: r.project_user.display_name,
@@ -1451,6 +1452,7 @@ export class _HexclaveAdminAppImplIncomplete<HasTokenStore extends boolean, Proj
     const response = await this._interface.getSessionReplay(sessionReplayId);
     return {
       id: response.id,
+      refreshTokenId: response.refresh_token_id,
       projectUser: {
         id: response.project_user.id,
         displayName: response.project_user.display_name,

--- a/packages/template/src/lib/hexclave-app/session-replays/index.ts
+++ b/packages/template/src/lib/hexclave-app/session-replays/index.ts
@@ -1,5 +1,7 @@
 export type AdminSessionReplay = {
   id: string,
+  /** The session the replay was recorded in; analytics events of the same session carry it too. */
+  refreshTokenId: string,
   projectUser: {
     id: string,
     displayName: string | null,


### PR DESCRIPTION
The session replay player's header was a single link with the user's display name. It now shows who you're watching and where they came from, without leaving the replay.

**New header** (`session-replays/replay-user-overview.tsx`), rendered in place of the old `StyledLink`:
- Identity: avatar, name (still links to the user page), email with a verified/unverified marker, badges for anonymous / restricted / 2FA / high bot risk.
- This session: duration, page views, clicks; device (`Chrome 141 on macOS`, with an icon per device type) plus screen and window size; approximate location with flag and local time; referrer host with favicon (or "Direct traffic"); the page they landed on.
- Account: signed up / last active, sign-in methods, teams, user ID with a copy button.

Session-specific facts come from the analytics events recorded alongside the replay: the entry `$page-view` for device/referrer/entry page, aggregate counts for pages and clicks, and the `$token-refresh` nearest the session for geo (replay events carry no IP). Those three queries are one `useEffect` with explicit loading / error / empty handling, so an analytics outage degrades to "Session context unavailable" rather than breaking the player. Account facts come from `useUser` + `useOAuthProviders` + `useTeams`, with the slower two behind their own Suspense boundary so the rest of the header doesn't flash.

`lib/user-agent.ts` describes a UA as browser + OS + device type without adding a dependency (ordered rules, since Edge claims to be Chrome and every iOS browser claims to be Safari); unit-tested against real UA strings.

Supporting moves: `formatDurationMs` → `lib/session-replay-format.ts`, and the country-flag/referrer-favicon/region helpers out of the overview page's `top-lists.tsx` into `components/geo-referrer.tsx` so both surfaces share them.

The dummy-data seeder previously created replay rows with no analytics events, so the new header (and the existing timeline markers) had nothing to show locally. It now emits matching `$page-view` / `$click` / `$token-refresh` events per seeded replay, across a spread of devices and locations.


Link to Devin session: https://app.devin.ai/sessions/378ba4e117634c449c6a5d64a03b1f70
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Adds a user overview to the session replay header so you can see who you’re watching and key session context without leaving the replay. Correlates device, referrer, and geo to the replay’s exact session with safer scoping and resilient loading.

- **New Features**
  - Replaced the header link with `ReplayUserOverview` and a Suspense-backed skeleton.
  - Shows identity and session context: duration, pages, clicks; device with icon + screen/window size; location with flag and local time; referrer host with favicon; landing page.
  - Data source: first `$page-view` for device/referrer/entry, aggregated counts for pages/clicks, and the `$token-refresh` nearest the replay start for geo (keyed by `refresh_token_id`), with explicit loading/error/empty handling.
  - Reusable utilities: UA parsing without a dependency (with tests), shared `formatDurationMs`, and `CountryFlag`/`ReferrerFavicon`/`regionName`.
  - Demo data: seeds `$page-view`/`$click`/`$token-refresh` events (with segment IDs and varied devices) so the header shows realistic context locally; only inserted when ClickHouse is configured.

- **Bug Fixes**
  - Geo is tied to the replay’s own session via `refresh_token_id` and taken from the refresh closest to the replay start to avoid cross-session or clock-boundary errors.
  - Each analytics query degrades independently; unavailable activity counts aren’t shown as 0; a replay row without a session fails fast.
  - Keeps Headless Chrome labelled while marking it as a bot; improved favicon/flag fallbacks and small tooltip/accessibility tweaks.
  - E2E: added a test asserting `refresh_token_id` is returned by single/list endpoints and aligned snapshots with the serializer that strips it.

<sup>Written for commit 3c0a36b388fafd5a88f1a2c432b3c28ac041d154. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1870?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a detailed session replay overview with duration, device, viewport, location, referrer, landing page, activity, account, and authentication information.
  * Added improved browser and device recognition, including bot, mobile, tablet, and desktop detection.
  * Added country flags, referrer favicons, and readable region names.
  * Seeded replays with realistic analytics activity for richer demo data.
  * Linked replays with refresh-token information for more accurate session context.

* **Bug Fixes**
  * Improved handling of missing, invalid, or deleted user and session information.
  * Added loading, error, and fallback states throughout replay details.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->