### PR TITLE
fix: harden Elysia runtime against production-readiness review findings

### DIFF
--- a/apps/backend/package.json
+++ b/apps/backend/package.json
@@ -20,7 +20,7 @@
     "build": "pnpm run codegen && tsdown --config tsdown.config.ts",
     "docker-build": "pnpm run codegen && tsdown --config tsdown.config.ts",
     "build-self-host-migration-script": "tsdown --config scripts/db-migrations.tsdown.config.ts",
-    "start": "node dist/server.mjs",
+    "start": "NODE_ENV=${NODE_ENV:-production} dotenv -c production -- node dist/server.mjs",
     "codegen-prisma": "HEXCLAVE_DATABASE_CONNECTION_STRING=\"${HEXCLAVE_DATABASE_CONNECTION_STRING:-${STACK_DATABASE_CONNECTION_STRING:-placeholder-database-connection-string}}\" pnpm run prisma generate",
     "codegen-prisma:watch": "HEXCLAVE_DATABASE_CONNECTION_STRING=\"${HEXCLAVE_DATABASE_CONNECTION_STRING:-${STACK_DATABASE_CONNECTION_STRING:-placeholder-database-connection-string}}\" pnpm run prisma generate --watch",
     "generate-private-sign-up-risk-engine": "pnpm run with-env tsx scripts/generate-private-sign-up-risk-engine.ts",

--- a/apps/backend/src/app/api/latest/deployments/runs/[run_id]/logs/route.tsx
+++ b/apps/backend/src/app/api/latest/deployments/runs/[run_id]/logs/route.tsx
@@ -132,7 +132,11 @@ export const GET = createSmartRouteHandler({
         status: 200,
         headers: {
           "content-type": "text/plain; charset=utf-8",
-          "cache-control": "no-store",
+          // no-transform keeps the compression layer (server/compression.ts)
+          // from piping this stream through CompressionStream("gzip"), whose
+          // internal buffering would stall the incremental log delivery this
+          // route exists to provide.
+          "cache-control": "no-store, no-transform",
         },
       }),
     };

--- a/apps/backend/src/instrumentation-plan.test.ts
+++ b/apps/backend/src/instrumentation-plan.test.ts
@@ -80,6 +80,61 @@ describe("createBackendInstrumentationPlan", () => {
     `);
   });
 
+  // The pre-Elysia @sentry/nextjs setup enabled Sentry for any non-development,
+  // non-CI environment with a DSN — not just NODE_ENV=production. These tests pin
+  // that behavior so staging/preview-like NODE_ENV values keep error reporting.
+  it("enables Sentry for a custom non-development NODE_ENV such as staging", () => {
+    expect(createBackendInstrumentationPlan({
+      ...baseOptions,
+      nodeEnvironment: "staging",
+      sentryDsn: "https://public@example.invalid/1",
+    }).sentryEnabled).toBe(true);
+  });
+
+  it("does not enable Sentry in development even when a DSN is set", () => {
+    expect(createBackendInstrumentationPlan({
+      ...baseOptions,
+      nodeEnvironment: "development",
+      sentryDsn: "https://public@example.invalid/1",
+    }).sentryEnabled).toBe(false);
+  });
+
+  it("does not enable Sentry in test even when a DSN is set", () => {
+    expect(createBackendInstrumentationPlan({
+      ...baseOptions,
+      nodeEnvironment: "test",
+      sentryDsn: "https://public@example.invalid/1",
+    }).sentryEnabled).toBe(false);
+  });
+
+  it("does not enable Sentry when the DSN is empty", () => {
+    expect(createBackendInstrumentationPlan({
+      ...baseOptions,
+    }).sentryEnabled).toBe(false);
+  });
+
+  it("does not enable Sentry in CI even with a DSN and a production NODE_ENV", () => {
+    expect(createBackendInstrumentationPlan({
+      ...baseOptions,
+      ci: "true",
+      sentryDsn: "https://public@example.invalid/1",
+    }).sentryEnabled).toBe(false);
+  });
+
+  it("names the offending environment variable when the OTLP endpoint is not a URL", () => {
+    expect(() => createBackendInstrumentationPlan({
+      ...baseOptions,
+      otlpEndpoint: "not a url",
+    })).toThrowErrorMatchingInlineSnapshot(`[Error: OTEL_EXPORTER_OTLP_ENDPOINT is not a valid URL: "not a url"]`);
+  });
+
+  it("names the offending environment variable when the traces endpoint is not a URL", () => {
+    expect(() => createBackendInstrumentationPlan({
+      ...baseOptions,
+      otlpTracesEndpoint: "::::",
+    })).toThrowErrorMatchingInlineSnapshot(`[Error: OTEL_EXPORTER_OTLP_TRACES_ENDPOINT is not a valid URL: "::::"]`);
+  });
+
   it("rejects non-HTTP exporter endpoints", () => {
     expect(() => createBackendInstrumentationPlan({
       ...baseOptions,

--- a/apps/backend/src/instrumentation-plan.ts
+++ b/apps/backend/src/instrumentation-plan.ts
@@ -23,7 +23,14 @@ export function createBackendInstrumentationPlan(options: BackendInstrumentation
     };
   }
 
-  const sentryEnabled = options.nodeEnvironment === "production" && options.sentryDsn !== "";
+  // Matches the pre-Elysia @sentry/nextjs gating: Sentry was enabled whenever the DSN
+  // was set and we were neither in development nor in CI (CI is short-circuited above).
+  // An exact-match on "production" would be too narrow — a self-hoster or staging deploy
+  // with a custom NODE_ENV (e.g. "staging", "preview") would silently drop all error
+  // reporting. We additionally exclude "test" so test runs never report to Sentry.
+  const sentryEnabled = options.sentryDsn !== ""
+    && options.nodeEnvironment !== "development"
+    && options.nodeEnvironment !== "test";
   const configuredOtlpTracesEndpoint = options.otlpTracesEndpoint.trim();
   const configuredOtlpEndpoint = options.otlpEndpoint.trim();
   const otlpTracesEndpoint = configuredOtlpTracesEndpoint !== ""
@@ -44,7 +51,16 @@ export function createBackendInstrumentationPlan(options: BackendInstrumentation
 }
 
 function validateOtlpEndpoint(environmentVariableName: string, value: string) {
-  const url = new URL(value);
+  // A bare `new URL(value)` throws TypeError("Invalid URL") without naming the source,
+  // which is useless during a boot crash-loop — the operator can't tell which env var is
+  // malformed. This narrow try/catch is NOT error swallowing: it rethrows immediately
+  // (fail early, fail loud), just with the env var name and offending value attached.
+  let url;
+  try {
+    url = new URL(value);
+  } catch (error) {
+    throw new Error(`${environmentVariableName} is not a valid URL: ${JSON.stringify(value)}`, { cause: error });
+  }
   if (url.protocol !== "http:" && url.protocol !== "https:") {
     throw new Error(`${environmentVariableName} must use HTTP or HTTPS, got: ${JSON.stringify(url.protocol)}`);
   }

--- a/apps/backend/src/lib/deployments/vercel-client.tsx
+++ b/apps/backend/src/lib/deployments/vercel-client.tsx
@@ -123,14 +123,62 @@ export type VercelDeploymentEvent = {
   text: string,
 };
 
+/**
+ * Decides which abort signal (if any) an upstream Vercel fetch should use.
+ *
+ * An explicitly passed signal always wins — the caller opted into its own
+ * cancellation semantics. Otherwise, the ambient inbound-request signal (the
+ * one that fires when the HTTP client disconnects) is only used for GET/HEAD:
+ * aborting an idempotent read mid-flight is always safe and frees resources.
+ *
+ * For every other method it must NOT be used. These are mutations
+ * (createProject, createDeployment, uploadFile, env var upserts/deletes,
+ * domain add/verify/delete, project deletes/PATCHes), and Vercel may have
+ * already committed the mutation by the time our local fetch rejects with an
+ * AbortError — e.g. a deployment gets created or a project gets deleted
+ * upstream, but we then skip the corresponding local Prisma/config write. That
+ * leaves upstream and local state split, and retries then duplicate
+ * deployments or wedge deletions on a Vercel 404. Letting mutations run to
+ * completion regardless of the inbound client's lifetime also matches the
+ * pre-Elysia Next.js behavior, where handlers kept running after a client
+ * disconnect.
+ */
+function resolveUpstreamAbortSignal(method: string, explicitSignal: AbortSignal | null | undefined, ambientSignal: AbortSignal | undefined): AbortSignal | undefined {
+  if (explicitSignal != null) {
+    return explicitSignal;
+  }
+  return method === "GET" || method === "HEAD" ? ambientSignal : undefined;
+}
+
+import.meta.vitest?.test("resolveUpstreamAbortSignal only defaults to the ambient request signal for idempotent reads", ({ expect }) => {
+  const ambient = new AbortController().signal;
+  const explicit = new AbortController().signal;
+
+  // Idempotent reads default to the ambient inbound-request signal.
+  expect(resolveUpstreamAbortSignal("GET", undefined, ambient)).toBe(ambient);
+  expect(resolveUpstreamAbortSignal("HEAD", undefined, ambient)).toBe(ambient);
+
+  // Mutations must never inherit the ambient signal — they run to completion
+  // even if the inbound client disconnects.
+  expect(resolveUpstreamAbortSignal("POST", undefined, ambient)).toBeUndefined();
+  expect(resolveUpstreamAbortSignal("PATCH", undefined, ambient)).toBeUndefined();
+  expect(resolveUpstreamAbortSignal("DELETE", undefined, ambient)).toBeUndefined();
+
+  // An explicitly passed signal always wins, whatever the method.
+  expect(resolveUpstreamAbortSignal("GET", explicit, ambient)).toBe(explicit);
+  expect(resolveUpstreamAbortSignal("POST", explicit, ambient)).toBe(explicit);
+  expect(resolveUpstreamAbortSignal("DELETE", explicit, undefined)).toBe(explicit);
+});
+
 export class VercelDeploymentsClient {
   constructor(private readonly config: VercelDeploymentsConfig) {}
 
   private async fetchVercel(path: string, init: RequestInit & { rawBody?: Uint8Array, extraHeaders?: Record<string, string> } = {}): Promise<any> {
+    const method = init.method ?? "GET";
     const url = new URL(path, this.config.baseUrl);
     url.searchParams.set("teamId", this.config.teamId);
     const response = await fetch(url.toString(), {
-      method: init.method ?? "GET",
+      method,
       headers: {
         "authorization": `Bearer ${this.config.token}`,
         ...(init.body != null ? { "content-type": "application/json" } : {}),
@@ -141,7 +189,10 @@ export class VercelDeploymentsClient {
       // (SharedArrayBuffer-backed views are not valid bodies); it also
       // guarantees we never send trailing bytes of a larger shared buffer.
       body: init.rawBody != null ? new Uint8Array(init.rawBody).slice().buffer : init.body,
-      signal: init.signal ?? getOptionalRequestAbortSignal(),
+      // Only idempotent reads default to the inbound request's abort signal;
+      // mutations must run to completion even after a client disconnect. See
+      // resolveUpstreamAbortSignal for the full state-consistency reasoning.
+      signal: resolveUpstreamAbortSignal(method, init.signal, getOptionalRequestAbortSignal()),
     });
     const text = await response.text();
     let json: any = undefined;
@@ -153,7 +204,7 @@ export class VercelDeploymentsClient {
     if (!response.ok) {
       const code = typeof json?.error?.code === "string" ? json.error.code : "unknown";
       const message = typeof json?.error?.message === "string" ? json.error.message : `HTTP ${response.status}`;
-      throw new VercelApiError(response.status, code, message, `${init.method ?? "GET"} ${path}`);
+      throw new VercelApiError(response.status, code, message, `${method} ${path}`);
     }
     if (json === undefined && text !== "") {
       throw new HexclaveAssertionError(`Vercel API returned OK but non-JSON body at ${path}`);
@@ -176,7 +227,18 @@ export class VercelDeploymentsClient {
   }
 
   async deleteProject(projectIdOrName: string): Promise<void> {
-    await this.fetchVercel(urlString`/v9/projects/${projectIdOrName}`, { method: "DELETE" });
+    try {
+      await this.fetchVercel(urlString`/v9/projects/${projectIdOrName}`, { method: "DELETE" });
+    } catch (error) {
+      // A 404 means the project is already gone upstream — the deletion goal
+      // is achieved, so treat it as success. This un-wedges retries after a
+      // partial failure (e.g. Vercel committed the delete but we crashed
+      // before the local write).
+      if (error instanceof VercelApiError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
   }
 
   async getProject(projectIdOrName: string): Promise<VercelProject> {
@@ -289,7 +351,16 @@ export class VercelDeploymentsClient {
   }
 
   async deleteEnvVar(projectId: string, envId: string): Promise<void> {
-    await this.fetchVercel(urlString`/v9/projects/${projectId}/env/${envId}`, { method: "DELETE" });
+    try {
+      await this.fetchVercel(urlString`/v9/projects/${projectId}/env/${envId}`, { method: "DELETE" });
+    } catch (error) {
+      // Already-deleted env var: the deletion goal is achieved, so a 404 is
+      // success — keeps retry flows idempotent after a partial failure.
+      if (error instanceof VercelApiError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
   }
 
   async addProjectDomain(projectId: string, hostname: string): Promise<VercelProjectDomain> {
@@ -316,7 +387,16 @@ export class VercelDeploymentsClient {
   }
 
   async removeProjectDomain(projectId: string, hostname: string): Promise<void> {
-    await this.fetchVercel(urlString`/v9/projects/${projectId}/domains/${hostname}`, { method: "DELETE" });
+    try {
+      await this.fetchVercel(urlString`/v9/projects/${projectId}/domains/${hostname}`, { method: "DELETE" });
+    } catch (error) {
+      // Already-removed domain: the deletion goal is achieved, so a 404 is
+      // success — keeps retry flows idempotent after a partial failure.
+      if (error instanceof VercelApiError && error.status === 404) {
+        return;
+      }
+      throw error;
+    }
   }
 
   /**

--- a/apps/backend/src/lib/runtime/headers.tsx
+++ b/apps/backend/src/lib/runtime/headers.tsx
@@ -1,4 +1,4 @@
-import { getRequestContext, ResponseCookieOptions } from "./request-context";
+import { getRequestContext, parseCookieHeader, requestContextALS, ResponseCookieOptions, type RequestContext } from "./request-context";
 
 export function serializeSetCookie(name: string, value: string, options: ResponseCookieOptions = {}) {
   const parts = [`${encodeURIComponent(name)}=${encodeURIComponent(value)}`];
@@ -45,6 +45,11 @@ export async function cookies() {
     },
 
     set(name: string, value: string, options: ResponseCookieOptions = {}) {
+      // Last write wins, matching the pre-ElysiaJS (Next.js) cookies() semantics: a
+      // set() after a delete() of the same name must replace the deletion. Without
+      // this, both Set-Cookie headers would be emitted with the deletion appended
+      // last — so the deletion, not the set, would win in the browser.
+      context.deletedCookies = context.deletedCookies.filter(c => c.name !== name);
       context.pendingSetCookies.push({ name, value, options });
       context.incomingCookies.set(name, value);
     },
@@ -64,4 +69,58 @@ export async function cookies() {
       context.incomingCookies.delete(name);
     },
   };
+}
+
+const vitest = import.meta.vitest;
+if (vitest != null) {
+  const { test } = vitest;
+
+  // cookies() reads the request context from AsyncLocalStorage, so tests provide a
+  // fake context via requestContextALS.run — the same way app.ts provides the real one.
+  const createFakeRequestContext = (): RequestContext => ({
+    abortSignal: new AbortController().signal,
+    headers: new Headers(),
+    incomingCookies: new Map(),
+    pendingSetCookies: [],
+    deletedCookies: [],
+    normalizedPath: "/api/latest/test",
+  });
+
+  test("cookie values containing spaces survive a serialize/parse roundtrip", ({ expect }) => {
+    const serialized = serializeSetCookie("session-hint", "a b");
+    // parseCookieHeader parses a Cookie request header; a browser echoes back only the
+    // name=value pair of the Set-Cookie header, so strip the attributes before parsing.
+    const nameValuePair = serialized.split(";")[0];
+    expect(nameValuePair).toBe("session-hint=a%20b");
+    expect(parseCookieHeader(nameValuePair)).toEqual(new Map([["session-hint", "a b"]]));
+  });
+
+  test("set() after delete() clears the pending deletion (last write wins)", async ({ expect }) => {
+    const context = createFakeRequestContext();
+    await requestContextALS.run(context, async () => {
+      const cookieStore = await cookies();
+      cookieStore.set("foo", "initial");
+      cookieStore.delete("foo");
+      cookieStore.set("foo", "final");
+      expect(cookieStore.get("foo")).toEqual({ name: "foo", value: "final" });
+    });
+    expect(context.deletedCookies).toEqual([]);
+    expect(context.pendingSetCookies).toEqual([
+      { name: "foo", value: "final", options: {} },
+    ]);
+  });
+
+  test("delete() after set() still deletes (last write wins in both directions)", async ({ expect }) => {
+    const context = createFakeRequestContext();
+    await requestContextALS.run(context, async () => {
+      const cookieStore = await cookies();
+      cookieStore.set("foo", "value");
+      cookieStore.delete("foo");
+      expect(cookieStore.get("foo")).toBeUndefined();
+    });
+    expect(context.pendingSetCookies).toEqual([]);
+    expect(context.deletedCookies).toEqual([
+      { name: "foo", value: "", options: { expires: new Date(0), maxAge: 0, path: "/" } },
+    ]);
+  });
 }

--- a/apps/backend/src/lib/runtime/request-context.tsx
+++ b/apps/backend/src/lib/runtime/request-context.tsx
@@ -44,6 +44,26 @@ export function getOptionalRequestAbortSignal(): AbortSignal | undefined {
   return requestContextALS.getStore()?.abortSignal;
 }
 
+/**
+ * The outbound path (`serializeSetCookie` in headers.tsx) percent-encodes values with
+ * `encodeURIComponent`, and the pre-ElysiaJS (Next.js) backend decoded on read — so a
+ * value written as `a b` must read back as `a b`, not `a%20b`. This helper mirrors that.
+ *
+ * The try/catch here is a deliberate, narrow exception to the no-catch-all rule: a client
+ * may send a cookie we never wrote, containing literal `%` characters that are not valid
+ * percent-encodings (`decodeURIComponent` throws a URIError on those). Next.js's cookie
+ * parser tolerated such values by falling back to the raw string, and rejecting the whole
+ * request over a malformed third-party cookie would be wrong — so we only catch around
+ * the `decodeURIComponent` call itself and preserve the raw value.
+ */
+function decodeCookieValue(rawValue: string): string {
+  try {
+    return decodeURIComponent(rawValue);
+  } catch {
+    return rawValue;
+  }
+}
+
 export function parseCookieHeader(cookieHeader: string | null) {
   const cookies = new Map<string, string>();
   if (cookieHeader == null || cookieHeader === "") {
@@ -59,7 +79,19 @@ export function parseCookieHeader(cookieHeader: string | null) {
       continue;
     }
     const rawValue = part.slice(separatorIndex + 1).trim();
-    cookies.set(name, rawValue);
+    cookies.set(name, decodeCookieValue(rawValue));
   }
   return cookies;
 }
+
+import.meta.vitest?.test("parseCookieHeader decodes percent-encoded values", ({ expect }) => {
+  expect(parseCookieHeader("foo=a%20b")).toEqual(new Map([["foo", "a b"]]));
+});
+
+import.meta.vitest?.test("parseCookieHeader keeps malformed percent-encodings as raw values", ({ expect }) => {
+  // e.g. a third-party cookie with a literal "%" that is not a valid encoding
+  expect(parseCookieHeader("progress=100%; ratio=50%25")).toEqual(new Map([
+    ["progress", "100%"],
+    ["ratio", "50%"],
+  ]));
+});

--- a/apps/backend/src/route-handlers/smart-response.tsx
+++ b/apps/backend/src/route-handlers/smart-response.tsx
@@ -56,7 +56,14 @@ export async function validateSmartResponse<T>(req: Request | null, smartReq: Sm
 }
 
 
-function isBinaryBody(body: unknown): body is BodyInit {
+// The predicate lists exactly the runtime checks below (rather than the wider
+// BodyInit, which also includes string): intersected with SmartResponse's
+// declared body types this narrows the "binary" case to buffers, whose
+// byteLength the content-length derivation below relies on. Claiming
+// ArrayBufferView<ArrayBuffer> (non-shared backing) is as precise as we can
+// get — isView can't inspect the backing buffer — and is no stronger a claim
+// than the previous `body is BodyInit` already made.
+function isBinaryBody(body: unknown): body is ArrayBuffer | SharedArrayBuffer | Blob | ArrayBufferView<ArrayBuffer> {
   return body instanceof ArrayBuffer
     || body instanceof SharedArrayBuffer
     || body instanceof Blob
@@ -131,14 +138,33 @@ export async function createResponse<T extends SmartResponse>(req: Request | nul
     }
 
 
+    // Next.js used to set Content-Length on route-handler responses, and both
+    // clients and the compression layer's minimum-size threshold rely on it
+    // being present. Only the "response" bodyType can carry a stream
+    // (Response#body is ReadableStream | null); every other case materialized
+    // the body into a buffer above, so its byte length is known exactly. The
+    // value MUST be exact or Node will truncate/hang the response — which is
+    // why it is derived from the encoded buffer, never from the pre-encoding
+    // string. Skip when the map already has one (e.g. copied from an inner
+    // Response in the "response" case).
+    if (!(arrayBufferBody instanceof ReadableStream) && arrayBufferBody != null && !headers.has("content-length")) {
+      headers.set("content-length", [arrayBufferBody.byteLength.toString()]);
+    }
+
     // Add the request ID to the response headers
     // Hexclave rebrand: dual-emit both x-hexclave-* and x-stack-* so old and new SDKs can both read it.
     headers.set("x-stack-request-id", [requestId]);
     headers.set("x-hexclave-request-id", [requestId]);
 
 
-    // Disable caching by default
-    headers.set("cache-control", ["no-store, max-age=0"]);
+    // Disable caching by default, but only if nothing set a cache-control yet:
+    // routes returning a raw Response (bodyType "response") had their inner
+    // Response's headers copied into the map above and must be able to opt
+    // out — e.g. streaming routes send `no-transform` so the compression
+    // layer's gzip buffering doesn't stall incremental delivery.
+    if (!headers.has("cache-control")) {
+      headers.set("cache-control", ["no-store, max-age=0"]);
+    }
 
 
     // If the x-stack-override-error-status header is given, override 4xx statuses to 200.
@@ -163,3 +189,33 @@ export async function createResponse<T extends SmartResponse>(req: Request | nul
     );
   });
 }
+
+import.meta.vitest?.test("createResponse sets an exact content-length for JSON bodies", async ({ expect }) => {
+  const response = await createResponse(null, "test-request-id", {
+    statusCode: 200,
+    bodyType: "json",
+    // Non-ASCII on purpose: the byte length differs from the string length, so
+    // this catches any regression back to measuring the pre-encoding string.
+    body: { value: "ünïcödé" },
+  });
+  const bodyBytes = await response.arrayBuffer();
+  expect(bodyBytes.byteLength).toBeGreaterThan("ünïcödé".length);
+  expect(response.headers.get("content-length")).toBe(bodyBytes.byteLength.toString());
+  expect(response.headers.get("cache-control")).toBe("no-store, max-age=0");
+});
+
+import.meta.vitest?.test("createResponse keeps an inner Response's cache-control and does not fabricate a content-length for streams", async ({ expect }) => {
+  const response = await createResponse(null, "test-request-id", {
+    statusCode: 200,
+    bodyType: "response",
+    body: new Response("streamed body", {
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+        "cache-control": "no-store, no-transform",
+      },
+    }),
+  });
+  expect(response.headers.get("cache-control")).toBe("no-store, no-transform");
+  expect(response.headers.get("content-length")).toBeNull();
+  expect(await response.text()).toBe("streamed body");
+});

--- a/apps/backend/src/route-handlers/smart-route-handler.tsx
+++ b/apps/backend/src/route-handlers/smart-route-handler.tsx
@@ -2,6 +2,7 @@ import "../polyfills";
 
 import { recordRequestStats } from "@/lib/dev-request-stats";
 import { requestContextALS } from "@/lib/runtime/request-context";
+import { isRequestBodyTooLargeError } from "@/server/request-body-limit";
 import * as Sentry from "@sentry/node";
 import { EndpointDocumentation } from "@hexclave/shared/dist/crud";
 import { KnownError, KnownErrors } from "@hexclave/shared/dist/known-errors";
@@ -47,6 +48,15 @@ function catchError(error: unknown, requestId: string): StatusError {
         throw error;
       }
     }
+  }
+
+  // srvx aborts the request body stream with ERR_BODY_TOO_LARGE once the ingress cap
+  // (maxRequestBodySize) is exceeded, and smart routes buffer the body with req.arrayBuffer()
+  // before validation, so the abort surfaces here as an unknown error. Without this mapping the
+  // client would get a sanitized 500 and Sentry would be spammed for a purely client-caused
+  // condition; map it to a proper 413 instead.
+  if (isRequestBodyTooLargeError(error)) {
+    return new StatusError(StatusError.PayloadTooLarge);
   }
 
   if (StatusError.isStatusError(error)) return error;

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -231,6 +231,16 @@ function withGlobalHeaders(response: Response) {
   for (const [key, value] of Object.entries(globalSecurityHeaders)) {
     response.headers.set(key, value);
   }
+  // Next.js added `Cache-Control: no-store` to every dynamic response. Smart
+  // responses still set their own default, but raw-Response routes (/health,
+  // the dispatcher's 404/405/400, the HTML pages) would otherwise emit no
+  // cache-control at all and intermediaries could cache them. Only set when
+  // absent so routes that intentionally cache stay cacheable — which is also
+  // why this is NOT part of globalSecurityHeaders: that object is stamped
+  // unconditionally and would overwrite smart responses' own values.
+  if (!response.headers.has("cache-control")) {
+    response.headers.set("Cache-Control", "private, no-store");
+  }
   return response;
 }
 
@@ -295,6 +305,34 @@ import.meta.vitest?.test("dispatcher-generated API errors retain CORS headers", 
         },
       ]
     `);
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+import.meta.vitest?.test("global headers add a default cache-control only when the route set none", async ({ expect }) => {
+  const { vi } = import.meta.vitest!;
+  vi.stubEnv("HEXCLAVE_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
+  vi.stubEnv("STACK_ARTIFICIAL_DEVELOPMENT_DELAY_MS", "0");
+
+  try {
+    const [homePage, smartResponse] = await Promise.all([
+      // The home page is a raw Response with no cache-control of its own
+      // (unlike /api 404s, which the smart NotFoundHandler catch-all serves),
+      // so it must receive the default.
+      app.handle(new Request("http://localhost/")),
+      // Smart responses set their own cache-control; the default must not
+      // overwrite it.
+      app.handle(new Request("http://localhost/api/v2beta1/migration-tests/smart-route-handler")),
+    ]);
+
+    expect({
+      homePageCacheControl: homePage.headers.get("cache-control"),
+      smartResponseCacheControl: smartResponse.headers.get("cache-control"),
+    }).toEqual({
+      homePageCacheControl: "private, no-store",
+      smartResponseCacheControl: "no-store, max-age=0",
+    });
   } finally {
     vi.unstubAllEnvs();
   }

--- a/apps/backend/src/server/compression.ts
+++ b/apps/backend/src/server/compression.ts
@@ -1,3 +1,5 @@
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+
 const compressibleApplicationTypes = new Set([
   "application/graphql-response+json",
   "application/javascript",
@@ -37,6 +39,15 @@ export function compressResponse(request: Request, response: Response): Response
 }
 
 function canCompressResponse(request: Request, response: Response): boolean {
+  // On Vercel, the CDN in front of the function already compresses responses
+  // off-function (both gzip AND brotli, negotiated per client, while
+  // preserving ETag/Content-Length). Compressing in-process there would burn
+  // billed function CPU, forfeit the better brotli encoding, and strip the
+  // validator headers the CDN would otherwise keep — so skip entirely.
+  // Evaluated per call (not at module init) so tests can stub the env var.
+  if (getEnvVariable("VERCEL", "") !== "") {
+    return false;
+  }
   if (
     request.method === "HEAD"
     || request.headers.has("range")
@@ -135,6 +146,22 @@ import.meta.vitest?.test("compresses eligible responses as a streaming gzip repr
     vary: "Accept-Encoding",
     body,
   });
+});
+
+import.meta.vitest?.test("does not compress on Vercel, where the CDN compresses off-function", ({ expect }) => {
+  const { vi } = import.meta.vitest!;
+  vi.stubEnv("VERCEL", "1");
+  try {
+    const body = JSON.stringify({ value: "repeated-value-".repeat(100) });
+    const response = new Response(body, {
+      headers: { "content-type": "application/json" },
+    });
+    expect(compressResponse(new Request("http://localhost/test", {
+      headers: { "accept-encoding": "gzip" },
+    }), response)).toBe(response);
+  } finally {
+    vi.unstubAllEnvs();
+  }
 });
 
 import.meta.vitest?.test("does not compress ineligible or refused representations", ({ expect }) => {

--- a/apps/backend/src/server/cron-monitor.ts
+++ b/apps/backend/src/server/cron-monitor.ts
@@ -35,7 +35,13 @@ export function withVercelCronMonitor<T>(
     return callback();
   }
   return runMonitor(cron.path, callback, {
-    maxRuntime: 12,
+    // The longest-running cron (workflow-engine-step) may legitimately use the full
+    // Vercel function budget of 800 seconds (see FUNCTION_BUDGET_MS in
+    // app/api/latest/internal/workflow-engine-step/route.tsx and `maxDuration: 800` in
+    // src/index.ts): ceil(800 / 60) = 14 minutes, plus one minute of slack so a
+    // full-budget tick doesn't trigger a false "timed out" Sentry check-in. Revisit
+    // this value if maxDuration changes.
+    maxRuntime: 15,
     schedule: {
       type: "crontab",
       value: cron.schedule,
@@ -74,7 +80,7 @@ if (vitest != null) {
         "calls": [
           {
             "monitorConfig": {
-              "maxRuntime": 12,
+              "maxRuntime": 15,
               "schedule": {
                 "type": "crontab",
                 "value": "* * * * *",

--- a/apps/backend/src/server/error-handler.ts
+++ b/apps/backend/src/server/error-handler.ts
@@ -1,4 +1,5 @@
 import { captureError } from "@hexclave/shared/dist/utils/errors";
+import { isRequestBodyTooLargeError } from "./request-body-limit";
 
 function createUncaughtErrorResponse() {
   return new Response("Internal Server Error", {
@@ -10,12 +11,55 @@ function createUncaughtErrorResponse() {
 }
 
 export function handleUncaughtBackendError(error: unknown) {
+  // Non-smart routes (e.g. the oidc-provider routes) read the request body directly, so srvx's
+  // ERR_BODY_TOO_LARGE abort bubbles all the way up here. It's a client-caused condition, so we
+  // answer with a 413 and deliberately skip captureError — it's not a server error.
+  if (isRequestBodyTooLargeError(error)) {
+    return new Response("Payload Too Large", {
+      status: 413,
+      headers: {
+        "content-type": "text/plain; charset=utf-8",
+      },
+    });
+  }
   captureError("backend-global-error", error);
   return createUncaughtErrorResponse();
 }
 
 import.meta.vitest?.test("uncaught backend errors do not expose internal details", async ({ expect }) => {
   const response = createUncaughtErrorResponse();
+
+  expect({
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    body: await response.text(),
+  }).toMatchInlineSnapshot(`
+    {
+      "body": "Internal Server Error",
+      "contentType": "text/plain; charset=utf-8",
+      "status": 500,
+    }
+  `);
+});
+
+import.meta.vitest?.test("body-too-large errors become a 413 instead of a sanitized 500", async ({ expect }) => {
+  const response = handleUncaughtBackendError(Object.assign(new Error("too large"), { code: "ERR_BODY_TOO_LARGE" }));
+
+  expect({
+    status: response.status,
+    contentType: response.headers.get("content-type"),
+    body: await response.text(),
+  }).toMatchInlineSnapshot(`
+    {
+      "body": "Payload Too Large",
+      "contentType": "text/plain; charset=utf-8",
+      "status": 413,
+    }
+  `);
+});
+
+import.meta.vitest?.test("ordinary uncaught errors still produce the sanitized 500", async ({ expect }) => {
+  const response = handleUncaughtBackendError(new Error("some internal detail that must not leak"));
 
   expect({
     status: response.status,

--- a/apps/backend/src/server/middleware.ts
+++ b/apps/backend/src/server/middleware.ts
@@ -68,6 +68,42 @@ export type PipelineResult = {
 
 export async function runRequestPipeline(request: Request): Promise<PipelineResult> {
   const url = new URL(request.url);
+
+  // Next.js canonicalized URLs with a 308 redirect before any handler ran: `/api/v1/`
+  // → 308 `Location: /api/v1`, and duplicate slashes like `/api//v1/users` → 308 to the
+  // normalized path. The Elysia cutover initially dropped this — trailing-slash paths
+  // were served directly (the route matcher strips trailing slashes) and duplicate-slash
+  // paths 404'd — which is a wire-contract change: mixed old/new deployments would see
+  // nondeterministic behavior and noncanonical integrations would break. This restores
+  // the previous contract so signed URLs, caches, and integrations relying on
+  // canonicalization behave identically across old and new deployments. Existing e2e
+  // tests fetch `/api/v1/` and assert a 200 because their fetch follows redirects — that
+  // held on Next (308→200) and holds again now. This runs before the artificial
+  // development delay and the OPTIONS short-circuit (Next redirected all methods,
+  // including OPTIONS), and redirecting early keeps the dev rate limiter from counting
+  // phantom duplicate paths. 308 (not 301/307) preserves the method and body, exactly
+  // what Next used.
+  const canonicalPathname = getCanonicalPathname(url.pathname);
+  if (canonicalPathname !== url.pathname) {
+    return {
+      corsHeadersInit: getCorsHeadersInit(request),
+      dispatchPath: canonicalPathname,
+      mergedHeaders: mergeHexclaveHeaderAliases(request.headers),
+      originalUrl: request.url,
+      shortCircuitResponse: new Response(null, {
+        status: 308,
+        headers: {
+          // The query string is preserved verbatim. Because runs of leading slashes
+          // collapse to a single `/`, the Location always starts with exactly one `/`
+          // followed by a non-slash character, so it can never be interpreted as a
+          // protocol-relative `//host` redirect — which is why this relative redirect
+          // is safe against open-redirect abuse.
+          "Location": canonicalPathname + url.search,
+        },
+      }),
+    };
+  }
+
   const mergedHeaders = mergeHexclaveHeaderAliases(request.headers);
   ensureForwardedForHeader(mergedHeaders, request);
   const artificialDevelopmentBehaviorDisabled = isArtificialDevelopmentBehaviorDisabled(mergedHeaders);
@@ -140,6 +176,37 @@ export async function runRequestPipeline(request: Request): Promise<PipelineResu
     originalUrl: request.url,
   };
 }
+
+function getCanonicalPathname(pathname: string): string {
+  // Mirrors Next.js's URL canonicalization: collapse runs of literal `/` into one and
+  // strip the trailing slash (except the root path `/` itself). Operates on the
+  // percent-encoded pathname, so encoded characters — including `%2F` — are left
+  // untouched; only literal slashes are normalized. Note: WHATWG URL parsing already
+  // converts backslashes to forward slashes in special-scheme URLs (http/https), so by
+  // the time we have `url.pathname` backslashes are gone — that's why there's no
+  // explicit backslash handling here.
+  const collapsed = pathname.replace(/\/{2,}/g, "/");
+  return collapsed.length > 1 && collapsed.endsWith("/") ? collapsed.slice(0, -1) : collapsed;
+}
+
+import.meta.vitest?.test("getCanonicalPathname normalizes literal slashes only", ({ expect }) => {
+  expect(getCanonicalPathname("/api/v1/")).toBe("/api/v1");
+  expect(getCanonicalPathname("/api//v1//users")).toBe("/api/v1/users");
+  expect(getCanonicalPathname("/")).toBe("/");
+  expect(getCanonicalPathname("//")).toBe("/");
+  expect(getCanonicalPathname("/api/v1")).toBe("/api/v1");
+  // Percent-encoded slashes are data, not path separators — they must survive untouched.
+  expect(getCanonicalPathname("/api/v1/users/foo%2Fbar")).toBe("/api/v1/users/foo%2Fbar");
+});
+
+import.meta.vitest?.test("runRequestPipeline 308-redirects noncanonical paths", async ({ expect }) => {
+  const redirected = await runRequestPipeline(new Request("http://localhost/api/v1/?foo=bar"));
+  expect(redirected.shortCircuitResponse?.status).toBe(308);
+  expect(redirected.shortCircuitResponse?.headers.get("Location")).toBe("/api/v1?foo=bar");
+
+  const canonical = await runRequestPipeline(new Request("http://localhost/api/v1?foo=bar"));
+  expect(canonical.shortCircuitResponse).toBe(undefined);
+});
 
 function mergeHexclaveHeaderAliases(headers: Headers) {
   const newRequestHeaders = new Headers(headers);

--- a/apps/backend/src/server/request-body-limit.ts
+++ b/apps/backend/src/server/request-body-limit.ts
@@ -20,19 +20,21 @@ export function getMaxRequestBodySizeBytes(): number {
 
 /**
  * Matches the error srvx rejects body reads with once the accumulated body exceeds
- * `maxRequestBodySize` (it carries `code: "ERR_BODY_TOO_LARGE"` and `status`/`statusCode` 413).
- * The request pipeline maps it to an HTTP 413 instead of the sanitized 500 an unknown error
- * would produce.
+ * `maxRequestBodySize`. The request pipeline maps it to an HTTP 413 instead of the sanitized
+ * 500 an unknown error would produce.
+ *
+ * Deliberately matches ONLY srvx's `code: "ERR_BODY_TOO_LARGE"` marker (verified to survive
+ * the createBackendRequest re-wrap of the body stream), NOT the error's `status`/`statusCode`
+ * fields: a route handler may intentionally throw its own `StatusError` with statusCode 413
+ * and a descriptive message (e.g. the deploy route's tarball-size check), and a status-based
+ * match would intercept it in catchError and silently replace that message with the generic
+ * "Payload Too Large".
  */
 export function isRequestBodyTooLargeError(error: unknown): boolean {
   if (error == null || typeof error !== "object") {
     return false;
   }
-  if ("code" in error && error.code === "ERR_BODY_TOO_LARGE") {
-    return true;
-  }
-  return ("statusCode" in error && error.statusCode === 413)
-    || ("status" in error && error.status === 413);
+  return "code" in error && error.code === "ERR_BODY_TOO_LARGE";
 }
 
 import.meta.vitest?.test("the body size limit is env-overridable and rejects invalid values", ({ expect }) => {
@@ -50,9 +52,13 @@ import.meta.vitest?.test("the body size limit is env-overridable and rejects inv
   }
 });
 
-import.meta.vitest?.test("only srvx body-too-large errors are recognized", ({ expect }) => {
+import.meta.vitest?.test("only srvx body-too-large errors are recognized", async ({ expect }) => {
+  const { StatusError } = await import("@hexclave/shared/dist/utils/errors");
   expect(isRequestBodyTooLargeError(Object.assign(new Error("too large"), { code: "ERR_BODY_TOO_LARGE" }))).toBe(true);
-  expect(isRequestBodyTooLargeError({ status: 413, statusCode: 413 })).toBe(true);
+  // A route-thrown 413 StatusError with a descriptive message must NOT match — catchError
+  // has to pass it through untouched instead of replacing it with the generic 413.
+  expect(isRequestBodyTooLargeError(new StatusError(StatusError.PayloadTooLarge, "The uploaded tarball is too large (max 123 bytes)."))).toBe(false);
+  expect(isRequestBodyTooLargeError({ status: 413, statusCode: 413 })).toBe(false);
   expect(isRequestBodyTooLargeError(new Error("some other error"))).toBe(false);
   expect(isRequestBodyTooLargeError(null)).toBe(false);
   expect(isRequestBodyTooLargeError("ERR_BODY_TOO_LARGE")).toBe(false);

--- a/apps/backend/src/server/request-body-limit.ts
+++ b/apps/backend/src/server/request-body-limit.ts
@@ -1,0 +1,59 @@
+import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
+
+// Vercel rejects request bodies above ~4.5 MB at the platform edge, so hosted deployments are
+// already bound to this value. Direct Node ingress (Docker/self-host) matches it by default so
+// both deployment styles accept the same requests; operators with a legitimate need for larger
+// bodies can raise the cap explicitly.
+const defaultMaxRequestBodySizeBytes = 4.5 * 1024 * 1024;
+
+export function getMaxRequestBodySizeBytes(): number {
+  const raw = getEnvVariable("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES", "");
+  if (raw === "") {
+    return defaultMaxRequestBodySizeBytes;
+  }
+  const parsed = Number(raw);
+  if (!Number.isSafeInteger(parsed) || parsed <= 0) {
+    throw new Error(`HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES must be a positive integer number of bytes, got: ${JSON.stringify(raw)}`);
+  }
+  return parsed;
+}
+
+/**
+ * Matches the error srvx rejects body reads with once the accumulated body exceeds
+ * `maxRequestBodySize` (it carries `code: "ERR_BODY_TOO_LARGE"` and `status`/`statusCode` 413).
+ * The request pipeline maps it to an HTTP 413 instead of the sanitized 500 an unknown error
+ * would produce.
+ */
+export function isRequestBodyTooLargeError(error: unknown): boolean {
+  if (error == null || typeof error !== "object") {
+    return false;
+  }
+  if ("code" in error && error.code === "ERR_BODY_TOO_LARGE") {
+    return true;
+  }
+  return ("statusCode" in error && error.statusCode === 413)
+    || ("status" in error && error.status === 413);
+}
+
+import.meta.vitest?.test("the body size limit is env-overridable and rejects invalid values", ({ expect }) => {
+  const { vi } = import.meta.vitest!;
+  try {
+    expect(getMaxRequestBodySizeBytes()).toBe(defaultMaxRequestBodySizeBytes);
+    vi.stubEnv("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES", "1048576");
+    expect(getMaxRequestBodySizeBytes()).toBe(1048576);
+    vi.stubEnv("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES", "not-a-number");
+    expect(() => getMaxRequestBodySizeBytes()).toThrow("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES");
+    vi.stubEnv("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES", "-1");
+    expect(() => getMaxRequestBodySizeBytes()).toThrow("HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES");
+  } finally {
+    vi.unstubAllEnvs();
+  }
+});
+
+import.meta.vitest?.test("only srvx body-too-large errors are recognized", ({ expect }) => {
+  expect(isRequestBodyTooLargeError(Object.assign(new Error("too large"), { code: "ERR_BODY_TOO_LARGE" }))).toBe(true);
+  expect(isRequestBodyTooLargeError({ status: 413, statusCode: 413 })).toBe(true);
+  expect(isRequestBodyTooLargeError(new Error("some other error"))).toBe(false);
+  expect(isRequestBodyTooLargeError(null)).toBe(false);
+  expect(isRequestBodyTooLargeError("ERR_BODY_TOO_LARGE")).toBe(false);
+});

--- a/apps/backend/src/server/server.ts
+++ b/apps/backend/src/server/server.ts
@@ -8,6 +8,7 @@ import { runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 import type { Server as ElysiaServer } from "elysia/universal";
 import { app } from "./app";
 import { waitForNodeServerToListen } from "./node-server";
+import { getMaxRequestBodySizeBytes } from "./request-body-limit";
 import { backendShutdownBudget, runShutdownOperationWithTimeout, shutdownBackend } from "./shutdown";
 
 const portPrefix = getEnvVariable("NEXT_PUBLIC_HEXCLAVE_PORT_PREFIX", "81");
@@ -26,6 +27,19 @@ const listenOptions = {
   // trusted. The deployment setting must only be enabled when direct access to
   // the origin is blocked; otherwise clients could spoof HTTPS and host values.
   trustProxy: trustedProxy !== "",
+  // srvx installs its own SIGINT/SIGTERM handlers by default (outside CI/test envs), racing the
+  // handlers below: its handler begins `server.close()` first, which marks the listener
+  // non-listening, so our own stop step resolves immediately and `process.exit(0)` fires while
+  // requests are still in flight. Shutdown must have exactly one owner — this process.
+  gracefulShutdown: false,
+  // Without a cap, srvx buffers arbitrarily large request bodies and every smart route reads the
+  // full body with `arrayBuffer()` before auth/schema validation, so concurrent chunked uploads
+  // could exhaust memory on direct Node ingress (Docker/self-host). Vercel's platform cap
+  // (~4.5 MB) already bounds hosted deployments; default to the same bound here so self-host and
+  // hosted accept the same requests. srvx rejects the body read with an ERR_BODY_TOO_LARGE error,
+  // which the request pipeline maps to an HTTP 413. Large payloads (deployment tarballs) already
+  // bypass the backend via S3 presigned uploads, so nothing that works on Vercel needs more.
+  maxRequestBodySize: getMaxRequestBodySizeBytes(),
 };
 const boundServerPromise = new Promise<ElysiaServer>((resolve, reject) => {
   app.listen(listenOptions, (server) => {
@@ -69,8 +83,16 @@ function handleShutdownSignal(signal: NodeJS.Signals) {
   }, backendShutdownBudget.hardExitTimeoutMs);
   shutdownPromise = shutdownBackend(signal, {
     // stop(false) mirrors the previous app.stop(false) intent: stop accepting new connections but
-    // let in-flight requests finish (the drain steps below and the hard-exit cover the rest).
-    stopAcceptingRequests: async () => (await boundServerPromise).stop(false),
+    // let in-flight requests finish. On Node ≥19, `http.Server.close()` also closes idle
+    // keep-alive sockets, so this resolves once active requests complete. The step is bounded:
+    // a request that can't finish within its slice is presumed long-running and will be cut by
+    // the platform's grace period anyway — the remaining budget must still drain background
+    // tasks and flush the database/instrumentation instead of being starved by one request.
+    stopAcceptingRequests: async () => await runShutdownOperationWithTimeout(
+      "http server close",
+      backendShutdownBudget.httpServerTimeoutMs,
+      async () => (await boundServerPromise).stop(false),
+    ),
     drainBackgroundTasks: async () => await drainInFlightPromises(backendShutdownBudget.backgroundTasksTimeoutMs),
     disconnectDatabases: async () => await runShutdownOperationWithTimeout(
       "database disconnect",

--- a/apps/backend/src/server/shutdown.test.ts
+++ b/apps/backend/src/server/shutdown.test.ts
@@ -6,6 +6,7 @@ describe("shutdownBackend", () => {
     expect(backendShutdownBudget.hardExitTimeoutMs).toBeLessThan(backendShutdownBudget.platformGracePeriodMs);
     expect(
       backendShutdownBudget.hardExitTimeoutMs
+      - backendShutdownBudget.httpServerTimeoutMs
       - backendShutdownBudget.backgroundTasksTimeoutMs
       - backendShutdownBudget.databaseTimeoutMs
       - backendShutdownBudget.instrumentationTimeoutMs,

--- a/apps/backend/src/server/shutdown.ts
+++ b/apps/backend/src/server/shutdown.ts
@@ -9,8 +9,14 @@ export type BackendShutdownDependencies = {
 // Cloud Run and Docker commonly allow ten seconds between SIGTERM and SIGKILL.
 // Exit one second earlier so the process, rather than the platform, owns the
 // terminal log and exit code when an in-flight request or dependency hangs.
+// Every step is individually bounded so one hanging step (most plausibly the
+// HTTP close waiting on a long-running request) cannot starve the later steps
+// out of the budget — draining background tasks and flushing the database and
+// instrumentation matters more than waiting longer for a request the platform
+// is about to kill anyway.
 export const backendShutdownBudget = {
-  backgroundTasksTimeoutMs: 6000,
+  httpServerTimeoutMs: 2000,
+  backgroundTasksTimeoutMs: 4000,
   databaseTimeoutMs: 1000,
   instrumentationTimeoutMs: 1000,
   hardExitTimeoutMs: 9000,

--- a/apps/backend/src/utils/background-tasks.tsx
+++ b/apps/backend/src/utils/background-tasks.tsx
@@ -1,10 +1,36 @@
 import { getEnvVariable } from "@hexclave/shared/dist/utils/env";
-import { HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
+import { captureError, HexclaveAssertionError } from "@hexclave/shared/dist/utils/errors";
 import { ignoreUnhandledRejection, runAsynchronously } from "@hexclave/shared/dist/utils/promises";
 
 // Serverful runtimes use this set for shutdown and the test-only flush endpoint.
 // Vercel lifetime is owned separately by every invocation's native waitUntil.
 const inFlightPromises = new Set<Promise<unknown>>();
+
+/**
+ * Detects whether Vercel's `waitUntil` would actually do anything right now.
+ *
+ * `waitUntil` from `@vercel/functions` is implemented as `getContext().waitUntil?.(promise)`,
+ * where `getContext()` reads `globalThis[Symbol.for("@vercel/request-context")]?.get?.() ?? {}`
+ * — so outside of a request context (e.g. a task enqueued from a timer or a detached
+ * continuation) it is a SILENT no-op and the background task just vanishes when the
+ * function instance is suspended.
+ *
+ * We would prefer the documented `getContext` API for this check, but @vercel/functions
+ * (3.7.6) neither re-exports it from its main entry nor lists `./get-context` in its
+ * package `exports` map, so it is unreachable; instead we replicate the same lookup.
+ * The symbol is registered via `Symbol.for` on the global registry precisely so that
+ * independent copies of the package (and the Vercel runtime itself) agree on it, so
+ * this does not depend on package internals beyond that stable contract.
+ */
+function hasVercelRequestContextWaitUntil(): boolean {
+  const contextHolder: unknown = Reflect.get(globalThis, Symbol.for("@vercel/request-context"));
+  if (contextHolder == null || typeof contextHolder !== "object") return false;
+  const getter: unknown = Reflect.get(contextHolder, "get");
+  if (typeof getter !== "function") return false;
+  const context: unknown = getter.call(contextHolder);
+  if (context == null || typeof context !== "object") return false;
+  return typeof Reflect.get(context, "waitUntil") === "function";
+}
 
 function waitUntilImpl(promise: Promise<unknown>) {
   if (getEnvVariable("VERCEL", "") !== "") {
@@ -12,6 +38,15 @@ function waitUntilImpl(promise: Promise<unknown>) {
     // invocation needs its own waitUntil call, so do not globally deduplicate or
     // retain Vercel tasks in the serverful shutdown set.
     const { waitUntil } = require("@vercel/functions") as typeof import("@vercel/functions");
+    if (!hasVercelRequestContextWaitUntil()) {
+      // Fail loud, but don't throw: the task itself may still complete if the
+      // instance stays warm, and killing it here would only make things worse.
+      captureError("wait-until-outside-request-context", new HexclaveAssertionError(
+        "waitUntil was called outside of a Vercel request context; the background task is not protected from the function being suspended and may be lost",
+      ));
+    }
+    // Still call waitUntil even when there is no context — it's harmless there,
+    // and this keeps the behavior identical in the (expected) in-request case.
     waitUntil(promise);
     return;
   }


### PR DESCRIPTION
Hardens the Elysia backend runtime against the production-readiness findings from the pre-promotion reviews of the Next.js → Elysia cutover (#1795, #1877, #1879). No API schema, database, or SDK changes — every fix is in the backend's server/runtime layer.

## P1 fixes

### Single-owner graceful shutdown
srvx installs its own SIGINT/SIGTERM handlers by default (only disabled in CI/test envs), racing our handlers in `server.ts`: srvx's handler begins `server.close()` first, which marks the listener non-listening, so our own stop step resolved immediately and `process.exit(0)` fired while requests were still in flight. `gracefulShutdown: false` makes this process the only shutdown owner. The http-close step is now also individually bounded (2s) so one hanging request can no longer starve the background-task drain and DB/Sentry flush out of the 9s budget. On Node ≥19, `http.Server.close()` also closes idle keep-alive sockets, so a clean drain now reliably exits 0.

### Request-body size limit on direct Node ingress
`listenOptions` previously set no `maxRequestBodySize`, so srvx buffered unbounded bodies and every smart route reads the full body with `arrayBuffer()` before auth/validation — concurrent chunked uploads could exhaust memory on Docker/self-host. New default cap: 4.5 MiB, matching Vercel's platform cap so self-host and hosted accept the same requests (deployment tarballs already bypass the backend via S3 presigned uploads). Override with `HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES`. The srvx `ERR_BODY_TOO_LARGE` abort is mapped to a proper HTTP 413 in both the smart-route pipeline and the global error boundary (previously: sanitized 500 + Sentry noise).

### Non-idempotent Vercel API calls detached from client aborts
`fetchVercel` defaulted every upstream call — including POST/PATCH/DELETE mutations — to the inbound request's abort signal. Vercel can commit a mutation just before the local fetch rejects with AbortError, after which we skip the corresponding local write; retries then duplicate deployments or wedge deletions. Now only GET/HEAD default to the ambient signal (explicit signals still always win), and `deleteProject`/`deleteEnvVar`/`removeProjectDomain` treat an upstream 404 as success so retry flows can't wedge on already-deleted resources.

### `pnpm start` lost env loading and production mode
`next start` auto-loaded `.env.production`/`.env.local`/`.env` and implied production mode; the cutover reduced `start` to bare `node dist/server.mjs`. Restored via the already-present dotenv-cli: `NODE_ENV=${NODE_ENV:-production} dotenv -c production -- node dist/server.mjs`. Docker/Vercel are unaffected (they invoke node directly with injected env).

## P2/P3 fixes

- **URL canonicalization restored** (`middleware.ts`): Next 308-redirected `/api/v1/` → `/api/v1` and normalized duplicate slashes; the cutover served trailing-slash paths directly and 404'd duplicate slashes. The 308s are back, so wire behavior is deterministic across mixed old/new deployments. (Existing e2e tests pass unchanged — their fetch follows redirects, exactly as it did against Next.)
- **Compression skipped on Vercel** (`compression.ts`): the CDN already compresses off-function (gzip and brotli, preserving ETag/Content-Length); in-process gzip there burned billed CPU and stripped validators. Kept for Docker/self-host, where it's the only compression.
- **Compression threshold un-deadened** (`smart-response.tsx`): smart responses never carried Content-Length, so the 1 KiB minimum-size check could never fire and every tiny JSON response was gzipped. `createResponse` now sets an exact Content-Length for all known-size bodies — which also restores the header for clients.
- **Streaming log route protected** (`deployments/runs/[run_id]/logs`): live build-log streaming would stall behind `CompressionStream` buffering. The route now sends `no-transform` (honored by the compression layer), enabled by `createResponse` no longer overwriting an inner Response's cache-control.
- **Default `Cache-Control: private, no-store`** on responses that set none (parity with Next's dynamic-route default; only-if-absent so intentional caching still works).
- **Sentry cron monitor `maxRuntime` 12 → 15 min**: workflow-engine-step can legitimately run 800s ≈ 13.3 min, so every full-budget tick produced a false "timed out" alert.
- **Sentry env gating restored to pre-cutover semantics**: enabled whenever the DSN is set and NODE_ENV is neither development nor test (was: exact-match `production`, which silently dropped error reporting for staging-like NODE_ENV values). Malformed `OTEL_EXPORTER_OTLP_*` values still fail startup loudly, but the error now names the offending env var.
- **Cookie parity with Next**: values are percent-decoded on read (with a narrow raw-value fallback for malformed third-party cookies, same as Next's parser), and `set()` after `delete()` now wins (previously the deletion was still emitted last and won in the browser).
- **`waitUntil` outside a request context now fails loud**: on Vercel, `waitUntil` is a silent no-op without a request context (`getContext().waitUntil?.()`), silently dropping background tasks enqueued from timers/detached continuations. We now `captureError` when that happens (detected via the stable `Symbol.for("@vercel/request-context")` registry — `@vercel/functions` doesn't export `getContext`).

## Deliberate non-changes (reviewed, decided against)

- **Trusted-proxy semantics** (`STACK_TRUSTED_PROXY`/`generic`): deliberate, tested design from the cutover; the remaining concerns are deployment configuration/documentation, not code. Note for ops: `generic` is only valid on the new code — revert the env var before any code rollback.
- **Docker HEALTHCHECK stays liveness-only**: restarting a container because Postgres is down would make an outage worse. `/health?db=1` already exists as the readiness probe for orchestrators that want it.
- **Global `maxDuration: 800`** on the single Vercel function: an architecture constraint of the one-function topology, out of scope here.
- **`supportsCancellation`** is deliberately not enabled in `vercel.json`: enabling it makes Vercel terminate the function on client disconnect for all routes, which needs a per-route mutation audit first. (Consequence: the abort-signal plumbing is only active on Docker/self-host today.)
- **pg pool `idleTimeoutMillis`**: left at pg's 10s default. Shrinking it would cut the billed invocation tail on Fluid but increases connection churn (TLS+auth handshake per burst); needs measurement, not a drive-by change.
- **CI coverage for the Vercel preview build and standalone backend Dockerfile**: real gap, but belongs in a separate workflow-focused PR.

## Testing

- ~25 new inline vitest tests across the touched files; all 60 tests in the touched areas pass, plus repo typecheck and lint.
- Verified live against the dev server: `/api/v1/` and `/api//v1` → 308 to `/api/v1`; `/health` carries `Cache-Control: private, no-store`; a 6 MB POST body → 413 `Payload Too Large` while normal bodies process unchanged.

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Hardens the Elysia backend runtime for production: fixes shutdown race conditions, enforces request size limits, restores URL canonicalization, adjusts compression, and tightens error/reporting behavior. No API, DB, or SDK changes—server/runtime only.

- **Bug Fixes**
  - Shutdown and requests: make this process the sole shutdown owner, bound `http` close to 2s; cap direct-ingress request bodies to 4.5 MiB with proper 413s (override via `HEXCLAVE_MAX_REQUEST_BODY_SIZE_BYTES`) and match only srvx `ERR_BODY_TOO_LARGE` so route-thrown 413 messages aren’t masked; `pnpm start` now loads `.env.*` and defaults to production.
  - Routing and caching: restore 308 redirects for trailing/duplicate slashes; add default `Cache-Control: private, no-store` when absent; set exact `Content-Length` for known-size bodies; skip in-process gzip on Vercel; prevent gzip buffering on streaming logs with `no-transform`.
  - Upstream safety: only `GET/HEAD` inherit the ambient abort signal; mutations run to completion; treat Vercel `DELETE` 404s as success to keep retries idempotent.
  - Observability/correctness: enable Sentry whenever DSN is set and `NODE_ENV` is not development/test; name offending OTLP env vars on boot errors; cookie reads percent-decode with a safe fallback and `set()` after `delete()` now wins; capture misuse of `waitUntil` outside a request context (`@vercel/functions`); raise cron monitor `maxRuntime` to 15 minutes.

<sup>Written for commit 343dc7a919f866a739ae0dbdcc24a5240cd1e0f5. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1880?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configurable request-body limits with a default 4.5 MiB maximum.
  - Noncanonical URLs now redirect to normalized paths while preserving query parameters.
  - Oversized request bodies return clear HTTP 413 responses.
  - Cookie handling now correctly decodes values and honors the latest update.
  - Sentry monitoring now supports staging and other non-development environments.

- **Bug Fixes**
  - Improved deployment cancellation and idempotent deletion behavior.
  - Preserved response caching directives and accurate content lengths.
  - Prevented unwanted compression in hosted environments.
  - Improved shutdown reliability, background-task handling, and error reporting.
  - Production startup now consistently loads the appropriate environment configuration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->