### PR TITLE
Avoid ClickHouse FINAL when counting users in the newly-created-projects tool

### DIFF
--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
@@ -273,6 +273,7 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
         // user-heavy projects). A manual argMax dedup spills to disk under the
         // same memory setting. `(project_id, branch_id, id)` is the table's
         // ORDER BY / dedup key, so grouping by it reproduces `FINAL` exactly.
+        // Re-seeded rows can share a version, so break ties by insertion time.
         query: `
           SELECT
             project_id AS projectId,
@@ -281,8 +282,8 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
           FROM (
             SELECT
               project_id,
-              argMax(is_anonymous, sync_sequence_id) AS isAnonymous,
-              argMax(sync_is_deleted, sync_sequence_id) AS syncIsDeleted
+              argMax(is_anonymous, (sync_sequence_id, sync_created_at)) AS isAnonymous,
+              argMax(sync_is_deleted, (sync_sequence_id, sync_created_at)) AS syncIsDeleted
             FROM analytics_internal.users
             WHERE branch_id = {branchId:String}
               AND project_id IN {projectIds:Array(String)}

--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
@@ -262,15 +262,33 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
   try {
     const [userRowsResult, activityRowsResult] = await Promise.all([
       clickhouse.query({
+        // Deduplicate the ReplacingMergeTree rows to each user's latest version
+        // with an explicit argMax GROUP BY instead of `FINAL`. `FINAL` merges
+        // parts outside the aggregation pipeline, so it is NOT bounded by
+        // `max_bytes_before_external_group_by`; over this tool's candidate
+        // window (up to CANDIDATE_WINDOW_SIZE projects, unbounded in time) that
+        // merge blew past the per-query `max_memory_usage` cap and threw
+        // MEMORY_LIMIT_EXCEEDED (most visibly with `neon=exclude`, which skips
+        // the many near-empty Neon projects and fills the window with real,
+        // user-heavy projects). A manual argMax dedup spills to disk under the
+        // same memory setting. `(project_id, branch_id, id)` is the table's
+        // ORDER BY / dedup key, so grouping by it reproduces `FINAL` exactly.
         query: `
           SELECT
             project_id AS projectId,
-            countIf(is_anonymous = 0) AS nonAnon,
-            countIf(is_anonymous = 1) AS anon
-          FROM analytics_internal.users FINAL
-          WHERE branch_id = {branchId:String}
-            AND sync_is_deleted = 0
-            AND project_id IN {projectIds:Array(String)}
+            countIf(isAnonymous = 0) AS nonAnon,
+            countIf(isAnonymous = 1) AS anon
+          FROM (
+            SELECT
+              project_id,
+              argMax(is_anonymous, sync_sequence_id) AS isAnonymous,
+              argMax(sync_is_deleted, sync_sequence_id) AS syncIsDeleted
+            FROM analytics_internal.users
+            WHERE branch_id = {branchId:String}
+              AND project_id IN {projectIds:Array(String)}
+            GROUP BY project_id, branch_id, id
+          )
+          WHERE syncIsDeleted = 0
           GROUP BY project_id
         `,
         query_params: { branchId, projectIds },


### PR DESCRIPTION
The per-project user counts in `loadProjectActivityMetrics` read `analytics_internal.users FINAL` for the whole candidate window (up to `CANDIDATE_WINDOW_SIZE` projects, with no time bound). `FINAL` merges parts outside the aggregation pipeline, so it isn't bounded by `max_bytes_before_external_group_by` and could exceed the per-query `max_memory_usage` cap, failing the request with `MEMORY_LIMIT_EXCEEDED`.

Every other `users FINAL` query in the codebase is scoped to a single project plus a 30-day window, which is the assumption `METRICS_CLICKHOUSE_SETTINGS` was tuned for; this endpoint is the one that doesn't fit it.

Replaces `FINAL` with an explicit dedup on the table's `ORDER BY` / dedup key, which spills to disk under the existing memory setting:

```sql
SELECT project_id, countIf(isAnonymous = 0), countIf(isAnonymous = 1)
FROM (
  SELECT project_id,
         argMax(is_anonymous, sync_sequence_id) AS isAnonymous,
         argMax(sync_is_deleted, sync_sequence_id) AS syncIsDeleted
  FROM analytics_internal.users
  WHERE branch_id = {branchId} AND project_id IN {projectIds}
  GROUP BY project_id, branch_id, id
)
WHERE syncIsDeleted = 0
GROUP BY project_id
```

`users` is a `ReplacingMergeTree(sync_sequence_id)` ordered by `(project_id, branch_id, id)`, so grouping by that key and taking `argMax` over the version column reproduces `FINAL` exactly — results are unchanged.

Backend typecheck, lint, and the existing `newly-created-projects` e2e suite pass.


Link to Devin session: https://app.devin.ai/sessions/166ffd91dd254582bd258dc202058e05
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Replaced ClickHouse FINAL in newly-created-projects user counting with an explicit argMax dedup on `(project_id, branch_id, id)`, now tie‑breaking by insert time. This prevents memory spikes and keeps results identical.

- **Bug Fixes**
  - Deduplicates `analytics_internal.users` using `argMax(..., (sync_sequence_id, sync_created_at))`, filters out deleted rows, then counts anon vs non‑anon per project (handles reseeded rows with equal versions).
  - Keeps work inside the aggregation pipeline so disk spill applies, avoiding `MEMORY_LIMIT_EXCEEDED` on large candidate windows.

<sup>Written for commit c386c31ad4a480ef4d27660c9021b0de892821e0. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1873?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved the accuracy of project activity metrics by preventing duplicate user records from affecting newly created project statistics.
  * Preserved correct handling of deleted, anonymous, and identified users.
  * Improved reliability when processing larger volumes of activity data.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->