### PR TITLE
Preload the routes and look em up via an in memory index

### DIFF
--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -162,6 +162,45 @@ describe("sanitizeBackendSentryEvent", () => {
     expect(result.transaction).toBe("backend.request");
   });
 
+  it("does not use unsupported extension methods in request descriptions", () => {
+    const event: Event = {
+      request: {
+        method: "BREW",
+      },
+      transaction: "BREW /api/latest/users",
+      contexts: {
+        trace: {
+          data: {
+            "http.request.method": "BREW",
+            "http.route": "/api/latest/users",
+          },
+          span_id: "0123456789abcdef",
+          trace_id: "0123456789abcdef0123456789abcdef",
+        },
+      },
+      spans: [{
+        data: {
+          "http.request.method": "BREW",
+          "http.route": "/api/latest/users",
+        },
+        description: "BREW /api/latest/users",
+        span_id: "0123456789abcdef",
+        start_timestamp: 1,
+        trace_id: "0123456789abcdef0123456789abcdef",
+      }],
+    };
+
+    const result = sanitizeBackendSentryEvent(event);
+
+    expect({
+      spanDescription: result.spans?.[0]?.description,
+      transaction: result.transaction,
+    }).toEqual({
+      spanDescription: undefined,
+      transaction: "backend.request",
+    });
+  });
+
   it("retains a fixed placeholder for requests that finish before route matching", () => {
     const event: Event = {
       request: {

--- a/apps/backend/src/sentry-scrubbing.test.ts
+++ b/apps/backend/src/sentry-scrubbing.test.ts
@@ -55,6 +55,7 @@ describe("sanitizeBackendSentryEvent", () => {
         data: {
           "db.statement": "SELECT * FROM users WHERE email = 'user@example.com'",
           "http.request.method": "POST",
+          "http.route": "/api/latest/users/{user_id}",
           "stack.request.path": "/api/latest/users",
           "stack.smart-request.user.primary-email": "user@example.com",
         },
@@ -103,19 +104,94 @@ describe("sanitizeBackendSentryEvent", () => {
           {
             "data": {
               "http.request.method": "POST",
+              "http.route": "/api/latest/users/{user_id}",
             },
-            "description": undefined,
+            "description": "POST /api/latest/users/{user_id}",
             "span_id": "0123456789abcdef",
             "start_timestamp": 1,
             "trace_id": "0123456789abcdef0123456789abcdef",
           },
         ],
         "tags": undefined,
-        "transaction": "backend.request",
+        "transaction": "POST /api/latest/users/[user_id]",
         "user": undefined,
       }
     `);
     expect(JSON.stringify(result)).not.toContain("secret");
     expect(JSON.stringify(result)).not.toContain("user@example.com");
+  });
+
+  it("retains audited application span names while stripping data-bearing descriptions", () => {
+    const safeSpan = {
+      data: {},
+      description: "STACK: smart request parseAuth",
+      span_id: "0123456789abcdef",
+      start_timestamp: 1,
+      trace_id: "0123456789abcdef0123456789abcdef",
+    };
+    const unsafeSpan = {
+      data: {},
+      description: "STACK: sending email to user@example.com",
+      span_id: "fedcba9876543210",
+      start_timestamp: 1,
+      trace_id: "0123456789abcdef0123456789abcdef",
+    };
+
+    const result = sanitizeBackendSentryEvent({
+      spans: [safeSpan, unsafeSpan],
+    });
+
+    expect(result.spans.map((span) => span.description)).toEqual([
+      "STACK: smart request parseAuth",
+      undefined,
+    ]);
+  });
+
+  it("does not use concrete URLs or malformed route metadata as transaction names", () => {
+    const result = sanitizeBackendSentryEvent({
+      transaction: "GET /users/customer-123?token=secret",
+      contexts: {
+        "stack-request": {
+          method: "GET",
+          route: "/users/customer-123?token=secret",
+          requestId: "request-123",
+        },
+      },
+    });
+
+    expect(result.transaction).toBe("backend.request");
+  });
+
+  it("retains a fixed placeholder for requests that finish before route matching", () => {
+    const event: Event = {
+      request: {
+        method: "OPTIONS",
+        url: "https://api.example.com/api/latest/users/customer-secret",
+      },
+      contexts: {
+        trace: {
+          data: {},
+          span_id: "0123456789abcdef",
+          trace_id: "0123456789abcdef0123456789abcdef",
+        },
+      },
+    };
+    const result = sanitizeBackendSentryEvent(event);
+
+    expect(result.transaction).toBe("OPTIONS <unmatched>");
+    expect(result.request).toEqual({ method: "OPTIONS" });
+    expect(result.contexts).toEqual({
+      trace: {
+        data: {
+          "http.request.method": "OPTIONS",
+          "http.route": "<unmatched>",
+        },
+        links: undefined,
+        span_id: "0123456789abcdef",
+        tags: undefined,
+        trace_id: "0123456789abcdef0123456789abcdef",
+      },
+    });
+    expect(JSON.stringify(result)).not.toContain("customer-secret");
   });
 });

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -18,6 +18,19 @@ const safeSpanAttributeNames = new Set([
   "stack.smart-request.client-version.version",
 ]);
 
+// These names are code-owned constants from the request pipeline. Keep this list
+// default-deny: other custom span names may interpolate customer data (for example,
+// the email sender used to include its recipient in the description).
+const safeApplicationSpanDescriptions = new Set([
+  "STACK: handling API request",
+  "STACK: creating smart request",
+  "STACK: smart request parseAuth",
+  "STACK: validating smart request",
+  "STACK: calling smart route handler callback",
+  "STACK: validating smart response",
+  "STACK: creating HTTP response from smart response",
+]);
+
 type BackendSentrySpan = NonNullable<Event["spans"]>[number];
 
 function getSafeSpanData(data: BackendSentrySpan["data"]): BackendSentrySpan["data"] {
@@ -26,8 +39,37 @@ function getSafeSpanData(data: BackendSentrySpan["data"]): BackendSentrySpan["da
   );
 }
 
+function getSafeRequestDescription(method: unknown, route: unknown): string | undefined {
+  if (typeof method !== "string" || !/^[A-Z]+$/.test(method)) {
+    return undefined;
+  }
+  if (
+    typeof route !== "string"
+    || (route !== "<unmatched>" && !route.startsWith("/"))
+    || route.length > 500
+    || route.includes("?")
+    || route.includes("#")
+    || route.includes("://")
+  ) {
+    return undefined;
+  }
+  return `${method} ${route}`;
+}
+
 export function sanitizeBackendSentrySpan(span: BackendSentrySpan): BackendSentrySpan {
-  span.description = undefined;
+  // @sentry/node runs beforeSendSpan for the segment/root span as well as its
+  // children. For a transaction, the SDK converts event.transaction into this
+  // description and then converts it back after the hook; clearing it therefore
+  // erases the transaction name entirely. Rebuild request names only from the
+  // normalized route pattern, and preserve a small audited set of application
+  // span names. Database statements, outbound URLs, and arbitrary custom names
+  // remain stripped.
+  span.description = getSafeRequestDescription(
+    span.data["http.request.method"],
+    span.data["http.route"],
+  ) ?? (span.description != null && safeApplicationSpanDescriptions.has(span.description)
+      ? span.description
+      : undefined);
   span.data = getSafeSpanData(span.data);
   return span;
 }
@@ -45,9 +87,6 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   }
   event.user = undefined;
   event.tags = undefined;
-  if (event.transaction != null) {
-    event.transaction = "backend.request";
-  }
 
   const location = event.extra?.location;
   event.extra = typeof location === "string" ? { location } : undefined;
@@ -68,6 +107,36 @@ export function sanitizeBackendSentryEvent<T extends Event>(event: T): T {
   // `route` is the matched route pattern (e.g. `/api/latest/users/[user_id]`), never the
   // concrete path — same safety rationale as the http.route span attribute above.
   const requestRoute = requestContext?.route;
+  const safeRequestDescription = getSafeRequestDescription(requestMethod, requestRoute);
+  const safeTraceDescription = getSafeRequestDescription(
+    traceContext?.data?.["http.request.method"],
+    traceContext?.data?.["http.route"],
+  );
+  // Sentry retains request.method even when its Node HTTP finalizer discards a
+  // custom route on Elysia middleware short-circuits. A fixed placeholder keeps
+  // those transactions identifiable without admitting any part of the URL.
+  const safeUnmatchedDescription = getSafeRequestDescription(event.request?.method, "<unmatched>");
+  if (
+    traceContext != null
+    && safeRequestDescription == null
+    && safeTraceDescription == null
+    && safeUnmatchedDescription != null
+    && typeof event.request?.method === "string"
+  ) {
+    traceContext.data = {
+      ...(traceContext.data ?? {}),
+      "http.request.method": event.request.method,
+      "http.route": "<unmatched>",
+    };
+  }
+  const safeTransactionDescription = safeRequestDescription
+    ?? safeTraceDescription
+    ?? safeUnmatchedDescription;
+  if (safeTransactionDescription != null) {
+    event.transaction = safeTransactionDescription;
+  } else if (event.transaction != null) {
+    event.transaction = "backend.request";
+  }
   const safeRequestContext = typeof requestId === "string"
     ? {
       requestId,

--- a/apps/backend/src/sentry-scrubbing.ts
+++ b/apps/backend/src/sentry-scrubbing.ts
@@ -1,4 +1,7 @@
+import { httpMethodNames } from "@/generated/route-modules";
 import type { Event } from "@sentry/node";
+
+const knownHttpMethods = new Set<string>(httpMethodNames);
 
 const safeSpanAttributeNames = new Set([
   "sentry.op",
@@ -40,7 +43,7 @@ function getSafeSpanData(data: BackendSentrySpan["data"]): BackendSentrySpan["da
 }
 
 function getSafeRequestDescription(method: unknown, route: unknown): string | undefined {
-  if (typeof method !== "string" || !/^[A-Z]+$/.test(method)) {
+  if (typeof method !== "string" || !knownHttpMethods.has(method)) {
     return undefined;
   }
   if (

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -113,7 +113,9 @@ async function dispatch(request: Request) {
   // one of Sentry's framework integrations, so attach the matched route pattern
   // here instead of registering a second OpenTelemetry provider through Elysia's
   // plugin. The normalized path is safe; the concrete path may contain customer IDs.
-  updateRequestSpanName(method, match.normalizedPath);
+  if (isHttpMethod(method)) {
+    updateRequestSpanName(method, match.normalizedPath);
+  }
   const context: RequestContext = {
     abortSignal: request.signal,
     headers: pipeline.mergedHeaders,
@@ -176,7 +178,7 @@ async function dispatch(request: Request) {
   });
 }
 
-function updateRequestSpanName(method: string, normalizedPath: string) {
+function updateRequestSpanName(method: typeof httpMethodNames[number], normalizedPath: string) {
   const requestSpan = trace.getActiveSpan();
   if (requestSpan == null) {
     return;

--- a/apps/backend/src/server/app.ts
+++ b/apps/backend/src/server/app.ts
@@ -4,6 +4,7 @@ import { parseCookieHeader, requestContextALS, type RequestContext } from "@/lib
 import { node } from "@elysia/node";
 import { getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
 import { trace } from "@opentelemetry/api";
+import * as Sentry from "@sentry/node";
 import { Elysia } from "elysia";
 import { gunzipSync } from "node:zlib";
 import { createBackendRequest } from "./backend-request";
@@ -39,7 +40,8 @@ export const app = new Elysia({
   .onRequest(({ request }) => {
     requestStartTimes.set(request, performance.now());
     const pathname = new URL(request.url).pathname;
-    requestLogPaths.set(request, staticRequestLogPaths.has(pathname) ? pathname : "<unmatched>");
+    const staticRequestPath = staticRequestLogPaths.has(pathname) ? pathname : undefined;
+    requestLogPaths.set(request, staticRequestPath ?? "<unmatched>");
   })
   .mapResponse(({ request, responseValue }) => responseValue instanceof Response
     ? compressResponse(request, responseValue)
@@ -82,6 +84,7 @@ export const app = new Elysia({
   });
 
 async function dispatch(request: Request) {
+  const method = request.method.toUpperCase();
   const pipeline = await runRequestPipeline(request);
   if (pipeline.shortCircuitResponse != null) {
     return withResponseHeaders(pipeline.shortCircuitResponse, pipeline.corsHeadersInit);
@@ -106,15 +109,11 @@ async function dispatch(request: Request) {
   }
   requestLogPaths.set(request, match.normalizedPath);
 
-  const method = request.method.toUpperCase();
   // Sentry's Node HTTP integration owns the incoming request span. Elysia is not
   // one of Sentry's framework integrations, so attach the matched route pattern
   // here instead of registering a second OpenTelemetry provider through Elysia's
   // plugin. The normalized path is safe; the concrete path may contain customer IDs.
-  const requestSpan = trace.getActiveSpan();
-  requestSpan?.updateName(`${method} ${match.normalizedPath}`);
-  requestSpan?.setAttribute("http.request.method", method);
-  requestSpan?.setAttribute("http.route", match.normalizedPath);
+  updateRequestSpanName(method, match.normalizedPath);
   const context: RequestContext = {
     abortSignal: request.signal,
     headers: pipeline.mergedHeaders,
@@ -175,6 +174,19 @@ async function dispatch(request: Request) {
     }
     return withResponseHeaders(finalResponse, pipeline.corsHeadersInit);
   });
+}
+
+function updateRequestSpanName(method: string, normalizedPath: string) {
+  const requestSpan = trace.getActiveSpan();
+  if (requestSpan == null) {
+    return;
+  }
+  // Raw OpenTelemetry updateName() can be overwritten when Sentry finalizes an
+  // http.server span. This helper also marks the normalized, non-customer path as
+  // an authoritative custom name so the beforeSend scrubber can retain it.
+  Sentry.updateSpanName(requestSpan, `${method} ${normalizedPath}`);
+  requestSpan.setAttribute("http.request.method", method);
+  requestSpan.setAttribute("http.route", normalizedPath);
 }
 
 async function discardHeadResponseBody(method: string, response: Response): Promise<void> {

--- a/apps/backend/src/server/middleware.ts
+++ b/apps/backend/src/server/middleware.ts
@@ -1,12 +1,23 @@
 import apiVersions from "@/generated/api-versions.json";
 import routes from "@/generated/routes.json";
-import { SmartRouter } from "@/smart-router";
 import { getEnvVariable, getNodeEnvironment } from "@hexclave/shared/dist/utils/env";
 import { wait } from "@hexclave/shared/dist/utils/promises";
+import { RoutePatternIndex } from "./route-pattern-index";
 
 const DEV_RATE_LIMIT_MAX_REQUESTS = 100;
 const DEV_RATE_LIMIT_WINDOW_MS = 10_000;
 const devRateLimitMarks: number[] = [];
+const migrationRouteIndexes = new Map<string, RoutePatternIndex<(typeof routes)[number]>>();
+for (const version of apiVersions) {
+  if (version.migrationFolder == null) {
+    continue;
+  }
+  const migrationFolder = version.migrationFolder;
+  migrationRouteIndexes.set(migrationFolder, new RoutePatternIndex(
+    routes.filter((route) => (route.normalizedPath + "/").startsWith(migrationFolder + "/")),
+    (route) => route.normalizedPath,
+  ));
+}
 
 const corsAllowedRequestHeaders = [
   "content-type",
@@ -311,13 +322,13 @@ function getDispatchPath(originalPathname: string) {
     if ((pathname + "/").startsWith(version.servedRoute + "/")) {
       const nextPathname = pathname.replace(version.servedRoute, nextVersion.servedRoute);
       const migrationPathname = nextPathname.replace(nextVersion.servedRoute, nextVersion.migrationFolder);
-      for (const route of routes) {
-        if (nextVersion.migrationFolder && (route.normalizedPath + "/").startsWith(nextVersion.migrationFolder + "/")) {
-          if (SmartRouter.matchNormalizedPath(migrationPathname, route.normalizedPath)) {
-            pathname = migrationPathname;
-            break outer;
-          }
-        }
+      const migrationRouteIndex = migrationRouteIndexes.get(nextVersion.migrationFolder);
+      if (migrationRouteIndex == null) {
+        throw new Error(`No route index found for migration folder ${JSON.stringify(nextVersion.migrationFolder)}`);
+      }
+      if (migrationRouteIndex.hasMatch(migrationPathname)) {
+        pathname = migrationPathname;
+        break outer;
       }
       pathname = nextPathname;
     }

--- a/apps/backend/src/server/registry.ts
+++ b/apps/backend/src/server/registry.ts
@@ -1,5 +1,5 @@
 import { httpMethodNames, routeModules } from "@/generated/route-modules";
-import { SmartRouter } from "@/smart-router";
+import { RoutePatternIndex } from "./route-pattern-index";
 
 type HttpMethod = typeof httpMethodNames[number];
 type RouteParams = Record<string, string | string[]>;
@@ -12,7 +12,6 @@ export type RouteMethods = Map<HttpMethod, RouteHandler>;
 type RouteEntry = {
   loadMethods: () => Promise<RouteMethods>,
   normalizedPath: string,
-  specificity: number[],
 };
 
 type RouteMatch = {
@@ -22,27 +21,38 @@ type RouteMatch = {
 };
 
 const routeRegistry = buildRouteRegistry();
+const routePatternIndex = new RoutePatternIndex(routeRegistry, (entry) => entry.normalizedPath);
 
 export async function matchRoute(dispatchPath: string): Promise<RouteMatch | undefined> {
-  return await findRouteMatch(dispatchPath, routeRegistry);
+  return await findRouteMatch(dispatchPath, routePatternIndex);
 }
 
-async function findRouteMatch(dispatchPath: string, entries: RouteEntry[]): Promise<RouteMatch | undefined> {
-  for (const entry of entries) {
-    const params = SmartRouter.matchNormalizedPath(dispatchPath, entry.normalizedPath);
-    if (params !== false) {
-      const methods = await entry.loadMethods();
-      if (methods.size === 0) {
-        continue;
-      }
-      return {
-        methods,
-        normalizedPath: entry.normalizedPath,
-        params: decodeRouteParams(params),
-      };
+async function findRouteMatch(dispatchPath: string, index: RoutePatternIndex<RouteEntry>): Promise<RouteMatch | undefined> {
+  for (const entry of index.getStaticMatches(dispatchPath) ?? []) {
+    const match = await loadRouteMatch(entry, {});
+    if (match != null) {
+      return match;
+    }
+  }
+  for (const { params, value } of index.getDynamicMatches(dispatchPath)) {
+    const match = await loadRouteMatch(value, params);
+    if (match != null) {
+      return match;
     }
   }
   return undefined;
+}
+
+async function loadRouteMatch(entry: RouteEntry, params: Record<string, string | string[]>): Promise<RouteMatch | undefined> {
+  const methods = await entry.loadMethods();
+  if (methods.size === 0) {
+    return undefined;
+  }
+  return {
+    methods,
+    normalizedPath: entry.normalizedPath,
+    params: decodeRouteParams(params),
+  };
 }
 
 export class MalformedRouteParamError extends Error {
@@ -75,10 +85,8 @@ function buildRouteRegistry() {
       return {
         loadMethods: createRouteMethodsLoader(route.normalizedPath, route.load),
         normalizedPath: route.normalizedPath,
-        specificity: getSpecificity(route.normalizedPath),
       };
-    })
-    .sort(compareRouteEntries);
+    });
 }
 
 function createRouteMethodsLoader(
@@ -115,36 +123,6 @@ function createRouteHandler(normalizedPath: string, method: HttpMethod, handler:
     }
     throw new Error(`Route ${normalizedPath} ${method} did not return a Response`);
   };
-}
-
-function compareRouteEntries(a: RouteEntry, b: RouteEntry) {
-  const maxLength = Math.max(a.specificity.length, b.specificity.length);
-  for (let i = 0; i < maxLength; i++) {
-    const diff = (b.specificity[i] ?? 0) - (a.specificity[i] ?? 0);
-    if (diff !== 0) {
-      return diff;
-    }
-  }
-  return stringCompare(a.normalizedPath, b.normalizedPath);
-}
-
-function getSpecificity(normalizedPath: string) {
-  return normalizedPath.split("/").filter(Boolean).map((segment) => {
-    if (segment.startsWith("[[...") && segment.endsWith("]]")) {
-      return 0;
-    }
-    if (segment.startsWith("[...") && segment.endsWith("]")) {
-      return 1;
-    }
-    if (segment.startsWith("[") && segment.endsWith("]")) {
-      return 2;
-    }
-    return 3;
-  });
-}
-
-function stringCompare(a: string, b: string) {
-  return a < b ? -1 : a > b ? 1 : 0;
 }
 
 import.meta.vitest?.test("route modules are loaded lazily and only once", async ({ expect }) => {
@@ -184,19 +162,29 @@ import.meta.vitest?.test("a failed route import stays isolated to its loader", a
   expect((await healthyLoader()).has("GET")).toBe(true);
 });
 
+import.meta.vitest?.test("a generated static API route resolves through the indexed registry", async ({ expect }) => {
+  const match = await matchRoute("/api/latest/users/me");
+
+  expect({
+    hasGetHandler: match?.methods.has("GET"),
+    normalizedPath: match?.normalizedPath,
+  }).toEqual({
+    hasGetHandler: true,
+    normalizedPath: "/api/latest/users/me",
+  });
+});
+
 import.meta.vitest?.test("an empty specific route does not shadow a valid fallback route", async ({ expect }) => {
-  const match = await findRouteMatch("/test/value", [
+  const match = await findRouteMatch("/test/value", new RoutePatternIndex([
     {
       loadMethods: async () => new Map(),
       normalizedPath: "/test/[id]",
-      specificity: getSpecificity("/test/[id]"),
     },
     {
       loadMethods: async () => new Map([["GET", async () => new Response("fallback")]]),
       normalizedPath: "/test/[...path]",
-      specificity: getSpecificity("/test/[...path]"),
     },
-  ]);
+  ], (entry) => entry.normalizedPath));
 
   expect(match?.normalizedPath).toBe("/test/[...path]");
 });

--- a/apps/backend/src/server/route-pattern-index.test.ts
+++ b/apps/backend/src/server/route-pattern-index.test.ts
@@ -14,6 +14,16 @@ describe("RoutePatternIndex", () => {
     ]);
   });
 
+  it("matches a normalized pathname against a static pattern with a trailing slash", () => {
+    const index = new RoutePatternIndex([
+      "/api/users/",
+    ], (pattern) => pattern);
+
+    expect(index.getStaticMatches("/api/users")).toEqual([
+      "/api/users/",
+    ]);
+  });
+
   it("matches dynamic and catch-all routes with Next-compatible precedence and params", () => {
     const index = new RoutePatternIndex([
       "/api/[...notFoundPath]",
@@ -28,6 +38,32 @@ describe("RoutePatternIndex", () => {
       {
         params: { notFoundPath: ["latest", "users", "user-123"] },
         value: "/api/[...notFoundPath]",
+      },
+    ]);
+  });
+
+  it("keeps __proto__ route parameters as own enumerable properties", () => {
+    const index = new RoutePatternIndex([
+      "/api/[__proto__]",
+      "/files/[[...__proto__]]",
+    ], (pattern) => pattern);
+
+    expect(index.getDynamicMatches("/api/user-123").map(({ params }) => ({
+      entries: Object.entries(params),
+      hasDefaultPrototype: Object.getPrototypeOf(params) === Object.prototype,
+    }))).toEqual([
+      {
+        entries: [["__proto__", "user-123"]],
+        hasDefaultPrototype: true,
+      },
+    ]);
+    expect(index.getDynamicMatches("/files/a/b").map(({ params }) => ({
+      entries: Object.entries(params),
+      hasDefaultPrototype: Object.getPrototypeOf(params) === Object.prototype,
+    }))).toEqual([
+      {
+        entries: [["__proto__", ["a", "b"]]],
+        hasDefaultPrototype: true,
       },
     ]);
   });

--- a/apps/backend/src/server/route-pattern-index.test.ts
+++ b/apps/backend/src/server/route-pattern-index.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from "vitest";
+import { RoutePatternIndex } from "./route-pattern-index";
+
+describe("RoutePatternIndex", () => {
+  it("keeps the common static API path on the precomputed fast path", () => {
+    const index = new RoutePatternIndex([
+      "/api/latest/users/[user_id]",
+      "/api/latest/users/me",
+      "/api/[...notFoundPath]",
+    ], (pattern) => pattern);
+
+    expect(index.getStaticMatches("/api/latest/users/me")).toEqual([
+      "/api/latest/users/me",
+    ]);
+  });
+
+  it("matches dynamic and catch-all routes with Next-compatible precedence and params", () => {
+    const index = new RoutePatternIndex([
+      "/api/[...notFoundPath]",
+      "/api/latest/users/[user_id]",
+    ], (pattern) => pattern);
+
+    expect(index.getDynamicMatches("/api/latest/users/user-123")).toEqual([
+      {
+        params: { user_id: "user-123" },
+        value: "/api/latest/users/[user_id]",
+      },
+      {
+        params: { notFoundPath: ["latest", "users", "user-123"] },
+        value: "/api/[...notFoundPath]",
+      },
+    ]);
+  });
+});

--- a/apps/backend/src/server/route-pattern-index.ts
+++ b/apps/backend/src/server/route-pattern-index.ts
@@ -1,0 +1,181 @@
+export type RoutePatternMatch<T> = {
+  params: Record<string, string | string[]>,
+  value: T,
+};
+
+type RoutePatternSegment =
+  | { type: "static", value: string }
+  | { name: string, type: "dynamic" }
+  | { name: string, type: "catch-all" }
+  | { name: string, type: "optional-catch-all" };
+
+type DynamicRoutePattern<T> = {
+  pattern: string,
+  segments: readonly RoutePatternSegment[],
+  value: T,
+};
+
+/**
+ * Indexes static routes separately from dynamic patterns. The backend's overwhelmingly
+ * common case is a literal API path; keeping it in a Map avoids walking every generated
+ * route and recursively reparsing the URL for each candidate on every request.
+ */
+export class RoutePatternIndex<T> {
+  private readonly dynamicPatterns: readonly DynamicRoutePattern<T>[];
+  private readonly staticPatterns = new Map<string, T[]>();
+
+  constructor(values: readonly T[], getPattern: (value: T) => string) {
+    const dynamicPatterns: DynamicRoutePattern<T>[] = [];
+    for (const value of values) {
+      const pattern = getPattern(value);
+      const segments = compileRoutePattern(pattern);
+      if (segments == null) {
+        const existing = this.staticPatterns.get(pattern);
+        if (existing == null) {
+          this.staticPatterns.set(pattern, [value]);
+        } else {
+          existing.push(value);
+        }
+      } else {
+        dynamicPatterns.push({ pattern, segments, value });
+      }
+    }
+    this.dynamicPatterns = dynamicPatterns.sort((a, b) => compareRoutePatterns(a.pattern, b.pattern));
+  }
+
+  getStaticMatches(pathname: string): readonly T[] | undefined {
+    return this.staticPatterns.get(normalizePathname(pathname));
+  }
+
+  getDynamicMatches(pathname: string): RoutePatternMatch<T>[] {
+    const pathSegments = splitPathname(pathname);
+    const matches: RoutePatternMatch<T>[] = [];
+    for (const pattern of this.dynamicPatterns) {
+      const params = matchRouteSegments(pathSegments, pattern.segments);
+      if (params != null) {
+        matches.push({ params, value: pattern.value });
+      }
+    }
+    return matches;
+  }
+
+  hasMatch(pathname: string): boolean {
+    if (this.getStaticMatches(pathname) != null) {
+      return true;
+    }
+    const pathSegments = splitPathname(pathname);
+    return this.dynamicPatterns.some((pattern) => matchRouteSegments(pathSegments, pattern.segments) != null);
+  }
+}
+
+function compileRoutePattern(pattern: string): readonly RoutePatternSegment[] | undefined {
+  const segments = splitPathname(pattern);
+  if (!segments.some((segment) => segment.startsWith("[") && segment.endsWith("]"))) {
+    return undefined;
+  }
+
+  return segments.map((segment, index) => {
+    const isLastSegment = index === segments.length - 1;
+    if (segment.startsWith("[[...") && segment.endsWith("]]")) {
+      if (!isLastSegment) {
+        throw new Error(`Optional catch-all route segment must be last: ${JSON.stringify(pattern)}`);
+      }
+      return { name: getRouteParamName(segment, 5, 2, pattern), type: "optional-catch-all" };
+    }
+    if (segment.startsWith("[...") && segment.endsWith("]")) {
+      if (!isLastSegment) {
+        throw new Error(`Catch-all route segment must be last: ${JSON.stringify(pattern)}`);
+      }
+      return { name: getRouteParamName(segment, 4, 1, pattern), type: "catch-all" };
+    }
+    if (segment.startsWith("[") && segment.endsWith("]")) {
+      return { name: getRouteParamName(segment, 1, 1, pattern), type: "dynamic" };
+    }
+    return { type: "static", value: segment };
+  });
+}
+
+function getRouteParamName(segment: string, prefixLength: number, suffixLength: number, pattern: string): string {
+  const name = segment.slice(prefixLength, -suffixLength);
+  if (name === "") {
+    throw new Error(`Route parameter name must not be empty: ${JSON.stringify(pattern)}`);
+  }
+  return name;
+}
+
+function matchRouteSegments(
+  pathSegments: readonly string[],
+  patternSegments: readonly RoutePatternSegment[],
+): Record<string, string | string[]> | undefined {
+  const params: Record<string, string | string[]> = {};
+  let pathIndex = 0;
+
+  for (const segment of patternSegments) {
+    if (segment.type === "optional-catch-all") {
+      params[segment.name] = pathSegments.slice(pathIndex);
+      return params;
+    }
+    if (segment.type === "catch-all") {
+      if (pathIndex >= pathSegments.length) {
+        return undefined;
+      }
+      params[segment.name] = pathSegments.slice(pathIndex);
+      return params;
+    }
+
+    if (pathIndex >= pathSegments.length) {
+      return undefined;
+    }
+    const pathSegment = pathSegments[pathIndex];
+    if (segment.type === "static") {
+      if (segment.value !== pathSegment) {
+        return undefined;
+      }
+    } else {
+      params[segment.name] = pathSegment;
+    }
+    pathIndex++;
+  }
+
+  return pathIndex === pathSegments.length ? params : undefined;
+}
+
+function normalizePathname(pathname: string): string {
+  if (!pathname.startsWith("/")) {
+    throw new Error(`Route pathname must start with a slash: ${JSON.stringify(pathname)}`);
+  }
+  return pathname.length > 1 ? pathname.replace(/\/+$/, "") : pathname;
+}
+
+function splitPathname(pathname: string): string[] {
+  const normalized = normalizePathname(pathname);
+  return normalized === "/" ? [] : normalized.slice(1).split("/");
+}
+
+function compareRoutePatterns(a: string, b: string): number {
+  const aSpecificity = getSpecificity(a);
+  const bSpecificity = getSpecificity(b);
+  const maxLength = Math.max(aSpecificity.length, bSpecificity.length);
+  for (let i = 0; i < maxLength; i++) {
+    const difference = (bSpecificity[i] ?? 0) - (aSpecificity[i] ?? 0);
+    if (difference !== 0) {
+      return difference;
+    }
+  }
+  return a < b ? -1 : a > b ? 1 : 0;
+}
+
+function getSpecificity(normalizedPath: string): number[] {
+  return splitPathname(normalizedPath).map((segment) => {
+    if (segment.startsWith("[[...") && segment.endsWith("]]")) {
+      return 0;
+    }
+    if (segment.startsWith("[...") && segment.endsWith("]")) {
+      return 1;
+    }
+    if (segment.startsWith("[") && segment.endsWith("]")) {
+      return 2;
+    }
+    return 3;
+  });
+}

--- a/apps/backend/src/server/route-pattern-index.ts
+++ b/apps/backend/src/server/route-pattern-index.ts
@@ -30,9 +30,10 @@ export class RoutePatternIndex<T> {
       const pattern = getPattern(value);
       const segments = compileRoutePattern(pattern);
       if (segments == null) {
-        const existing = this.staticPatterns.get(pattern);
+        const normalizedPattern = normalizePathname(pattern);
+        const existing = this.staticPatterns.get(normalizedPattern);
         if (existing == null) {
-          this.staticPatterns.set(pattern, [value]);
+          this.staticPatterns.set(normalizedPattern, [value]);
         } else {
           existing.push(value);
         }
@@ -112,14 +113,14 @@ function matchRouteSegments(
 
   for (const segment of patternSegments) {
     if (segment.type === "optional-catch-all") {
-      params[segment.name] = pathSegments.slice(pathIndex);
+      setRouteParam(params, segment.name, pathSegments.slice(pathIndex));
       return params;
     }
     if (segment.type === "catch-all") {
       if (pathIndex >= pathSegments.length) {
         return undefined;
       }
-      params[segment.name] = pathSegments.slice(pathIndex);
+      setRouteParam(params, segment.name, pathSegments.slice(pathIndex));
       return params;
     }
 
@@ -132,12 +133,21 @@ function matchRouteSegments(
         return undefined;
       }
     } else {
-      params[segment.name] = pathSegment;
+      setRouteParam(params, segment.name, pathSegment);
     }
     pathIndex++;
   }
 
   return pathIndex === pathSegments.length ? params : undefined;
+}
+
+function setRouteParam(params: Record<string, string | string[]>, name: string, value: string | string[]): void {
+  Object.defineProperty(params, name, {
+    configurable: true,
+    enumerable: true,
+    value,
+    writable: true,
+  });
 }
 
 function normalizePathname(pathname: string): string {


### PR DESCRIPTION
<!--

Make sure you've read the CONTRIBUTING.md guidelines: https://github.com/hexclave/hexclave/blob/dev/CONTRIBUTING.md

-->

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Preloaded backend routes into an in-memory index to speed up route matching and migration checks. Hardened Sentry span and transaction naming with a known-method allowlist and unmatched placeholders to keep useful metadata without leaking URLs or secrets.

- **Refactors**
  - Added a route pattern index separating static paths from dynamic and catch-all patterns.
  - Switched `registry.ts` to resolve via the index (static first, then dynamic) and lazy-load handlers.
  - Precomputed migration route indexes in `middleware.ts` for fast migration path checks.
  - Normalized static pathnames (handles trailing slashes) and added tests for dynamic precedence and `__proto__` params.

- **Bug Fixes**
  - Built safe Sentry transaction names from method + normalized route; used method + "<unmatched>" when requests finish before matching; never use concrete URLs. Validated request descriptions against a known HTTP method list and ignore unsupported methods.
  - Preserved a small audited set of app span descriptions, scrubbed others, and set `http.request.method` and `http.route` on the request span via `@sentry/node`; used `Sentry.updateSpanName` to retain safe request names (and set trace data for unmatched requests).
  - Ensured route params are stored as safe own enumerable properties (e.g., `__proto__`) to prevent prototype pollution.

<sup>Written for commit be055a6f0c403b51713d3781354a1c3e0cf49c5d. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1883?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved matching for static, dynamic, trailing-slash, and catch-all routes.
  * Ensured route parameters are correctly extracted and decoded.
  * Added reliable fallback behavior for routes without handlers.
  * Improved migration path matching and error handling.
  * Improved request tracing and transaction names while preserving approved route information.
  * Prevented unsafe or malformed request details from appearing in telemetry.
  * Added clearer handling for requests completed before route matching.

* **Tests**
  * Added coverage for route precedence, parameter extraction, static paths, catch-all patterns, and request-tracing sanitization.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->