### PR TITLE
Batch the newly-created-projects ClickHouse metrics queries

### DIFF
--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.test.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.test.tsx
@@ -4,11 +4,21 @@ import {
   getEnabledAppIds,
   getTrustedDomainBaseUrls,
   isStripeAccountSetupComplete,
+  chunkProjectIds,
   mergeInternalProjectIntoCandidates,
   selectProjectsWithInternalPinned,
 } from "./helpers";
 
 describe("newly-created-projects helpers", () => {
+  it("chunks project IDs without changing their order", () => {
+    expect(chunkProjectIds(["a", "b", "c", "d", "e"], 2)).toEqual([
+      ["a", "b"],
+      ["c", "d"],
+      ["e"],
+    ]);
+    expect(chunkProjectIds([], 2)).toEqual([]);
+  });
+
   it("reads enabled apps from normalized nested config", () => {
     expect(getEnabledAppIds({
       apps: {

--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/helpers.tsx
@@ -30,6 +30,8 @@ export const CANDIDATE_WINDOW_SIZE = 5_000;
 export const DETAIL_REPLAY_LIMIT = 50;
 const CONFIG_RENDER_CONCURRENCY = 12;
 const STRIPE_ACCOUNT_CONCURRENCY = 8;
+const METRICS_PROJECT_BATCH_SIZE = 200;
+const METRICS_QUERY_CONCURRENCY = 4;
 
 export const FEATURED_APP_IDS = [
   "authentication",
@@ -248,6 +250,17 @@ export type ProjectActivityMetrics = {
   lastActivityByProjectId: Map<string, Date>,
 };
 
+export function chunkProjectIds(projectIds: readonly string[], chunkSize: number): string[][] {
+  if (!Number.isInteger(chunkSize) || chunkSize < 1) {
+    throw new HexclaveAssertionError("Project ID chunk size must be a positive integer", { chunkSize });
+  }
+  const chunks: string[][] = [];
+  for (let index = 0; index < projectIds.length; index += chunkSize) {
+    chunks.push(projectIds.slice(index, index + chunkSize));
+  }
+  return chunks;
+}
+
 export async function loadProjectActivityMetrics(projectIds: string[]): Promise<ProjectActivityMetrics> {
   const empty = {
     nonAnonByProjectId: new Map<string, number>(),
@@ -260,77 +273,93 @@ export async function loadProjectActivityMetrics(projectIds: string[]): Promise<
   const branchId = DEFAULT_BRANCH_ID;
 
   try {
-    const [userRowsResult, activityRowsResult] = await Promise.all([
-      clickhouse.query({
-        // Deduplicate the ReplacingMergeTree rows to each user's latest version
-        // with an explicit argMax GROUP BY instead of `FINAL`. `FINAL` merges
-        // parts outside the aggregation pipeline, so it is NOT bounded by
-        // `max_bytes_before_external_group_by`; over this tool's candidate
-        // window (up to CANDIDATE_WINDOW_SIZE projects, unbounded in time) that
-        // merge blew past the per-query `max_memory_usage` cap and threw
-        // MEMORY_LIMIT_EXCEEDED (most visibly with `neon=exclude`, which skips
-        // the many near-empty Neon projects and fills the window with real,
-        // user-heavy projects). A manual argMax dedup spills to disk under the
-        // same memory setting. `(project_id, branch_id, id)` is the table's
-        // ORDER BY / dedup key, so grouping by it reproduces `FINAL` exactly.
-        // Re-seeded rows can share a version, so break ties by insertion time.
-        query: `
-          SELECT
-            project_id AS projectId,
-            countIf(isAnonymous = 0) AS nonAnon,
-            countIf(isAnonymous = 1) AS anon
-          FROM (
-            SELECT
-              project_id,
-              argMax(is_anonymous, (sync_sequence_id, sync_created_at)) AS isAnonymous,
-              argMax(sync_is_deleted, (sync_sequence_id, sync_created_at)) AS syncIsDeleted
-            FROM analytics_internal.users
-            WHERE branch_id = {branchId:String}
-              AND project_id IN {projectIds:Array(String)}
-            GROUP BY project_id, branch_id, id
-          )
-          WHERE syncIsDeleted = 0
-          GROUP BY project_id
-        `,
-        query_params: { branchId, projectIds },
-        format: "JSONEachRow",
-      }),
-      clickhouse.query({
-        query: `
-          SELECT
-            project_id AS projectId,
-            max(event_at) AS lastActive
-          FROM analytics_internal.events
-          WHERE event_type = '$token-refresh'
-            AND user_id IS NOT NULL
-            AND project_id IN {projectIds:Array(String)}
-          GROUP BY project_id
-        `,
-        query_params: { projectIds },
-        format: "JSONEachRow",
-      }),
-    ]);
+    // The candidate window can contain thousands of user-heavy projects. Even
+    // with external aggregation enabled, one query over the whole window can
+    // exceed ClickHouse's per-query memory cap because the inner dedup must
+    // hold one group for every user. Batch project IDs so each aggregation has
+    // a bounded number of groups, while keeping a small concurrency limit to
+    // avoid replacing one large query with an unbounded fan-out.
+    const chunkResults = await mapWithConcurrency(
+      chunkProjectIds(projectIds, METRICS_PROJECT_BATCH_SIZE),
+      METRICS_QUERY_CONCURRENCY,
+      async (projectIdChunk) => {
+        const [userRowsResult, activityRowsResult] = await Promise.all([
+          clickhouse.query({
+            // Deduplicate the ReplacingMergeTree rows to each user's latest
+            // version with an explicit argMax GROUP BY instead of `FINAL`.
+            // `FINAL` merges parts outside the aggregation pipeline. The
+            // candidate window can therefore exceed the per-query
+            // max_memory_usage cap even though a manual argMax dedup can spill
+            // to disk. Batching project IDs bounds the number of groups in
+            // each query; `(project_id, branch_id, id)` is the table's ORDER BY
+            // / dedup key, so grouping by it reproduces FINAL exactly. Since
+            // the grouping key matches that ORDER BY, this setting also lets
+            // ClickHouse stream the inner aggregation in order.
+            // Re-seeded rows can share a version, so break ties by insertion time.
+            query: `
+              SELECT
+                project_id AS projectId,
+                countIf(isAnonymous = 0) AS nonAnon,
+                countIf(isAnonymous = 1) AS anon
+              FROM (
+                SELECT
+                  project_id,
+                  argMax(is_anonymous, (sync_sequence_id, sync_created_at)) AS isAnonymous,
+                  argMax(sync_is_deleted, (sync_sequence_id, sync_created_at)) AS syncIsDeleted
+                FROM analytics_internal.users
+                WHERE branch_id = {branchId:String}
+                  AND project_id IN {projectIds:Array(String)}
+                GROUP BY project_id, branch_id, id
+              )
+              WHERE syncIsDeleted = 0
+              GROUP BY project_id
+            `,
+            query_params: { branchId, projectIds: projectIdChunk },
+            clickhouse_settings: { optimize_aggregation_in_order: 1 },
+            format: "JSONEachRow",
+          }),
+          clickhouse.query({
+            query: `
+              SELECT
+                project_id AS projectId,
+                max(event_at) AS lastActive
+              FROM analytics_internal.events
+              WHERE event_type = '$token-refresh'
+                AND user_id IS NOT NULL
+                AND project_id IN {projectIds:Array(String)}
+              GROUP BY project_id
+            `,
+            query_params: { projectIds: projectIdChunk },
+            format: "JSONEachRow",
+          }),
+        ]);
 
-    // clickhouse-js `json<T>()` returns T[] — pass the row type, not Array<row>.
-    const userRows = await userRowsResult.json<{ projectId: string, nonAnon: string | number, anon: string | number }>();
-    const activityRows = await activityRowsResult.json<{ projectId: string, lastActive: string }>();
+        // clickhouse-js `json<T>()` returns T[] — pass the row type, not Array<row>.
+        return {
+          userRows: await userRowsResult.json<{ projectId: string, nonAnon: string | number, anon: string | number }>(),
+          activityRows: await activityRowsResult.json<{ projectId: string, lastActive: string }>(),
+        };
+      },
+    );
 
     const nonAnonByProjectId = new Map<string, number>();
     const anonByProjectId = new Map<string, number>();
-    for (const row of userRows) {
-      nonAnonByProjectId.set(row.projectId, Number(row.nonAnon) || 0);
-      anonByProjectId.set(row.projectId, Number(row.anon) || 0);
-    }
     const lastActivityByProjectId = new Map<string, Date>();
-    for (const row of activityRows) {
-      // ClickHouse DateTime comes back as "YYYY-MM-DD HH:MM:SS" (UTC, no zone).
-      const normalized = row.lastActive.includes("T")
-        ? row.lastActive
-        : row.lastActive.replace(" ", "T");
-      const withZone = /[zZ]|[+-]\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`;
-      const parsed = new Date(withZone);
-      if (!Number.isNaN(parsed.getTime())) {
-        lastActivityByProjectId.set(row.projectId, parsed);
+    for (const { userRows, activityRows } of chunkResults) {
+      for (const row of userRows) {
+        nonAnonByProjectId.set(row.projectId, Number(row.nonAnon) || 0);
+        anonByProjectId.set(row.projectId, Number(row.anon) || 0);
+      }
+      for (const row of activityRows) {
+        // ClickHouse DateTime comes back as "YYYY-MM-DD HH:MM:SS" (UTC, no zone).
+        const normalized = row.lastActive.includes("T")
+          ? row.lastActive
+          : row.lastActive.replace(" ", "T");
+        const withZone = /[zZ]|[+-]\d\d:\d\d$/.test(normalized) ? normalized : `${normalized}Z`;
+        const parsed = new Date(withZone);
+        if (!Number.isNaN(parsed.getTime())) {
+          lastActivityByProjectId.set(row.projectId, parsed);
+        }
       }
     }
     return { nonAnonByProjectId, anonByProjectId, lastActivityByProjectId };

--- a/apps/backend/src/app/api/latest/internal/newly-created-projects/route.tsx
+++ b/apps/backend/src/app/api/latest/internal/newly-created-projects/route.tsx
@@ -26,7 +26,7 @@ import { ProjectRowSchema } from "./schemas";
 
 const RdeFilterSchema = yupString().oneOf(["both", "rde", "not_rde"]).default("both");
 const OnboardingFilterSchema = yupString().oneOf(["both", "incomplete", "completed"]).default("both");
-const NeonFilterSchema = yupString().oneOf(["include", "exclude"]).default("include");
+const NeonFilterSchema = yupString().oneOf(["include", "exclude"]).default("exclude");
 const NEON_PROJECT_DESCRIPTION = "Created with Neon";
 
 function parseNonNegativeInt(name: string, raw: string | undefined, fallback: number): number {

--- a/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/newly-created-projects/page-client.tsx
+++ b/apps/dashboard/src/app/(main)/(protected)/projects/[projectId]/newly-created-projects/page-client.tsx
@@ -195,9 +195,9 @@ type ListFilters = {
 
 const DEFAULT_FILTERS: ListFilters = {
   minUsers: "0",
-  rde: "not_rde",
+  rde: "both",
   onboarding: "both",
-  neon: "include",
+  neon: "exclude",
   activity24h: "no",
 };
 
@@ -669,9 +669,9 @@ function NewlyCreatedProjectsContent(props: {
 }) {
   const initialListState = use(props.initialListStatePromise);
   const [minUsers, setMinUsers] = useState("0");
-  const [rde, setRde] = useState<RdeFilter>("not_rde");
+  const [rde, setRde] = useState<RdeFilter>("both");
   const [onboarding, setOnboarding] = useState<OnboardingFilter>("both");
-  const [neon, setNeon] = useState<NeonFilter>("include");
+  const [neon, setNeon] = useState<NeonFilter>("exclude");
   const [activity24h, setActivity24h] = useState<"yes" | "no">("no");
   const [listState, setListState] = useState<ListState>(initialListState);
   const [selectedProjectId, setSelectedProjectId] = useState<string | null>(null);

--- a/apps/e2e/tests/backend/endpoints/api/v1/internal/newly-created-projects.test.ts
+++ b/apps/e2e/tests/backend/endpoints/api/v1/internal/newly-created-projects.test.ts
@@ -120,4 +120,24 @@ describe("internal newly-created projects", () => {
     expect(excluded.body.filters.neon).toBe("exclude");
     expect(excluded.body.projects.some((project: { id: string }) => project.id === projectId)).toBe(false);
   });
+
+  it("defaults to both development environments and excludes Neon projects", async ({ expect }) => {
+    const internalUserAuth = await signInAsInternalAdmin();
+    const { projectId } = await Project.createAndSwitch({
+      display_name: "Default Neon-created project",
+      description: "Created with Neon",
+    }, true);
+
+    backendContext.set({ projectKeys: InternalProjectKeys, userAuth: internalUserAuth });
+    const response = await niceBackendFetch(
+      `${BASE_PATH}?onboarding=both&min_users=0`,
+      { accessType: "client" },
+    );
+    expect(response.status).toBe(200);
+    expect(response.body.filters).toMatchObject({
+      rde: "both",
+      neon: "exclude",
+    });
+    expect(response.body.projects.some((project: { id: string }) => project.id === projectId)).toBe(false);
+  });
 });


### PR DESCRIPTION
The internal newly-created-projects tool could exceed ClickHouse's per-query memory cap in `loadProjectActivityMetrics`: the per-user dedup aggregation holds one group per user, and the candidate window can contain thousands of user-heavy projects, so a single query over the whole window blew past `max_memory_usage` in `AggregatingTransform`.

`loadProjectActivityMetrics` now runs the queries over batches of 200 project IDs with a concurrency limit of 4, merging the per-batch maps. The users query additionally sets `optimize_aggregation_in_order` — the inner `GROUP BY (project_id, branch_id, id)` matches the table's `ORDER BY`, so the aggregation can stream instead of building a full hash table. Query semantics are unchanged.

Also changes the default filters to include development environments and exclude Neon-created projects (`rde: "both"`, `neon: "exclude"`), both server-side and in the dashboard.

Verified against a local ClickHouse seeded with 500k users across 5k projects, under a deliberately tight memory cap: the previous single query fails with MEMORY_LIMIT_EXCEEDED, the batched path completes.


Link to Devin session: https://app.devin.ai/sessions/cfd16ed9198f45469712920f3bf46816
Requested by: @N2D4

<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Batches the ClickHouse metrics queries in the newly-created-projects tool to prevent memory limit errors. Also updates default filters to include development environments and exclude Neon-created projects; query semantics stay the same.

- **Bug Fixes**
  - `loadProjectActivityMetrics` now runs in batches of 200 project IDs with concurrency 4 and merges results.
  - Enables `optimize_aggregation_in_order` for the users query since `GROUP BY (project_id, branch_id, id)` matches the table `ORDER BY`, allowing streaming aggregation.
  - Adds `chunkProjectIds` with tests and updates server/dashboard defaults (`rde: "both"`, `neon: "exclude"`) with e2e coverage.

<sup>Written for commit a55ad48afbb0a5c2ec86da51e193e7b50d7605a4. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/hexclave/hexclave/pull/1886?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches internal-only analytics loading and changes default list behavior (more RDE rows, fewer Neon projects) without altering query semantics per batch; batched ClickHouse load adds latency/complexity but reduces OOM risk.
> 
> **Overview**
> Fixes **ClickHouse `MEMORY_LIMIT_EXCEEDED`** on the internal newly-created-projects tool by changing **`loadProjectActivityMetrics`** from one query over the full candidate window to **batches of 200 project IDs** with **concurrency 4**, merging per-batch user counts and last-activity maps. Adds **`chunkProjectIds`** (with unit tests). The users dedup query keeps the same **`argMax`/`GROUP BY`** semantics and now sets **`optimize_aggregation_in_order: 1`** so aggregation can stream when the grouping key matches table order.
> 
> **Default filters** are aligned on API and dashboard: **`rde: "both"`** (was effectively not-RDE-only on the UI) and **`neon: "exclude"`** (was include). An e2e test asserts those defaults when query params are omitted.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a55ad48afbb0a5c2ec86da51e193e7b50d7605a4. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved loading of newly created project activity by processing results efficiently while preserving project order.
  * Newly created projects now include both development environments by default and exclude Neon-created projects unless specified otherwise.

* **Tests**
  * Added coverage for project batching, ordering, empty inputs, and default project filtering behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->