### PR TITLE
Fix replica-lag flake in the users list limit test

### DIFF
--- a/apps/e2e/tests/backend/endpoints/api/v1/users-list-limit.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/users-list-limit.test.ts
@@ -3,6 +3,7 @@ import { describe } from "vitest";
 import { test } from "../../../../helpers";
 import { POSTGRES_HOST, POSTGRES_PASSWORD, POSTGRES_USER } from "./external-db-sync-utils";
 import { InternalProjectKeys, Project, backendContext, niceBackendFetch } from "../../../backend-helpers";
+import { waitUntilReplicasHaveCaughtUp } from "../../../helpers/replication";
 
 const batchSize = 5000;
 
@@ -73,6 +74,9 @@ async function seedUsers(projectId: string, userCount: number, prefix: string): 
       `, [tenancyId, projectId, offset + 1, count, prefix]);
     }
 
+    // The users endpoint reads from a read replica, and these inserts don't go through the Prisma extension that
+    // normally waits for replication, so without this the request below can see an empty tenancy.
+    await waitUntilReplicasHaveCaughtUp(client);
   } finally {
     await client.end();
   }

--- a/apps/e2e/tests/backend/helpers/replication.ts
+++ b/apps/e2e/tests/backend/helpers/replication.ts
@@ -1,0 +1,29 @@
+import { throwErr } from "@hexclave/shared/dist/utils/errors";
+import { wait } from "@hexclave/shared/dist/utils/promises";
+import { Client } from "pg";
+
+// The backend's Prisma client routes read queries to a read replica (in dev/CI, db-replica applies WAL with an
+// artificial delay). Read-after-write consistency comes from a Prisma extension that, after every write it performs,
+// waits until the replicas have replayed the primary's WAL. Tests that seed rows with raw SQL bypass that extension,
+// so the replica may still be behind when the test calls the API next and the endpoint then reads a tenancy that
+// looks empty. Call this after raw-SQL writes whose effect the test expects a subsequent API request to observe.
+//
+// pg_stat_replication lives on the primary and only has a row per currently streaming standby, so a deployment
+// without replicas (where reads go to the primary anyway) returns immediately.
+export async function waitUntilReplicasHaveCaughtUp(primaryClient: Client, timeoutMs: number = 60_000): Promise<void> {
+  const target = (await primaryClient.query<{ lsn: string }>(`SELECT pg_current_wal_lsn()::text AS lsn`)).rows[0]?.lsn
+    ?? throwErr("pg_current_wal_lsn() returned no row; is this connection pointing at a PostgreSQL primary?");
+
+  const deadline = performance.now() + timeoutMs;
+  while (true) {
+    const behind = (await primaryClient.query<{ behind: number }>(
+      `SELECT count(*)::int AS behind FROM pg_stat_replication WHERE "replay_lsn" IS NULL OR "replay_lsn" < $1::pg_lsn`,
+      [target],
+    )).rows[0]?.behind ?? throwErr("Counting lagging replicas returned no row");
+    if (behind === 0) return;
+    if (performance.now() > deadline) {
+      throw new Error(`${behind} replica(s) did not replay up to ${target} within ${timeoutMs}ms`);
+    }
+    await wait(20);
+  }
+}


### PR DESCRIPTION
`users-list-limit.test.ts` intermittently failed with a 200 and an empty item list where it expects the 400:

```
- "status": 400,
- "body": "Listing more than 1000 users requires a limit. ..."
+ "status": 200,
+ "body": { "is_paginated": true, "items": [], "pagination": { "next_cursor": null } }
```

## Root cause

Not the endpoint: the tenancy genuinely had no visible users yet.

The test seeds users with raw SQL against the primary (`localhost:<prefix>28`), but `GET /api/v1/users` reads through Prisma, whose read-replica extension routes `findMany` to the replica (`localhost:<prefix>34`, `recovery_min_apply_delay` in dev/CI). Read-after-write consistency comes from the replication-wait extension, which only waits for writes Prisma itself performed — a raw-SQL insert is invisible to it. Each seed batch is one statement, so the replica either has all of it or none of it; when it is behind, the endpoint sees an empty tenancy, `db.length` is 0, and the >1000 check never fires.

## Fix

New `apps/e2e/tests/backend/helpers/replication.ts`: after raw-SQL writes, capture `pg_current_wal_lsn()` on the primary and poll `pg_stat_replication` until every streaming standby has `replay_lsn >= target`. `pg_stat_replication` is empty when there are no replicas (reads go to the primary anyway), so the helper is a no-op there.

`seedUsers` calls it before returning.

## Reproduce / validate

Restarting deps with `STACK_DATABASE_REPLICA_LAG_MS=1000` makes the flake deterministic:

| | before | after |
| --- | --- | --- |
| `allows exactly 1000 unbounded users` | fail (`expected [] to have a length of 1000`) | pass |
| `rejects 1001 unbounded users ...` | fail (identical snapshot diff to CI) | pass |
| `rejects the former high-volume failure case ...` | pass | pass |

Three consecutive runs of the file pass with the 1s lag still configured. `pnpm -C apps/e2e lint` and `pnpm -C apps/e2e typecheck` are clean.


Link to Devin session: https://app.devin.ai/sessions/adf3b3bee167462da2122c53c49f80b7
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Fixes the flaky users list limit test by waiting for the read replica to catch up after raw SQL seeding. Ensures the replica sees seeded users so the endpoint returns the expected 400.

- **Bug Fixes**
  - Root cause: seeding used raw SQL on the primary, while the API reads via Prisma on a replica; the Prisma wait only covers its own writes, so the replica sometimes saw an empty tenancy.
  - Fix: added `waitUntilReplicasHaveCaughtUp` to poll `pg_stat_replication` using `pg_current_wal_lsn()`; no-op without replicas; called in `seedUsers` before returning.
  - Validation: with `STACK_DATABASE_REPLICA_LAG_MS=1000`, previously failing tests now pass consistently.

<sup>Written for commit 95540111250f6b459aec00d9b21d2fcb37e7a035. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1872?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved end-to-end test reliability for user-list requests in environments with read replicas.
  * Added synchronization checks to ensure newly seeded data is available across replicas before validation.
  * Added timeout and error handling for replication delays and invalid database responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->